### PR TITLE
Cleanup Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -4,34 +4,11 @@
 
 CIRCLE_STDLIB_DIR = ../circle-stdlib
 SYNTH_DEXED_DIR = ../Synth_Dexed/src
-CMSIS_CORE_INCLUDE_DIR = ../CMSIS_5/CMSIS/Core/Include
-CMSIS_DSP_INCLUDE_DIR = ../CMSIS_5/CMSIS/DSP/Include
-CMSIS_DSP_PRIVATE_INCLUDE_DIR = ../CMSIS_5/CMSIS/DSP/PrivateInclude
-CMSIS_DSP_SOURCE_DIR = ../CMSIS_5/CMSIS/DSP/Source
+CMSIS_DIR = ../CMSIS_5/CMSIS
 
 OBJS = main.o kernel.o minidexed.o config.o userinterface.o \
        mididevice.o midikeyboard.o serialmididevice.o pckeyboard.o \
-       sysexfileloader.o perftimer.o ky040.o \
-       $(SYNTH_DEXED_DIR)/PluginFx.o \
-       $(SYNTH_DEXED_DIR)/dexed.o \
-       $(SYNTH_DEXED_DIR)/dx7note.o \
-       $(SYNTH_DEXED_DIR)/env.o \
-       $(SYNTH_DEXED_DIR)/exp2.o \
-       $(SYNTH_DEXED_DIR)/fm_core.o \
-       $(SYNTH_DEXED_DIR)/fm_op_kernel.o \
-       $(SYNTH_DEXED_DIR)/freqlut.o \
-       $(SYNTH_DEXED_DIR)/lfo.o \
-       $(SYNTH_DEXED_DIR)/pitchenv.o \
-       $(SYNTH_DEXED_DIR)/porta.o \
-       $(SYNTH_DEXED_DIR)/sin.o \
-       $(CMSIS_DSP_SOURCE_DIR)/SupportFunctions/SupportFunctions.o
+       sysexfileloader.o perftimer.o ky040.o
 
-INCLUDE += -I $(SYNTH_DEXED_DIR)
-INCLUDE += -I $(CMSIS_CORE_INCLUDE_DIR)
-INCLUDE += -I $(CMSIS_DSP_INCLUDE_DIR)
-INCLUDE += -I $(CMSIS_DSP_PRIVATE_INCLUDE_DIR)
-CXXFLAGS += -DARM_MATH_NEON
-
-EXTRACLEAN = $(SYNTH_DEXED_DIR)/*.o $(SYNTH_DEXED_DIR)/*.d $(CMSIS_DSP_SOURCE_DIR)/SupportFunctions/*.o $(CMSIS_DSP_SOURCE_DIR)/SupportFunctions/*.d
-
+include ./Synth_Dexed.mk
 include ./Rules.mk

--- a/src/Synth_Dexed.mk
+++ b/src/Synth_Dexed.mk
@@ -1,0 +1,31 @@
+#
+# Synth_Dexed.mk
+#
+
+CMSIS_CORE_INCLUDE_DIR = $(CMSIS_DIR)/Core/Include
+CMSIS_DSP_INCLUDE_DIR = $(CMSIS_DIR)/DSP/Include
+CMSIS_DSP_PRIVATE_INCLUDE_DIR = $(CMSIS_DIR)/DSP/PrivateInclude
+CMSIS_DSP_SOURCE_DIR = $(CMSIS_DIR)/DSP/Source
+
+OBJS += \
+       $(SYNTH_DEXED_DIR)/PluginFx.o \
+       $(SYNTH_DEXED_DIR)/dexed.o \
+       $(SYNTH_DEXED_DIR)/dx7note.o \
+       $(SYNTH_DEXED_DIR)/env.o \
+       $(SYNTH_DEXED_DIR)/exp2.o \
+       $(SYNTH_DEXED_DIR)/fm_core.o \
+       $(SYNTH_DEXED_DIR)/fm_op_kernel.o \
+       $(SYNTH_DEXED_DIR)/freqlut.o \
+       $(SYNTH_DEXED_DIR)/lfo.o \
+       $(SYNTH_DEXED_DIR)/pitchenv.o \
+       $(SYNTH_DEXED_DIR)/porta.o \
+       $(SYNTH_DEXED_DIR)/sin.o \
+       $(CMSIS_DSP_SOURCE_DIR)/SupportFunctions/SupportFunctions.o
+
+INCLUDE += -I $(SYNTH_DEXED_DIR)
+INCLUDE += -I $(CMSIS_CORE_INCLUDE_DIR)
+INCLUDE += -I $(CMSIS_DSP_INCLUDE_DIR)
+INCLUDE += -I $(CMSIS_DSP_PRIVATE_INCLUDE_DIR)
+CXXFLAGS += -DARM_MATH_NEON
+
+EXTRACLEAN = $(SYNTH_DEXED_DIR)/*.[od] $(CMSIS_DSP_SOURCE_DIR)/SupportFunctions/*.[od]


### PR DESCRIPTION
This PR moves the definitions for building Synth_Dexed from the main *Makefile* into a separate file. These definitions are relatively extensive now and the *Makefile* is not easy to survey any more.

The better solution would be to put the file *Synth_Dexed.mk* into the Synth_Dexed submodule itself, because @dcoredump could handle modifications to Synth_Dexed build then locally in his project.