### PR TITLE
Restructure code and add new features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,8 +63,8 @@ jobs:
            mkdir -p sdcard
            cp -r ./circle-stdlib/libs/circle/boot/* sdcard
            rm -rf sdcard/config*.txt sdcard/README sdcard/Makefile sdcard/armstub sdcard/COPYING.linux
-           cp ./src/config.txt ./src/*img sdcard/
-           echo "usbspeed=full sounddev=sndpwm" > sdcard/cmdline.txt
+           cp ./src/config.txt ./src/minidexed.txt ./src/*img sdcard/
+           echo "usbspeed=full" > sdcard/cmdline.txt
            cd sdcard
            cp ../kernels/* . || true
            zip -r ../MiniDexed_$GITHUB_RUN_NUMBER_$(date +%Y-%m-%d).zip *

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ I am wondering whether we can run multiple Dexed instances, in order to recreate
 * Unzip
 * Put the files into the root directory of a FAT32 formatted partition on SD/microSD card
 * Put SD/microSD card into Raspberry Pi 1, 2, 3 or 4 (Zero and Zero 2 can probably be used but need HDMI or a supported i2c DAC for audio out)
-* Attach headphones to the headphone jack using `sounddev=sndpwm` in `cmdline.txt` (default)
-* Alternatively, attach a  PCM5102A or PCM5122 based DAC and select i2c sound output using `sounddev=sndi2s | sndhdmi` in `cmdline.txt`
-* Alternatively, attach a HDMI display with sound and select HDMI sound output using `sounddev=sndhdmi` in `cmdline.txt` (this may introduce slight latency)
+* Attach headphones to the headphone jack using `SoundDevice=pwm` in `minidexed.ini` (default)
+* Alternatively, attach a  PCM5102A or PCM5122 based DAC and select i2c sound output using `SoundDevice=i2s | sndhdmi` in `minidexed.ini`
+* Alternatively, attach a HDMI display with sound and select HDMI sound output using `SoundDevice=hdmi` in `minidexed.ini` (this may introduce slight latency)
 * Attach a MIDI keyboard via USB
 * Boot
 * Stat playing

--- a/build.sh
+++ b/build.sh
@@ -26,6 +26,9 @@ make -j
 cd libs/circle/addon/display/
 make clean || true
 make -j
+cd ../Properties/
+make clean || true
+make -j
 cd ../../../..
 
 cd ..

--- a/src/Makefile
+++ b/src/Makefile
@@ -15,10 +15,3 @@ INCLUDE += -I $(SYNTH_DEXED_DIR)
 EXTRACLEAN = $(SYNTH_DEXED_DIR)/*.o $(SYNTH_DEXED_DIR)/*.d
 
 include ./Rules.mk
-
-%.o: %.cc
-	@echo "  CPP   $@"
-	@$(CPP) $(CPPFLAGS) -c -o $@ $<
-
-%.d: %.cc
-	@$(CPP) $(CPPFLAGS) -M -MG -MT $*.o -MT $@ -MF $@ $<

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,8 @@
 CIRCLE_STDLIB_DIR = ../circle-stdlib
 SYNTH_DEXED_DIR = ../Synth_Dexed/src
 
-OBJS = main.o kernel.o minidexed.o config.o userinterface.o pckeyboard.o \
+OBJS = main.o kernel.o minidexed.o config.o userinterface.o \
+       mididevice.o midikeyboard.o serialmididevice.o pckeyboard.o \
        sysexfileloader.o perftimer.o \
        $(SYNTH_DEXED_DIR)/synth_dexed.o
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,7 @@
 CIRCLE_STDLIB_DIR = ../circle-stdlib
 SYNTH_DEXED_DIR = ../Synth_Dexed/src
 
-OBJS = main.o kernel.o minidexed.o pckeyboard.o sysexfileloader.o perftimer.o \
+OBJS = main.o kernel.o minidexed.o config.o pckeyboard.o sysexfileloader.o perftimer.o \
        $(SYNTH_DEXED_DIR)/synth_dexed.o
 
 INCLUDE += -I $(SYNTH_DEXED_DIR)

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,8 @@
 CIRCLE_STDLIB_DIR = ../circle-stdlib
 SYNTH_DEXED_DIR = ../Synth_Dexed/src
 
-OBJS = main.o kernel.o minidexed.o config.o pckeyboard.o sysexfileloader.o perftimer.o \
+OBJS = main.o kernel.o minidexed.o config.o userinterface.o pckeyboard.o \
+       sysexfileloader.o perftimer.o \
        $(SYNTH_DEXED_DIR)/synth_dexed.o
 
 INCLUDE += -I $(SYNTH_DEXED_DIR)

--- a/src/Rules.mk
+++ b/src/Rules.mk
@@ -18,6 +18,7 @@ LIBS += \
 	$(NEWLIBDIR)/lib/libc.a \
 	$(NEWLIBDIR)/lib/libcirclenewlib.a \
 	$(CIRCLEHOME)/addon/display/libdisplay.a \
+	$(CIRCLEHOME)/addon/Properties/libproperties.a \
 	$(CIRCLEHOME)/addon/SDCard/libsdcard.a \
   	$(CIRCLEHOME)/lib/usb/libusb.a \
  	$(CIRCLEHOME)/lib/input/libinput.a \

--- a/src/circle_stdlib_app.h
+++ b/src/circle_stdlib_app.h
@@ -97,6 +97,7 @@ public:
                 : CStdlibApp (kernel),
                   mScreenUnbuffered (mOptions.GetWidth (), mOptions.GetHeight ()),
                   mScreen (&mScreenUnbuffered),
+                  mbScreenAvailable (false),
                   mTimer (&mInterrupt),
                   mLogger (mOptions.GetLogLevel (), &mTimer)
         {
@@ -109,10 +110,7 @@ public:
                         return false;
                 }
 
-                if (!mScreenUnbuffered.Initialize ())
-                {
-                        return false;
-                }
+                mbScreenAvailable = mScreenUnbuffered.Initialize ();
 #if 0
                 if (!mSerial.Initialize (115200))
                 {
@@ -138,6 +136,7 @@ protected:
         CScreenDevice   mScreenUnbuffered;
         //CSerialDevice   mSerial;
         CWriteBufferDevice mScreen;
+        bool            mbScreenAvailable;
         CTimer          mTimer;
         CLogger         mLogger;
 };
@@ -164,7 +163,8 @@ public:
                   mUSBHCI (&mInterrupt, &mTimer, TRUE),
                   mEMMC (&mInterrupt, &mTimer, &mActLED),
 #if !defined(__aarch64__) || !defined(LEAVE_QEMU_ON_HALT)
-                  mConsole (&mScreen, TRUE)
+                  //mConsole (&mScreen, TRUE)
+                  mConsole (&mNullDevice, &mScreen)
 #else
                   mConsole (&mScreen)
 #endif

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,0 +1,132 @@
+//
+// config.cpp
+//
+// MiniDexed - Dexed FM synthesizer for bare metal Raspberry Pi
+// Copyright (C) 2022  The MiniDexed Team
+//
+// Original author of this class:
+//	R. Stange <rsta2@o2online.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include "config.h"
+
+CConfig::CConfig (FATFS *pFileSystem)
+:	m_Properties ("minidexed.ini", pFileSystem)
+{
+}
+
+CConfig::~CConfig (void)
+{
+}
+
+void CConfig::Load (void)
+{
+	m_Properties.Load ();
+
+	m_SoundDevice = m_Properties.GetString ("SoundDevice", "pwm");
+
+	m_nSampleRate = m_Properties.GetNumber ("SampleRate", 48000);
+	m_nChunkSize = m_Properties.GetNumber ("ChunkSize", m_SoundDevice == "hdmi" ? 384*6 : 256);
+	m_nDACI2CAddress = m_Properties.GetNumber ("DACI2CAddress", 0);
+
+	m_nMIDIBaudRate = m_Properties.GetNumber ("MIDIBaudRate", 31250);
+
+	m_bLCDEnabled = m_Properties.GetNumber ("LCDEnabled", 0) != 0;
+	m_nLCDPinEnable = m_Properties.GetNumber ("LCDPinEnable", 17);
+	m_nLCDPinRegisterSelect = m_Properties.GetNumber ("LCDPinRegisterSelect", 18);
+	m_nLCDPinReadWrite = m_Properties.GetNumber ("LCDPinReadWrite", 19);
+	m_nLCDPinData4 = m_Properties.GetNumber ("LCDPinData4", 22);
+	m_nLCDPinData5 = m_Properties.GetNumber ("LCDPinData5", 23);
+	m_nLCDPinData6 = m_Properties.GetNumber ("LCDPinData6", 24);
+	m_nLCDPinData7 = m_Properties.GetNumber ("LCDPinData7", 25);
+
+	m_bMIDIDumpEnabled  = m_Properties.GetNumber ("MIDIDumpEnabled", 0) != 0;
+	m_bProfileEnabled = m_Properties.GetNumber ("ProfileEnabled", 0) != 0;
+}
+
+const char *CConfig::GetSoundDevice (void) const
+{
+	return m_SoundDevice.c_str ();
+}
+
+unsigned CConfig::GetSampleRate (void) const
+{
+	return m_nSampleRate;
+}
+
+unsigned CConfig::GetChunkSize (void) const
+{
+	return m_nChunkSize;
+}
+
+unsigned CConfig::GetDACI2CAddress (void) const
+{
+	return m_nDACI2CAddress;
+}
+
+unsigned CConfig::GetMIDIBaudRate (void) const
+{
+	return m_nMIDIBaudRate;
+}
+
+bool CConfig::GetLCDEnabled (void) const
+{
+	return m_bLCDEnabled;
+}
+
+unsigned CConfig::GetLCDPinEnable (void) const
+{
+	return m_nLCDPinEnable;
+}
+
+unsigned CConfig::GetLCDPinRegisterSelect (void) const
+{
+	return m_nLCDPinRegisterSelect;
+}
+
+unsigned CConfig::GetLCDPinReadWrite (void) const
+{
+	return m_nLCDPinReadWrite;
+}
+
+unsigned CConfig::GetLCDPinData4 (void) const
+{
+	return m_nLCDPinData4;
+}
+
+unsigned CConfig::GetLCDPinData5 (void) const
+{
+	return m_nLCDPinData5;
+}
+
+unsigned CConfig::GetLCDPinData6 (void) const
+{
+	return m_nLCDPinData6;
+}
+
+unsigned CConfig::GetLCDPinData7 (void) const
+{
+	return m_nLCDPinData7;
+}
+
+bool CConfig::GetMIDIDumpEnabled (void) const
+{
+	return m_bMIDIDumpEnabled;
+}
+
+bool CConfig::GetProfileEnabled (void) const
+{
+	return m_bProfileEnabled;
+}

--- a/src/config.h
+++ b/src/config.h
@@ -32,6 +32,12 @@ class CConfig		// Configuration for MiniDexed
 public:
 	static const unsigned MaxNotes = 16;		// polyphony
 
+#if RASPPI <= 3
+	static const unsigned MaxUSBMIDIDevices = 2;
+#else
+	static const unsigned MaxUSBMIDIDevices = 4;
+#endif
+
 	static const unsigned LCDColumns = 16;		// HD44780 LCD
 	static const unsigned LCDRows = 2;
 

--- a/src/config.h
+++ b/src/config.h
@@ -1,0 +1,91 @@
+//
+// config.h
+//
+// MiniDexed - Dexed FM synthesizer for bare metal Raspberry Pi
+// Copyright (C) 2022  The MiniDexed Team
+//
+// Original author of this class:
+//	R. Stange <rsta2@o2online.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef _config_h
+#define _config_h
+
+#include <fatfs/ff.h>
+#include <Properties/propertiesfatfsfile.h>
+#include <string>
+
+class CConfig		// Configuration for MiniDexed
+{
+public:
+	static const unsigned MaxNotes = 16;		// polyphony
+
+	static const unsigned LCDColumns = 16;		// HD44780 LCD
+	static const unsigned LCDRows = 2;
+
+public:
+	CConfig (FATFS *pFileSystem);
+	~CConfig (void);
+
+	void Load (void);
+
+	// Sound device
+	const char *GetSoundDevice (void) const;
+	unsigned GetSampleRate (void) const;
+	unsigned GetChunkSize (void) const;
+	unsigned GetDACI2CAddress (void) const;		// 0 for auto probing
+
+	// MIDI
+	unsigned GetMIDIBaudRate (void) const;
+
+	// HD44780 LCD
+	// GPIO pin numbers are chip numbers, not header positions
+	bool GetLCDEnabled (void) const;
+	unsigned GetLCDPinEnable (void) const;
+	unsigned GetLCDPinRegisterSelect (void) const;
+	unsigned GetLCDPinReadWrite (void) const;	// set to 0 if not connected
+	unsigned GetLCDPinData4 (void) const;
+	unsigned GetLCDPinData5 (void) const;
+	unsigned GetLCDPinData6 (void) const;
+	unsigned GetLCDPinData7 (void) const;
+
+	// Debug
+	bool GetMIDIDumpEnabled (void) const;
+	bool GetProfileEnabled (void) const;
+
+private:
+	CPropertiesFatFsFile m_Properties;
+
+	std::string m_SoundDevice;
+	unsigned m_nSampleRate;
+	unsigned m_nChunkSize;
+	unsigned m_nDACI2CAddress;
+
+	unsigned m_nMIDIBaudRate;
+
+	bool m_bLCDEnabled;
+	unsigned m_nLCDPinEnable;
+	unsigned m_nLCDPinRegisterSelect;
+	unsigned m_nLCDPinReadWrite;
+	unsigned m_nLCDPinData4;
+	unsigned m_nLCDPinData5;
+	unsigned m_nLCDPinData6;
+	unsigned m_nLCDPinData7;
+
+	bool m_bMIDIDumpEnabled;
+	bool m_bProfileEnabled;
+};
+
+#endif

--- a/src/dexedadapter.h
+++ b/src/dexedadapter.h
@@ -1,0 +1,70 @@
+//
+// dexedadapter.h
+//
+// MiniDexed - Dexed FM synthesizer for bare metal Raspberry Pi
+// Copyright (C) 2022  The MiniDexed Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef _dexedadapter_h
+#define _dexedadapter_h
+
+#include <synth_dexed.h>
+#include <circle/spinlock.h>
+#include <stdint.h>
+
+// Some Dexed methods require to be guarded from being interrupted
+// by other Dexed calls. This is done herein.
+
+class CDexedAdapter : public Dexed
+{
+public:
+	CDexedAdapter (uint8_t maxnotes, int rate)
+	: Dexed (maxnotes, rate)
+	{
+	}
+
+	void loadVoiceParameters (uint8_t* data)
+	{
+		m_SpinLock.Acquire ();
+		Dexed::loadVoiceParameters (data);
+		m_SpinLock.Release ();
+	}
+
+	void keyup (int16_t pitch)
+	{
+		m_SpinLock.Acquire ();
+		Dexed::keyup (pitch);
+		m_SpinLock.Release ();
+	}
+
+	void keydown (int16_t pitch, uint8_t velo)
+	{
+		m_SpinLock.Acquire ();
+		Dexed::keydown (pitch, velo);
+		m_SpinLock.Release ();
+	}
+
+	void getSamples (uint16_t n_samples, int16_t* buffer)
+	{
+		m_SpinLock.Acquire ();
+		Dexed::getSamples (n_samples, buffer);
+		m_SpinLock.Release ();
+	}
+
+private:
+	CSpinLock m_SpinLock;
+};
+
+#endif

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -18,10 +18,10 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 #include "kernel.h"
-#include <iostream>
 #include <string.h>
 #include <circle/logger.h>
 #include <circle/synchronize.h>
+#include <assert.h>
 
 LOGMODULE ("kernel");
 
@@ -75,6 +75,8 @@ bool CKernel::Initialize (void)
 		m_pDexed = new CMiniDexedPWM (&m_Config, &mInterrupt);
 	}
 
+	assert (m_pDexed);
+
 	if (!m_pDexed->Initialize ())
 	{
 		return FALSE;
@@ -85,15 +87,18 @@ bool CKernel::Initialize (void)
 
 CStdlibApp::TShutdownMode CKernel::Run (void)
 {
-	std::cout << "Hello MiniDexed!\n";
+	assert (m_pDexed);
 
-	while(42==42)
+	while (42 == 42)
 	{
 		boolean bUpdated = mUSBHCI.UpdatePlugAndPlay ();
 
 		m_pDexed->Process(bUpdated);
 
-		mScreen.Update ();
+		if (mbScreenAvailable)
+		{
+			mScreen.Update ();
+		}
 	}
 
 	return ShutdownHalt;
@@ -103,5 +108,8 @@ void CKernel::PanicHandler (void)
 {
 	EnableIRQs ();
 
-	s_pThis->mScreen.Update (4096);
+	if (s_pThis->mbScreenAvailable)
+	{
+		s_pThis->mScreen.Update (4096);
+	}
 }

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -5,20 +5,27 @@
 #include <iostream>
 #include <string.h>
 #include <circle/logger.h>
+#include <circle/synchronize.h>
 #include "voices.c"
 
 LOGMODULE ("kernel");
 
+CKernel *CKernel::s_pThis = 0;
+
 CKernel::CKernel (void)
 :	CStdlibAppStdio ("minidexed"),
+	m_Config (&mFileSystem),
  	m_I2CMaster (CMachineInfo::Get ()->GetDevice (DeviceI2CMaster), TRUE),
 	m_pDexed (0)
 {
+	s_pThis = this;
+
 	// mActLED.Blink (5);	// show we are alive
 }
 
 CKernel::~CKernel(void)
 {
+	s_pThis = 0;
 }
 
 bool CKernel::Initialize (void)
@@ -28,25 +35,29 @@ bool CKernel::Initialize (void)
 		return FALSE;
 	}
 
+	mLogger.RegisterPanicHandler (PanicHandler);
+
+	m_Config.Load ();
+
 	// select the sound device
-	const char *pSoundDevice = mOptions.GetSoundDevice ();
-	if (strcmp (pSoundDevice, "sndi2s") == 0)
+	const char *pSoundDevice = m_Config.GetSoundDevice ();
+	if (strcmp (pSoundDevice, "i2s") == 0)
 	{
 		LOGNOTE ("I2S mode");
 
-		m_pDexed = new CMiniDexedI2S (16, SAMPLE_RATE, &mInterrupt, &m_I2CMaster);
+		m_pDexed = new CMiniDexedI2S (&m_Config, &mInterrupt, &m_I2CMaster);
 	}
-	else if (strcmp (pSoundDevice, "sndhdmi") == 0)
+	else if (strcmp (pSoundDevice, "hdmi") == 0)
 	{
 		LOGNOTE ("HDMI mode");
 
-		m_pDexed = new CMiniDexedHDMI (16, SAMPLE_RATE, &mInterrupt);
+		m_pDexed = new CMiniDexedHDMI (&m_Config, &mInterrupt);
 	}
 	else
 	{
 		LOGNOTE ("PWM mode");
 
-		m_pDexed = new CMiniDexedPWM (16, SAMPLE_RATE, &mInterrupt);
+		m_pDexed = new CMiniDexedPWM (&m_Config, &mInterrupt);
 	}
 
 	if (!m_pDexed->Initialize ())
@@ -71,4 +82,11 @@ CStdlibApp::TShutdownMode CKernel::Run (void)
 	}
 
 	return ShutdownHalt;
+}
+
+void CKernel::PanicHandler (void)
+{
+	EnableIRQs ();
+
+	s_pThis->mScreen.Update (4096);
 }

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -22,7 +22,6 @@
 #include <string.h>
 #include <circle/logger.h>
 #include <circle/synchronize.h>
-#include "voices.c"
 
 LOGMODULE ("kernel");
 

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -1,6 +1,22 @@
 //
 // kernel.cpp
 //
+// MiniDexed - Dexed FM synthesizer for bare metal Raspberry Pi
+// Copyright (C) 2022  The MiniDexed Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 #include "kernel.h"
 #include <iostream>
 #include <string.h>

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -47,9 +47,9 @@ private:
 
 private:
 	// do not change this order
-	CConfig			m_Config;
-	CI2CMaster		m_I2CMaster;
-	CMiniDexed		*m_pDexed;
+	CConfig		m_Config;
+	CI2CMaster	m_I2CMaster;
+	CMiniDexed	*m_pDexed;
 
 	static CKernel *s_pThis;
 };

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -6,6 +6,7 @@
 
 #include "circle_stdlib_app.h"
 #include <circle/i2cmaster.h>
+#include "config.h"
 #include "minidexed.h"
 
 enum TShutdownMode
@@ -26,9 +27,15 @@ public:
 	TShutdownMode Run (void);
 
 private:
+	static void PanicHandler (void);
+
+private:
 	// do not change this order
+	CConfig			m_Config;
 	CI2CMaster		m_I2CMaster;
 	CMiniDexed		*m_pDexed;
+
+	static CKernel *s_pThis;
 };
 
 #endif

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -1,6 +1,22 @@
 //
 // kernel.h
 //
+// MiniDexed - Dexed FM synthesizer for bare metal Raspberry Pi
+// Copyright (C) 2022  The MiniDexed Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 #ifndef _kernel_h
 #define _kernel_h
 

--- a/src/mididevice.cpp
+++ b/src/mididevice.cpp
@@ -35,6 +35,9 @@
 #define MIDI_PROGRAM_CHANGE	0b1100
 #define MIDI_PITCH_BEND		0b1110
 
+#define MIDI_TIMING_CLOCK	0xF8
+#define MIDI_ACTIVE_SENSING	0xFE
+
 CMIDIDevice::CMIDIDevice (CMiniDexed *pSynthesizer, CConfig *pConfig)
 :	m_pSynthesizer (pSynthesizer),
 	m_pConfig (pConfig)
@@ -58,7 +61,11 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 		switch (nLength)
 		{
 		case 1:
-			printf ("MIDI %u: %02X\n", nCable, (unsigned) pMessage[0]);
+			if (   pMessage[0] != MIDI_TIMING_CLOCK
+			    && pMessage[0] != MIDI_ACTIVE_SENSING)
+			{
+				printf ("MIDI %u: %02X\n", nCable, (unsigned) pMessage[0]);
+			}
 			break;
 
 		case 2:

--- a/src/mididevice.cpp
+++ b/src/mididevice.cpp
@@ -1,0 +1,143 @@
+//
+// mididevice.cpp
+//
+// MiniDexed - Dexed FM synthesizer for bare metal Raspberry Pi
+// Copyright (C) 2022  The MiniDexed Team
+//
+// Original author of this class:
+//	R. Stange <rsta2@o2online.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include "mididevice.h"
+#include "minidexed.h"
+#include "config.h"
+#include <stdio.h>
+#include <assert.h>
+
+#define MIDI_NOTE_OFF		0b1000
+#define MIDI_NOTE_ON		0b1001
+#define MIDI_AFTERTOUCH		0b1010			// TODO
+#define MIDI_CONTROL_CHANGE	0b1011
+	#define MIDI_CC_BANK_SELECT_MSB		0	// TODO
+	#define MIDI_CC_BANK_SELECT_LSB		32
+#define MIDI_PROGRAM_CHANGE	0b1100
+#define MIDI_PITCH_BEND		0b1110
+
+CMIDIDevice::CMIDIDevice (CMiniDexed *pSynthesizer, CConfig *pConfig)
+:	m_pSynthesizer (pSynthesizer),
+	m_pConfig (pConfig)
+{
+}
+
+CMIDIDevice::~CMIDIDevice (void)
+{
+	m_pSynthesizer = 0;
+}
+
+void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsigned nCable)
+{
+	assert (m_pSynthesizer != 0);
+
+	// The packet contents are just normal MIDI data - see
+	// https://www.midi.org/specifications/item/table-1-summary-of-midi-message
+
+	if (m_pConfig->GetMIDIDumpEnabled ())
+	{
+		switch (nLength)
+		{
+		case 1:
+			printf ("MIDI %u: %02X\n", nCable, (unsigned) pMessage[0]);
+			break;
+
+		case 2:
+			printf ("MIDI %u: %02X %02X\n", nCable,
+				(unsigned) pMessage[0], (unsigned) pMessage[1]);
+			break;
+
+		case 3:
+			printf ("MIDI %u: %02X %02X %02X\n", nCable,
+				(unsigned) pMessage[0], (unsigned) pMessage[1],
+				(unsigned) pMessage[2]);
+			break;
+		}
+	}
+
+	if (nLength < 2)
+	{
+		return;
+	}
+
+	u8 ucStatus    = pMessage[0];
+	// TODO: u8 ucChannel   = ucStatus & 0x0F;
+	u8 ucType      = ucStatus >> 4;
+	u8 ucKeyNumber = pMessage[1];
+	u8 ucVelocity  = pMessage[2];
+
+	switch (ucType)
+	{
+	case MIDI_NOTE_ON:
+		if (nLength < 3)
+		{
+			break;
+		}
+
+		if (ucVelocity > 0)
+		{
+			if (ucVelocity <= 127)
+			{
+				m_pSynthesizer->keydown (ucKeyNumber, ucVelocity);
+			}
+		}
+		else
+		{
+			m_pSynthesizer->keyup (ucKeyNumber);
+		}
+		break;
+
+	case MIDI_NOTE_OFF:
+		if (nLength < 3)
+		{
+			break;
+		}
+
+		m_pSynthesizer->keyup (ucKeyNumber);
+		break;
+
+	case MIDI_CONTROL_CHANGE:
+		if (nLength < 3)
+		{
+			break;
+		}
+
+		switch (pMessage[1])
+		{
+		case MIDI_CC_BANK_SELECT_LSB:
+			m_pSynthesizer->BankSelectLSB (pMessage[2]);
+			break;
+		}
+		break;
+
+	case MIDI_PROGRAM_CHANGE:
+		m_pSynthesizer->ProgramChange (pMessage[1]);
+		break;
+
+	case MIDI_PITCH_BEND:
+		m_pSynthesizer->setPitchbend (pMessage[1]);
+		break;
+
+	default:
+		break;
+	}
+}

--- a/src/mididevice.h
+++ b/src/mididevice.h
@@ -1,0 +1,45 @@
+//
+// mididevice.h
+//
+// MiniDexed - Dexed FM synthesizer for bare metal Raspberry Pi
+// Copyright (C) 2022  The MiniDexed Team
+//
+// Original author of this class:
+//	R. Stange <rsta2@o2online.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef _mididevice_h
+#define _mididevice_h
+
+#include "config.h"
+#include <circle/types.h>
+
+class CMiniDexed;
+
+class CMIDIDevice
+{
+public:
+	CMIDIDevice (CMiniDexed *pSynthesizer, CConfig *pConfig);
+	~CMIDIDevice (void);
+
+protected:
+	void MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsigned nCable = 0);
+
+private:
+	CMiniDexed *m_pSynthesizer;
+	CConfig *m_pConfig;
+};
+
+#endif

--- a/src/midikeyboard.cpp
+++ b/src/midikeyboard.cpp
@@ -1,0 +1,71 @@
+//
+// midikeyboard.cpp
+//
+// MiniDexed - Dexed FM synthesizer for bare metal Raspberry Pi
+// Copyright (C) 2022  The MiniDexed Team
+//
+// Original author of this class:
+//	R. Stange <rsta2@o2online.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include "midikeyboard.h"
+#include <circle/devicenameservice.h>
+#include <assert.h>
+
+CMIDIKeyboard *CMIDIKeyboard::s_pThis = 0;
+
+CMIDIKeyboard::CMIDIKeyboard (CMiniDexed *pSynthesizer, CConfig *pConfig)
+:	CMIDIDevice (pSynthesizer, pConfig),
+	m_pMIDIDevice (0)
+{
+	s_pThis = this;
+}
+
+CMIDIKeyboard::~CMIDIKeyboard (void)
+{
+	s_pThis = 0;
+}
+
+void CMIDIKeyboard::Process (boolean bPlugAndPlayUpdated)
+{
+	if (!bPlugAndPlayUpdated)
+	{
+		return;
+	}
+
+	if (m_pMIDIDevice == 0)
+	{
+		m_pMIDIDevice =
+			(CUSBMIDIDevice *) CDeviceNameService::Get ()->GetDevice ("umidi1", FALSE);
+		if (m_pMIDIDevice != 0)
+		{
+			m_pMIDIDevice->RegisterPacketHandler (MIDIPacketHandler);
+
+			m_pMIDIDevice->RegisterRemovedHandler (DeviceRemovedHandler);
+		}
+	}
+}
+
+void CMIDIKeyboard::MIDIPacketHandler (unsigned nCable, u8 *pPacket, unsigned nLength)
+{
+	assert (s_pThis != 0);
+	s_pThis->MIDIMessageHandler (pPacket, nLength, nCable);
+}
+
+void CMIDIKeyboard::DeviceRemovedHandler (CDevice *pDevice, void *pContext)
+{
+	assert (s_pThis != 0);
+	s_pThis->m_pMIDIDevice = 0;
+}

--- a/src/midikeyboard.h
+++ b/src/midikeyboard.h
@@ -27,6 +27,7 @@
 #include "config.h"
 #include <circle/usb/usbmidi.h>
 #include <circle/device.h>
+#include <circle/string.h>
 #include <circle/types.h>
 
 class CMiniDexed;
@@ -34,20 +35,31 @@ class CMiniDexed;
 class CMIDIKeyboard : public CMIDIDevice
 {
 public:
-	CMIDIKeyboard (CMiniDexed *pSynthesizer, CConfig *pConfig);
+	static const unsigned MaxInstances = 4;
+
+public:
+	CMIDIKeyboard (CMiniDexed *pSynthesizer, CConfig *pConfig, unsigned nInstance = 0);
 	~CMIDIKeyboard (void);
 
 	void Process (boolean bPlugAndPlayUpdated);
 
 private:
-	static void MIDIPacketHandler (unsigned nCable, u8 *pPacket, unsigned nLength);
+	static void MIDIPacketHandler0 (unsigned nCable, u8 *pPacket, unsigned nLength);
+	static void MIDIPacketHandler1 (unsigned nCable, u8 *pPacket, unsigned nLength);
+	static void MIDIPacketHandler2 (unsigned nCable, u8 *pPacket, unsigned nLength);
+	static void MIDIPacketHandler3 (unsigned nCable, u8 *pPacket, unsigned nLength);
 
 	static void DeviceRemovedHandler (CDevice *pDevice, void *pContext);
 
 private:
+	unsigned m_nInstance;
+	CString m_DeviceName;
+
 	CUSBMIDIDevice * volatile m_pMIDIDevice;
 
-	static CMIDIKeyboard *s_pThis;
+	static CMIDIKeyboard *s_pThis[MaxInstances];
+
+	static TMIDIPacketHandler * const s_pMIDIPacketHandler[MaxInstances];
 };
 
 #endif

--- a/src/midikeyboard.h
+++ b/src/midikeyboard.h
@@ -1,0 +1,53 @@
+//
+// midikeyboard.h
+//
+// MiniDexed - Dexed FM synthesizer for bare metal Raspberry Pi
+// Copyright (C) 2022  The MiniDexed Team
+//
+// Original author of this class:
+//	R. Stange <rsta2@o2online.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef _midikeyboard_h
+#define _midikeyboard_h
+
+#include "mididevice.h"
+#include "config.h"
+#include <circle/usb/usbmidi.h>
+#include <circle/device.h>
+#include <circle/types.h>
+
+class CMiniDexed;
+
+class CMIDIKeyboard : public CMIDIDevice
+{
+public:
+	CMIDIKeyboard (CMiniDexed *pSynthesizer, CConfig *pConfig);
+	~CMIDIKeyboard (void);
+
+	void Process (boolean bPlugAndPlayUpdated);
+
+private:
+	static void MIDIPacketHandler (unsigned nCable, u8 *pPacket, unsigned nLength);
+
+	static void DeviceRemovedHandler (CDevice *pDevice, void *pContext);
+
+private:
+	CUSBMIDIDevice * volatile m_pMIDIDevice;
+
+	static CMIDIKeyboard *s_pThis;
+};
+
+#endif

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -28,7 +28,6 @@ CMiniDexed::CMiniDexed (CConfig *pConfig, CInterruptSystem *pInterrupt)
 :	CDexedAdapter (CConfig::MaxNotes, pConfig->GetSampleRate ()),
 	m_pConfig (pConfig),
 	m_UI (this, pConfig),
-	m_MIDIKeyboard (this, pConfig),
 	m_PCKeyboard (this),
 	m_SerialMIDI (this, pInterrupt, pConfig),
 	m_bUseSerial (false),
@@ -36,6 +35,11 @@ CMiniDexed::CMiniDexed (CConfig *pConfig, CInterruptSystem *pInterrupt)
 			 1000000U * pConfig->GetChunkSize ()/2 / pConfig->GetSampleRate ()),
 	m_bProfileEnabled (m_pConfig->GetProfileEnabled ())
 {
+	for (unsigned i = 0; i < CConfig::MaxUSBMIDIDevices; i++)
+	{
+		m_pMIDIKeyboard[i] = new CMIDIKeyboard (this, pConfig, i);
+		assert (m_pMIDIKeyboard[i]);
+	}
 };
 
 bool CMiniDexed::Initialize (void)
@@ -64,7 +68,11 @@ bool CMiniDexed::Initialize (void)
 
 void CMiniDexed::Process (bool bPlugAndPlayUpdated)
 {
-	m_MIDIKeyboard.Process (bPlugAndPlayUpdated);
+	for (unsigned i = 0; i < CConfig::MaxUSBMIDIDevices; i++)
+	{
+		assert (m_pMIDIKeyboard[i]);
+		m_pMIDIKeyboard[i]->Process (bPlugAndPlayUpdated);
+	}
 
 	m_PCKeyboard.Process (bPlugAndPlayUpdated);
 

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -1,6 +1,22 @@
 //
 // minidexed.cpp
 //
+// MiniDexed - Dexed FM synthesizer for bare metal Raspberry Pi
+// Copyright (C) 2022  The MiniDexed Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 #include "minidexed.h"
 #include <circle/logger.h>
 #include <stdio.h>

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -19,7 +19,7 @@
 #include "sysexfileloader.h"
 #include "pckeyboard.h"
 #include "perftimer.h"
-#include <display/hd44780device.h>
+#include "userinterface.h"
 
 class CMiniDexed : public CDexedAdapter
 {
@@ -33,28 +33,17 @@ class CMiniDexed : public CDexedAdapter
     m_nSerialState (0),
     m_GetChunkTimer ("GetChunk", 1000000U * pConfig->GetChunkSize ()/2 / pConfig->GetSampleRate ()),
     m_pConfig (pConfig),
-    m_pLCD (0)
+    m_UI (this, pConfig)
     {
       s_pThis = this;
-
-      if (pConfig->GetLCDEnabled ())
-      {
-        m_pLCD = new CHD44780Device (CConfig::LCDColumns, CConfig::LCDRows,
-                                     pConfig->GetLCDPinData4 (), pConfig->GetLCDPinData5 (),
-                                     pConfig->GetLCDPinData6 (), pConfig->GetLCDPinData7 (),
-                                     pConfig->GetLCDPinEnable (), pConfig->GetLCDPinRegisterSelect (),
-                                     pConfig->GetLCDPinReadWrite ());
-      }
     };
 
     virtual bool Initialize (void);
     void Process(boolean bPlugAndPlayUpdated);
-  private:
-    void LCDWrite (const char *pString);
   protected:
     static void MIDIPacketHandler (unsigned nCable, u8 *pPacket, unsigned nLength);
     static void KeyStatusHandlerRaw (unsigned char ucModifiers, const unsigned char RawKeys[6]);
-    static void ChangeProgram(unsigned program);
+    void ChangeProgram(unsigned program);
     static void USBDeviceRemovedHandler (CDevice *pDevice, void *pContext);
     CUSBMIDIDevice     * volatile m_pMIDIDevice;
     CPCKeyboard        m_PCKeyboard;
@@ -66,7 +55,7 @@ class CMiniDexed : public CDexedAdapter
     CPerformanceTimer m_GetChunkTimer;
   private:
     CConfig             *m_pConfig;
-    CHD44780Device	*m_pLCD;
+    CUserInterface	m_UI;
 
     static CMiniDexed *s_pThis;
 };

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -54,7 +54,7 @@ private:
 	CUserInterface m_UI;
 	CSysExFileLoader m_SysExFileLoader;
 
-	CMIDIKeyboard m_MIDIKeyboard;
+	CMIDIKeyboard *m_pMIDIKeyboard[CConfig::MaxUSBMIDIDevices];
 	CPCKeyboard m_PCKeyboard;
 	CSerialMIDIDevice m_SerialMIDI;
 	bool m_bUseSerial;

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -21,94 +21,84 @@
 #define _minidexed_h
 
 #include "dexedadapter.h"
-#include <stdint.h>
-#include <math.h>
-#include <circle/interrupt.h>
-#include <circle/i2cmaster.h>
-#include <circle/types.h>
-#include <circle/pwmsoundbasedevice.h>
-#include <circle/i2ssoundbasedevice.h>
-#include <circle/hdmisoundbasedevice.h>
 #include "config.h"
+#include "userinterface.h"
 #include "sysexfileloader.h"
 #include "midikeyboard.h"
 #include "pckeyboard.h"
 #include "serialmididevice.h"
 #include "perftimer.h"
-#include "userinterface.h"
+#include <stdint.h>
+#include <circle/types.h>
+#include <circle/interrupt.h>
+#include <circle/i2cmaster.h>
+#include <circle/pwmsoundbasedevice.h>
+#include <circle/i2ssoundbasedevice.h>
+#include <circle/hdmisoundbasedevice.h>
 
 class CMiniDexed : public CDexedAdapter
 {
-  public:
-    CMiniDexed(CConfig *pConfig, CInterruptSystem *pInterrupt)
-:   CDexedAdapter (CConfig::MaxNotes, pConfig->GetSampleRate ()),
-    m_MIDIKeyboard (this, pConfig),
-    m_PCKeyboard (this),
-    m_SerialMIDI (this, pInterrupt, pConfig),
-    m_bUseSerial (FALSE),
-    m_pConfig (pConfig),
-    m_UI (this, pConfig),
-    m_GetChunkTimer ("GetChunk", 1000000U * pConfig->GetChunkSize ()/2 / pConfig->GetSampleRate ())
-    {
-    };
+public:
+	CMiniDexed (CConfig *pConfig, CInterruptSystem *pInterrupt);
 
-    virtual bool Initialize (void);
-    void Process(boolean bPlugAndPlayUpdated);
+	virtual bool Initialize (void);
 
-    void BankSelectLSB (unsigned nBankLSB);
-    void ProgramChange (unsigned program);
+	void Process (bool bPlugAndPlayUpdated);
 
-  private:
-    CMIDIKeyboard m_MIDIKeyboard;
-    CPCKeyboard m_PCKeyboard;
-    CSerialMIDIDevice m_SerialMIDI;
-    boolean m_bUseSerial;
-    CSysExFileLoader m_SysExFileLoader;
-    CConfig             *m_pConfig;
-    CUserInterface	m_UI;
+	void BankSelectLSB (unsigned nBankLSB);
+	void ProgramChange (unsigned nProgram);
 
-  protected:
-    CPerformanceTimer m_GetChunkTimer;
+private:
+	CConfig *m_pConfig;
+
+	CUserInterface m_UI;
+	CSysExFileLoader m_SysExFileLoader;
+
+	CMIDIKeyboard m_MIDIKeyboard;
+	CPCKeyboard m_PCKeyboard;
+	CSerialMIDIDevice m_SerialMIDI;
+	bool m_bUseSerial;
+
+protected:
+	CPerformanceTimer m_GetChunkTimer;
+	bool m_bProfileEnabled;
 };
+
+//// PWM //////////////////////////////////////////////////////////////////////
 
 class CMiniDexedPWM : public CMiniDexed, public CPWMSoundBaseDevice
 {
-  public:
-    CMiniDexedPWM(CConfig *pConfig, CInterruptSystem *pInterrupt)
-:   CMiniDexed(pConfig, pInterrupt),
-    CPWMSoundBaseDevice (pInterrupt, pConfig->GetSampleRate (), pConfig->GetChunkSize ())
-    {
-    }
+public:
+	CMiniDexedPWM (CConfig *pConfig, CInterruptSystem *pInterrupt);
 
-    bool Initialize (void);
-    unsigned GetChunk (u32 *pBuffer, unsigned nChunkSize);
+	bool Initialize (void);
+
+	unsigned GetChunk (u32 *pBuffer, unsigned nChunkSize);
 };
+
+//// I2S //////////////////////////////////////////////////////////////////////
 
 class CMiniDexedI2S : public CMiniDexed, public CI2SSoundBaseDevice
 {
-  public:
-    CMiniDexedI2S(CConfig *pConfig, CInterruptSystem *pInterrupt, CI2CMaster *pI2CMaster)
-:   CMiniDexed(pConfig, pInterrupt),
-    CI2SSoundBaseDevice (pInterrupt, pConfig->GetSampleRate (), pConfig->GetChunkSize (),
-			 FALSE, pI2CMaster, pConfig->GetDACI2CAddress ())
-    {
-    }
+public:
+	CMiniDexedI2S (CConfig *pConfig, CInterruptSystem *pInterrupt,
+		       CI2CMaster *pI2CMaster);
 
-    bool Initialize (void);
-    unsigned GetChunk (u32 *pBuffer, unsigned nChunkSize);
+	bool Initialize (void);
+
+	unsigned GetChunk (u32 *pBuffer, unsigned nChunkSize);
 };
+
+//// HDMI /////////////////////////////////////////////////////////////////////
 
 class CMiniDexedHDMI : public CMiniDexed, public CHDMISoundBaseDevice
 {
-  public:
-    CMiniDexedHDMI(CConfig *pConfig, CInterruptSystem *pInterrupt)
-:   CMiniDexed(pConfig, pInterrupt),
-    CHDMISoundBaseDevice (pInterrupt, pConfig->GetSampleRate (), pConfig->GetChunkSize ())
-    {
-    }
+public:
+	CMiniDexedHDMI (CConfig *pConfig, CInterruptSystem *pInterrupt);
 
-    bool Initialize (void);
-    unsigned GetChunk (u32 *pBuffer, unsigned nChunkSize);
+	bool Initialize (void);
+
+	unsigned GetChunk (u32 *pBuffer, unsigned nChunkSize);
 };
 
 #endif

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -9,15 +9,15 @@
 #include <math.h>
 #include <circle/interrupt.h>
 #include <circle/i2cmaster.h>
-#include <circle/usb/usbmidi.h>
-#include <circle/serial.h>
 #include <circle/types.h>
 #include <circle/pwmsoundbasedevice.h>
 #include <circle/i2ssoundbasedevice.h>
 #include <circle/hdmisoundbasedevice.h>
 #include "config.h"
 #include "sysexfileloader.h"
+#include "midikeyboard.h"
 #include "pckeyboard.h"
+#include "serialmididevice.h"
 #include "perftimer.h"
 #include "userinterface.h"
 
@@ -26,38 +26,33 @@ class CMiniDexed : public CDexedAdapter
   public:
     CMiniDexed(CConfig *pConfig, CInterruptSystem *pInterrupt)
 :   CDexedAdapter (CConfig::MaxNotes, pConfig->GetSampleRate ()),
-    m_pMIDIDevice (0),
+    m_MIDIKeyboard (this, pConfig),
     m_PCKeyboard (this),
-    m_Serial (pInterrupt, TRUE),
+    m_SerialMIDI (this, pInterrupt, pConfig),
     m_bUseSerial (FALSE),
-    m_nSerialState (0),
-    m_GetChunkTimer ("GetChunk", 1000000U * pConfig->GetChunkSize ()/2 / pConfig->GetSampleRate ()),
     m_pConfig (pConfig),
-    m_UI (this, pConfig)
+    m_UI (this, pConfig),
+    m_GetChunkTimer ("GetChunk", 1000000U * pConfig->GetChunkSize ()/2 / pConfig->GetSampleRate ())
     {
-      s_pThis = this;
     };
 
     virtual bool Initialize (void);
     void Process(boolean bPlugAndPlayUpdated);
-  protected:
-    static void MIDIPacketHandler (unsigned nCable, u8 *pPacket, unsigned nLength);
-    static void KeyStatusHandlerRaw (unsigned char ucModifiers, const unsigned char RawKeys[6]);
-    void ChangeProgram(unsigned program);
-    static void USBDeviceRemovedHandler (CDevice *pDevice, void *pContext);
-    CUSBMIDIDevice     * volatile m_pMIDIDevice;
-    CPCKeyboard        m_PCKeyboard;
-    CSerialDevice m_Serial;
-    boolean m_bUseSerial;
-    unsigned m_nSerialState;
-    u8 m_SerialMessage[3];
-    CSysExFileLoader m_SysExFileLoader;
-    CPerformanceTimer m_GetChunkTimer;
+
+    void BankSelectLSB (unsigned nBankLSB);
+    void ProgramChange (unsigned program);
+
   private:
+    CMIDIKeyboard m_MIDIKeyboard;
+    CPCKeyboard m_PCKeyboard;
+    CSerialMIDIDevice m_SerialMIDI;
+    boolean m_bUseSerial;
+    CSysExFileLoader m_SysExFileLoader;
     CConfig             *m_pConfig;
     CUserInterface	m_UI;
 
-    static CMiniDexed *s_pThis;
+  protected:
+    CPerformanceTimer m_GetChunkTimer;
 };
 
 class CMiniDexedPWM : public CMiniDexed, public CPWMSoundBaseDevice

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -1,6 +1,22 @@
 //
 // minidexed.h
 //
+// MiniDexed - Dexed FM synthesizer for bare metal Raspberry Pi
+// Copyright (C) 2022  The MiniDexed Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 #ifndef _minidexed_h
 #define _minidexed_h
 

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -4,7 +4,7 @@
 #ifndef _minidexed_h
 #define _minidexed_h
 
-#include <synth_dexed.h>
+#include "dexedadapter.h"
 #include <stdint.h>
 #include <math.h>
 #include <circle/interrupt.h>
@@ -21,11 +21,11 @@
 #include "perftimer.h"
 #include <display/hd44780device.h>
 
-class CMiniDexed : public Dexed
+class CMiniDexed : public CDexedAdapter
 {
   public:
     CMiniDexed(CConfig *pConfig, CInterruptSystem *pInterrupt)
-:   Dexed (CConfig::MaxNotes, pConfig->GetSampleRate ()),
+:   CDexedAdapter (CConfig::MaxNotes, pConfig->GetSampleRate ()),
     m_pMIDIDevice (0),
     m_PCKeyboard (this),
     m_Serial (pInterrupt, TRUE),

--- a/src/minidexed.ini
+++ b/src/minidexed.ini
@@ -1,0 +1,26 @@
+#
+# minidexed.ini
+#
+
+# Sound device
+SoundDevice=pwm
+SampleRate=48000
+#ChunkSize=256
+DACI2CAddress=0
+
+# MIDI
+MIDIBaudRate=31250
+
+# HD44780 LCD
+LCDEnabled=1
+LCDPinEnable=17
+LCDPinRegisterSelect=18
+LCDPinReadWrite=19
+LCDPinData4=22
+LCDPinData5=23
+LCDPinData6=24
+LCDPinData7=25
+
+# Debug
+MIDIDumpEnabled=1
+ProfileEnabled=1

--- a/src/perftimer.cpp
+++ b/src/perftimer.cpp
@@ -1,6 +1,22 @@
 //
 // perftimer.cpp
 //
+// MiniDexed - Dexed FM synthesizer for bare metal Raspberry Pi
+// Copyright (C) 2022  The MiniDexed Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 #include "perftimer.h"
 #include <iostream>
 

--- a/src/perftimer.h
+++ b/src/perftimer.h
@@ -1,6 +1,22 @@
 //
 // perftimer.h
 //
+// MiniDexed - Dexed FM synthesizer for bare metal Raspberry Pi
+// Copyright (C) 2022  The MiniDexed Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 #ifndef _perftimer_h
 #define _perftimer_h
 

--- a/src/serialmididevice.cpp
+++ b/src/serialmididevice.cpp
@@ -1,0 +1,98 @@
+//
+// serialmididevice.cpp
+//
+// MiniDexed - Dexed FM synthesizer for bare metal Raspberry Pi
+// Copyright (C) 2022  The MiniDexed Team
+//
+// Original author of this class:
+//	R. Stange <rsta2@o2online.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include "serialmididevice.h"
+#include <assert.h>
+
+CSerialMIDIDevice::CSerialMIDIDevice (CMiniDexed *pSynthesizer, CInterruptSystem *pInterrupt,
+				      CConfig *pConfig)
+:	CMIDIDevice (pSynthesizer, pConfig),
+	m_pConfig (pConfig),
+	m_Serial (pInterrupt, TRUE),
+	m_nSerialState (0)
+{
+}
+
+CSerialMIDIDevice::~CSerialMIDIDevice (void)
+{
+	m_nSerialState = 255;
+}
+
+boolean CSerialMIDIDevice::Initialize (void)
+{
+	assert (m_pConfig);
+	return m_Serial.Initialize (m_pConfig->GetMIDIBaudRate ());
+}
+
+void CSerialMIDIDevice::Process (void)
+{
+	// Read serial MIDI data
+	u8 Buffer[100];
+	int nResult = m_Serial.Read (Buffer, sizeof Buffer);
+	if (nResult <= 0)
+	{
+		return;
+	}
+
+	// Process MIDI messages
+	// See: https://www.midi.org/specifications/item/table-1-summary-of-midi-message
+	for (int i = 0; i < nResult; i++)
+	{
+		u8 uchData = Buffer[i];
+
+		switch (m_nSerialState)
+		{
+		case 0:
+		MIDIRestart:
+			if (   (uchData & 0x80) == 0x80		// status byte, all channels
+			    && (uchData & 0xF0) != 0xF0)	// ignore system messages
+			{
+				m_SerialMessage[m_nSerialState++] = uchData;
+			}
+			break;
+
+		case 1:
+		case 2:
+			if (uchData & 0x80)			// got status when parameter expected
+			{
+				m_nSerialState = 0;
+
+				goto MIDIRestart;
+			}
+
+			m_SerialMessage[m_nSerialState++] = uchData;
+
+			if (   (m_SerialMessage[0] & 0xE0) == 0xC0
+			    || m_nSerialState == 3)		// message is complete
+			{
+				MIDIMessageHandler (m_SerialMessage, m_nSerialState);
+
+				m_nSerialState = 0;
+			}
+			break;
+
+		default:
+			assert (0);
+			break;
+		}
+	}
+}

--- a/src/serialmididevice.h
+++ b/src/serialmididevice.h
@@ -1,0 +1,52 @@
+//
+// serialmididevice.h
+//
+// MiniDexed - Dexed FM synthesizer for bare metal Raspberry Pi
+// Copyright (C) 2022  The MiniDexed Team
+//
+// Original author of this class:
+//	R. Stange <rsta2@o2online.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef _serialmididevice_h
+#define _serialmididevice_h
+
+#include "mididevice.h"
+#include "config.h"
+#include <circle/interrupt.h>
+#include <circle/serial.h>
+#include <circle/types.h>
+
+class CMiniDexed;
+
+class CSerialMIDIDevice : public CMIDIDevice
+{
+public:
+	CSerialMIDIDevice (CMiniDexed *pSynthesizer, CInterruptSystem *pInterrupt, CConfig *pConfig);
+	~CSerialMIDIDevice (void);
+
+	boolean Initialize (void);
+
+	void Process (void);
+
+private:
+	CConfig *m_pConfig;
+
+	CSerialDevice m_Serial;
+	unsigned m_nSerialState;
+	u8 m_SerialMessage[3];
+};
+
+#endif

--- a/src/sysexfileloader.cpp
+++ b/src/sysexfileloader.cpp
@@ -24,8 +24,7 @@
 #include <string.h>
 #include <assert.h>
 #include <circle/logger.h>
-
-extern uint8_t voices_bank[1][32][156];
+#include "voices.c"
 
 LOGMODULE ("syxfile");
 

--- a/src/sysexfileloader.cpp
+++ b/src/sysexfileloader.cpp
@@ -1,6 +1,22 @@
 //
 // sysexfileloader.cpp
 //
+// MiniDexed - Dexed FM synthesizer for bare metal Raspberry Pi
+// Copyright (C) 2022  The MiniDexed Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 #include "sysexfileloader.h"
 #include <stdio.h>
 #include <dirent.h>

--- a/src/sysexfileloader.h
+++ b/src/sysexfileloader.h
@@ -3,6 +3,22 @@
 //
 // See: https://github.com/asb2m10/dexed/blob/master/Documentation/sysex-format.txt
 //
+// MiniDexed - Dexed FM synthesizer for bare metal Raspberry Pi
+// Copyright (C) 2022  The MiniDexed Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 #ifndef _sysexfileloader_h
 #define _sysexfileloader_h
 

--- a/src/userinterface.cpp
+++ b/src/userinterface.cpp
@@ -1,0 +1,107 @@
+//
+// userinterface.cpp
+//
+// MiniDexed - Dexed FM synthesizer for bare metal Raspberry Pi
+// Copyright (C) 2022  The MiniDexed Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include "userinterface.h"
+#include "minidexed.h"
+#include <circle/logger.h>
+#include <circle/string.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+LOGMODULE ("ui");
+
+CUserInterface::CUserInterface (CMiniDexed *pMiniDexed, CConfig *pConfig)
+:	m_pMiniDexed (pMiniDexed),
+	m_pConfig (pConfig),
+	m_pLCD (0),
+	m_pLCDBuffered (0)
+{
+}
+
+CUserInterface::~CUserInterface (void)
+{
+	delete m_pLCDBuffered;
+	delete m_pLCD;
+}
+
+bool CUserInterface::Initialize (void)
+{
+	assert (m_pConfig);
+
+	if (m_pConfig->GetLCDEnabled ())
+	{
+		m_pLCD = new CHD44780Device (CConfig::LCDColumns, CConfig::LCDRows,
+					     m_pConfig->GetLCDPinData4 (),
+					     m_pConfig->GetLCDPinData5 (),
+					     m_pConfig->GetLCDPinData6 (),
+					     m_pConfig->GetLCDPinData7 (),
+					     m_pConfig->GetLCDPinEnable (),
+					     m_pConfig->GetLCDPinRegisterSelect (),
+					     m_pConfig->GetLCDPinReadWrite ());
+		assert (m_pLCD);
+
+		if (!m_pLCD->Initialize ())
+		{
+			return false;
+		}
+
+		m_pLCDBuffered = new CWriteBufferDevice (m_pLCD);
+		assert (m_pLCDBuffered);
+
+		LCDWrite ("\x1B[?25l");		// cursor off
+
+		LOGDBG ("LCD initialized");
+	}
+
+	return true;
+}
+
+void CUserInterface::Process (void)
+{
+	if (m_pLCDBuffered)
+	{
+		m_pLCDBuffered->Update ();
+	}
+}
+
+void CUserInterface::ProgramChanged (unsigned nProgram)
+{
+	nProgram++;	// MIDI numbering starts with 0, user interface with 1
+
+	// fetch program name from Dexed instance
+	char ProgramName[11];
+	memset (ProgramName, 0, sizeof ProgramName);
+	assert (m_pMiniDexed);
+	m_pMiniDexed->setName (ProgramName);
+
+	printf ("Loading voice %u: \"%s\"\n", nProgram, ProgramName);
+
+	CString String;
+	String.Format ("\n\r%u\n\r%s", nProgram, ProgramName);
+	LCDWrite (String);
+}
+
+void CUserInterface::LCDWrite (const char *pString)
+{
+	if (m_pLCDBuffered)
+	{
+		m_pLCDBuffered->Write (pString, strlen (pString));
+	}
+}

--- a/src/userinterface.h
+++ b/src/userinterface.h
@@ -1,0 +1,52 @@
+//
+// userinterface.h
+//
+// MiniDexed - Dexed FM synthesizer for bare metal Raspberry Pi
+// Copyright (C) 2022  The MiniDexed Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef _userinterface_h
+#define _userinterface_h
+
+#include "config.h"
+#include <display/hd44780device.h>
+#include <circle/writebuffer.h>
+
+class CMiniDexed;
+
+class CUserInterface
+{
+public:
+	CUserInterface (CMiniDexed *pMiniDexed, CConfig *pConfig);
+	~CUserInterface (void);
+
+	bool Initialize (void);
+
+	void Process (void);
+
+	void ProgramChanged (unsigned nProgram);	// 0 .. 127
+
+private:
+	void LCDWrite (const char *pString);		// Print to optional HD44780 display
+
+private:
+	CMiniDexed *m_pMiniDexed;
+	CConfig *m_pConfig;
+
+	CHD44780Device *m_pLCD;
+	CWriteBufferDevice *m_pLCDBuffered;
+};
+
+#endif


### PR DESCRIPTION
This pull request provides the following changes:

* Support multiple USB MIDI inputs at once (two on Raspberry Pi 1-3, four on Raspberry Pi 4).

* Now all MIDI inputs (USB, serial, PC keyboard) can work simultaneous.

* Program change and bank select work with serial MIDI.

* The synth configuration is editable for the user now, without modifying the code. There can be a file minidexed.ini on the SD card, which contains the configuration values (see src/minidexed.ini for a template). The configuration of the sound device ("pwm", "i2s" or "hdmi") is done in minidexed.ini now. The option `sounddev=` in cmdline.txt does not have an effect any more.

* Support headless operation on Raspberry Pi 4.

* Suppress frequent messages in MIDI dump (timing clock, active sensing).

* Some Dexed methods require to be guarded from being interrupted by other Dexed calls. This is done in the class CDexedAdapter.

* LCD writes from an IRQ handler are allowed now. The LCD code has been moved to the class CUserInterface, which can be extended to provide an user interface.

* Fix: Performance timer did not show correct percent value with HDMI.

* Code restructured and headers added to all files. This is a suggestion only and can of course be modified.

There is a problem with the default GPIO pin configuration for the LCD. The I2S interface uses GPIO18-21, and GPIO18-19 is currently also used by the LCD. So I2S will only work, when the LCD is disabled in minidexed.ini.