### PR TITLE
Support multiple Dexed instances

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -38,7 +38,11 @@ void CConfig::Load (void)
 	m_SoundDevice = m_Properties.GetString ("SoundDevice", "pwm");
 
 	m_nSampleRate = m_Properties.GetNumber ("SampleRate", 48000);
+#ifdef ARM_ALLOW_MULTI_CORE
 	m_nChunkSize = m_Properties.GetNumber ("ChunkSize", m_SoundDevice == "hdmi" ? 384*6 : 256);
+#else
+	m_nChunkSize = m_Properties.GetNumber ("ChunkSize", m_SoundDevice == "hdmi" ? 384*6 : 1024);
+#endif
 	m_nDACI2CAddress = m_Properties.GetNumber ("DACI2CAddress", 0);
 
 	m_nMIDIBaudRate = m_Properties.GetNumber ("MIDIBaudRate", 31250);

--- a/src/config.h
+++ b/src/config.h
@@ -30,7 +30,13 @@
 class CConfig		// Configuration for MiniDexed
 {
 public:
+#if RASPPI == 1
+	static const unsigned ToneGenerators = 1;
+	static const unsigned MaxNotes = 8;		// polyphony
+#else
+	static const unsigned ToneGenerators = 2;
 	static const unsigned MaxNotes = 16;		// polyphony
+#endif
 
 #if RASPPI <= 3
 	static const unsigned MaxUSBMIDIDevices = 2;

--- a/src/config.h
+++ b/src/config.h
@@ -25,18 +25,27 @@
 
 #include <fatfs/ff.h>
 #include <Properties/propertiesfatfsfile.h>
+#include <circle/sysconfig.h>
 #include <string>
 
 class CConfig		// Configuration for MiniDexed
 {
 public:
-#if RASPPI == 1
+#ifndef ARM_ALLOW_MULTI_CORE
 	static const unsigned ToneGenerators = 1;
+#else
+	static const unsigned TGsCore1 = 2;		// process 2 TGs on core 1
+	static const unsigned TGsCore23 = 3;		// process 3 TGs on core 2 and 3 each
+	static const unsigned ToneGenerators = TGsCore1 + 2*TGsCore23;
+#endif
+
+#if RASPPI == 1
 	static const unsigned MaxNotes = 8;		// polyphony
 #else
-	static const unsigned ToneGenerators = 2;
-	static const unsigned MaxNotes = 16;		// polyphony
+	static const unsigned MaxNotes = 16;
 #endif
+
+	static const unsigned MaxChunkSize = 4096;
 
 #if RASPPI <= 3
 	static const unsigned MaxUSBMIDIDevices = 2;

--- a/src/dexedadapter.h
+++ b/src/dexedadapter.h
@@ -70,6 +70,13 @@ public:
 		m_SpinLock.Release ();
 	}
 
+	void setSustain (bool sustain)
+	{
+		m_SpinLock.Acquire ();
+		Dexed::setSustain (sustain);
+		m_SpinLock.Release ();
+	}
+
 private:
 	CSpinLock m_SpinLock;
 };

--- a/src/mididevice.cpp
+++ b/src/mididevice.cpp
@@ -107,12 +107,18 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 		{
 			if (ucVelocity <= 127)
 			{
-				m_pSynthesizer->keydown (ucKeyNumber, ucVelocity);
+				for (unsigned nTG = 0; nTG < CConfig::ToneGenerators; nTG++)
+				{
+					m_pSynthesizer->keydown (ucKeyNumber, ucVelocity, nTG);
+				}
 			}
 		}
 		else
 		{
-			m_pSynthesizer->keyup (ucKeyNumber);
+			for (unsigned nTG = 0; nTG < CConfig::ToneGenerators; nTG++)
+			{
+				m_pSynthesizer->keyup (ucKeyNumber, nTG);
+			}
 		}
 		break;
 
@@ -122,7 +128,10 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 			break;
 		}
 
-		m_pSynthesizer->keyup (ucKeyNumber);
+		for (unsigned nTG = 0; nTG < CConfig::ToneGenerators; nTG++)
+		{
+			m_pSynthesizer->keyup (ucKeyNumber, nTG);
+		}
 		break;
 
 	case MIDI_CONTROL_CHANGE:
@@ -134,26 +143,41 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 		switch (pMessage[1])
 		{
 		case MIDI_CC_MODULATION:
-			m_pSynthesizer->setModWheel (pMessage[2]);
-			m_pSynthesizer->ControllersRefresh ();
+			for (unsigned nTG = 0; nTG < CConfig::ToneGenerators; nTG++)
+			{
+				m_pSynthesizer->setModWheel (pMessage[2], nTG);
+				m_pSynthesizer->ControllersRefresh (nTG);
+			}
 			break;
 
 		case MIDI_CC_VOLUME:
-			m_pSynthesizer->SetVolume (pMessage[2]);
+			for (unsigned nTG = 0; nTG < CConfig::ToneGenerators; nTG++)
+			{
+				m_pSynthesizer->SetVolume (pMessage[2], nTG);
+			}
 			break;
 
 		case MIDI_CC_BANK_SELECT_LSB:
-			m_pSynthesizer->BankSelectLSB (pMessage[2]);
+			for (unsigned nTG = 0; nTG < CConfig::ToneGenerators; nTG++)
+			{
+				m_pSynthesizer->BankSelectLSB (pMessage[2], nTG);
+			}
 			break;
 
 		case MIDI_CC_BANK_SUSTAIN:
-			m_pSynthesizer->setSustain (pMessage[2] >= 64);
+			for (unsigned nTG = 0; nTG < CConfig::ToneGenerators; nTG++)
+			{
+				m_pSynthesizer->setSustain (pMessage[2] >= 64, nTG);
+			}
 			break;
 		}
 		break;
 
 	case MIDI_PROGRAM_CHANGE:
-		m_pSynthesizer->ProgramChange (pMessage[1]);
+		for (unsigned nTG = 0; nTG < CConfig::ToneGenerators; nTG++)
+		{
+			m_pSynthesizer->ProgramChange (pMessage[1], nTG);
+		}
 		break;
 
 	case MIDI_PITCH_BEND: {
@@ -166,7 +190,10 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 		nValue |= (s16) pMessage[2] << 7;
 		nValue -= 0x2000;
 
-		m_pSynthesizer->setPitchbend (nValue);
+		for (unsigned nTG = 0; nTG < CConfig::ToneGenerators; nTG++)
+		{
+			m_pSynthesizer->setPitchbend (nValue, nTG);
+		}
 		} break;
 
 	default:

--- a/src/mididevice.cpp
+++ b/src/mididevice.cpp
@@ -45,11 +45,27 @@ CMIDIDevice::CMIDIDevice (CMiniDexed *pSynthesizer, CConfig *pConfig)
 :	m_pSynthesizer (pSynthesizer),
 	m_pConfig (pConfig)
 {
+	for (unsigned nTG = 0; nTG < CConfig::ToneGenerators; nTG++)
+	{
+		m_ChannelMap[nTG] = Disabled;
+	}
 }
 
 CMIDIDevice::~CMIDIDevice (void)
 {
 	m_pSynthesizer = 0;
+}
+
+void CMIDIDevice::SetChannel (u8 ucChannel, unsigned nTG)
+{
+	assert (nTG < CConfig::ToneGenerators);
+	m_ChannelMap[nTG] = ucChannel;
+}
+
+u8 CMIDIDevice::GetChannel (unsigned nTG) const
+{
+	assert (nTG < CConfig::ToneGenerators);
+	return m_ChannelMap[nTG];
 }
 
 void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsigned nCable)
@@ -67,17 +83,17 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 			if (   pMessage[0] != MIDI_TIMING_CLOCK
 			    && pMessage[0] != MIDI_ACTIVE_SENSING)
 			{
-				printf ("MIDI %u: %02X\n", nCable, (unsigned) pMessage[0]);
+				printf ("MIDI%u: %02X\n", nCable, (unsigned) pMessage[0]);
 			}
 			break;
 
 		case 2:
-			printf ("MIDI %u: %02X %02X\n", nCable,
+			printf ("MIDI%u: %02X %02X\n", nCable,
 				(unsigned) pMessage[0], (unsigned) pMessage[1]);
 			break;
 
 		case 3:
-			printf ("MIDI %u: %02X %02X %02X\n", nCable,
+			printf ("MIDI%u: %02X %02X %02X\n", nCable,
 				(unsigned) pMessage[0], (unsigned) pMessage[1],
 				(unsigned) pMessage[2]);
 			break;
@@ -89,114 +105,93 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 		return;
 	}
 
-	u8 ucStatus    = pMessage[0];
-	// TODO: u8 ucChannel   = ucStatus & 0x0F;
-	u8 ucType      = ucStatus >> 4;
-	u8 ucKeyNumber = pMessage[1];
-	u8 ucVelocity  = pMessage[2];
+	u8 ucStatus  = pMessage[0];
+	u8 ucChannel = ucStatus & 0x0F;
+	u8 ucType    = ucStatus >> 4;
 
-	switch (ucType)
+	for (unsigned nTG = 0; nTG < CConfig::ToneGenerators; nTG++)
 	{
-	case MIDI_NOTE_ON:
-		if (nLength < 3)
+		if (   m_ChannelMap[nTG] == ucChannel
+		    || m_ChannelMap[nTG] == OmniMode)
 		{
-			break;
-		}
-
-		if (ucVelocity > 0)
-		{
-			if (ucVelocity <= 127)
+			switch (ucType)
 			{
-				for (unsigned nTG = 0; nTG < CConfig::ToneGenerators; nTG++)
+			case MIDI_NOTE_ON:
+				if (nLength < 3)
 				{
-					m_pSynthesizer->keydown (ucKeyNumber, ucVelocity, nTG);
+					break;
 				}
+
+				if (pMessage[2] > 0)
+				{
+					if (pMessage[2] <= 127)
+					{
+						m_pSynthesizer->keydown (pMessage[1],
+									 pMessage[2], nTG);
+					}
+				}
+				else
+				{
+					m_pSynthesizer->keyup (pMessage[1], nTG);
+				}
+				break;
+
+			case MIDI_NOTE_OFF:
+				if (nLength < 3)
+				{
+					break;
+				}
+
+				m_pSynthesizer->keyup (pMessage[1], nTG);
+				break;
+
+			case MIDI_CONTROL_CHANGE:
+				if (nLength < 3)
+				{
+					break;
+				}
+
+				switch (pMessage[1])
+				{
+				case MIDI_CC_MODULATION:
+					m_pSynthesizer->setModWheel (pMessage[2], nTG);
+					m_pSynthesizer->ControllersRefresh (nTG);
+					break;
+
+				case MIDI_CC_VOLUME:
+					m_pSynthesizer->SetVolume (pMessage[2], nTG);
+					break;
+
+				case MIDI_CC_BANK_SELECT_LSB:
+					m_pSynthesizer->BankSelectLSB (pMessage[2], nTG);
+					break;
+
+				case MIDI_CC_BANK_SUSTAIN:
+					m_pSynthesizer->setSustain (pMessage[2] >= 64, nTG);
+					break;
+				}
+				break;
+
+			case MIDI_PROGRAM_CHANGE:
+				m_pSynthesizer->ProgramChange (pMessage[1], nTG);
+				break;
+
+			case MIDI_PITCH_BEND: {
+				if (nLength < 3)
+				{
+					break;
+				}
+
+				s16 nValue = pMessage[1];
+				nValue |= (s16) pMessage[2] << 7;
+				nValue -= 0x2000;
+
+				m_pSynthesizer->setPitchbend (nValue, nTG);
+				} break;
+
+			default:
+				break;
 			}
 		}
-		else
-		{
-			for (unsigned nTG = 0; nTG < CConfig::ToneGenerators; nTG++)
-			{
-				m_pSynthesizer->keyup (ucKeyNumber, nTG);
-			}
-		}
-		break;
-
-	case MIDI_NOTE_OFF:
-		if (nLength < 3)
-		{
-			break;
-		}
-
-		for (unsigned nTG = 0; nTG < CConfig::ToneGenerators; nTG++)
-		{
-			m_pSynthesizer->keyup (ucKeyNumber, nTG);
-		}
-		break;
-
-	case MIDI_CONTROL_CHANGE:
-		if (nLength < 3)
-		{
-			break;
-		}
-
-		switch (pMessage[1])
-		{
-		case MIDI_CC_MODULATION:
-			for (unsigned nTG = 0; nTG < CConfig::ToneGenerators; nTG++)
-			{
-				m_pSynthesizer->setModWheel (pMessage[2], nTG);
-				m_pSynthesizer->ControllersRefresh (nTG);
-			}
-			break;
-
-		case MIDI_CC_VOLUME:
-			for (unsigned nTG = 0; nTG < CConfig::ToneGenerators; nTG++)
-			{
-				m_pSynthesizer->SetVolume (pMessage[2], nTG);
-			}
-			break;
-
-		case MIDI_CC_BANK_SELECT_LSB:
-			for (unsigned nTG = 0; nTG < CConfig::ToneGenerators; nTG++)
-			{
-				m_pSynthesizer->BankSelectLSB (pMessage[2], nTG);
-			}
-			break;
-
-		case MIDI_CC_BANK_SUSTAIN:
-			for (unsigned nTG = 0; nTG < CConfig::ToneGenerators; nTG++)
-			{
-				m_pSynthesizer->setSustain (pMessage[2] >= 64, nTG);
-			}
-			break;
-		}
-		break;
-
-	case MIDI_PROGRAM_CHANGE:
-		for (unsigned nTG = 0; nTG < CConfig::ToneGenerators; nTG++)
-		{
-			m_pSynthesizer->ProgramChange (pMessage[1], nTG);
-		}
-		break;
-
-	case MIDI_PITCH_BEND: {
-		if (nLength < 3)
-		{
-			break;
-		}
-
-		s16 nValue = pMessage[1];
-		nValue |= (s16) pMessage[2] << 7;
-		nValue -= 0x2000;
-
-		for (unsigned nTG = 0; nTG < CConfig::ToneGenerators; nTG++)
-		{
-			m_pSynthesizer->setPitchbend (nValue, nTG);
-		}
-		} break;
-
-	default:
-		break;
 	}
 }

--- a/src/mididevice.h
+++ b/src/mididevice.h
@@ -31,8 +31,20 @@ class CMiniDexed;
 class CMIDIDevice
 {
 public:
+	enum TChannel
+	{
+		Channels = 16,
+		OmniMode = Channels,
+		Disabled,
+		ChannelUnknown
+	};
+
+public:
 	CMIDIDevice (CMiniDexed *pSynthesizer, CConfig *pConfig);
 	~CMIDIDevice (void);
+
+	void SetChannel (u8 ucChannel, unsigned nTG);
+	u8 GetChannel (unsigned nTG) const;
 
 protected:
 	void MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsigned nCable = 0);
@@ -40,6 +52,8 @@ protected:
 private:
 	CMiniDexed *m_pSynthesizer;
 	CConfig *m_pConfig;
+
+	u8 m_ChannelMap[CConfig::ToneGenerators];
 };
 
 #endif

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -128,6 +128,8 @@ bool CMiniDexed::Initialize (void)
 		m_pTG[i]->setMWController (99, 7, 0);
 	}
 
+	SetMIDIChannel (CMIDIDevice::OmniMode, 0);
+
 	// setup and start the sound device
 	if (!m_pSoundDevice->AllocateQueueFrames (m_pConfig->GetChunkSize ()))
 	{
@@ -287,6 +289,26 @@ void CMiniDexed::SetVolume (unsigned nVolume, unsigned nTG)
 	m_pTG[nTG]->setGain (nVolume / 127.0);
 
 	m_UI.VolumeChanged (nVolume, nTG);
+}
+
+void CMiniDexed::SetMIDIChannel (uint8_t uchChannel, unsigned nTG)
+{
+	assert (nTG < CConfig::ToneGenerators);
+
+	for (unsigned i = 0; i < CConfig::MaxUSBMIDIDevices; i++)
+	{
+		assert (m_pMIDIKeyboard[i]);
+		m_pMIDIKeyboard[i]->SetChannel (uchChannel, nTG);
+	}
+
+	m_PCKeyboard.SetChannel (uchChannel, nTG);
+
+	if (m_bUseSerial)
+	{
+		m_SerialMIDI.SetChannel (uchChannel, nTG);
+	}
+
+	m_UI.MIDIChannelChanged (uchChannel, nTG);
 }
 
 void CMiniDexed::keyup (int16_t pitch, unsigned nTG)

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -115,12 +115,12 @@ bool CMiniDexed::Initialize (void)
 		m_bUseSerial = true;
 	}
 
-	SetVolume (100);
-	ProgramChange (0);
-
 	for (unsigned i = 0; i < CConfig::ToneGenerators; i++)
 	{
 		assert (m_pTG[i]);
+
+		SetVolume (100, i);
+		ProgramChange (0, i);
 
 		m_pTG[i]->setTranspose (24);
 
@@ -245,114 +245,98 @@ CSysExFileLoader *CMiniDexed::GetSysExFileLoader (void)
 	return &m_SysExFileLoader;
 }
 
-void CMiniDexed::BankSelectLSB (unsigned nBankLSB)
+void CMiniDexed::BankSelectLSB (unsigned nBankLSB, unsigned nTG)
 {
 	if (nBankLSB > 127)
 	{
 		return;
 	}
 
-	for (unsigned i = 0; i < CConfig::ToneGenerators; i++)
-	{
-		m_nVoiceBankID[i] = nBankLSB;
-	}
+	assert (nTG < CConfig::ToneGenerators);
+	m_nVoiceBankID[nTG] = nBankLSB;
 
-	m_UI.BankSelected (nBankLSB);
+	m_UI.BankSelected (nBankLSB, nTG);
 }
 
-void CMiniDexed::ProgramChange (unsigned nProgram)
+void CMiniDexed::ProgramChange (unsigned nProgram, unsigned nTG)
 {
 	if (nProgram > 31)
 	{
 		return;
 	}
 
-	for (unsigned i = 0; i < CConfig::ToneGenerators; i++)
-	{
-		uint8_t Buffer[156];
-		m_SysExFileLoader.GetVoice (m_nVoiceBankID[i], nProgram, Buffer);
+	assert (nTG < CConfig::ToneGenerators);
+	uint8_t Buffer[156];
+	m_SysExFileLoader.GetVoice (m_nVoiceBankID[nTG], nProgram, Buffer);
 
-		assert (m_pTG[i]);
-		m_pTG[i]->loadVoiceParameters (Buffer);
-	}
+	assert (m_pTG[nTG]);
+	m_pTG[nTG]->loadVoiceParameters (Buffer);
 
-	m_UI.ProgramChanged (nProgram);
+	m_UI.ProgramChanged (nProgram, nTG);
 }
 
-void CMiniDexed::SetVolume (unsigned nVolume)
+void CMiniDexed::SetVolume (unsigned nVolume, unsigned nTG)
 {
 	if (nVolume > 127)
 	{
 		return;
 	}
 
-	for (unsigned i = 0; i < CConfig::ToneGenerators; i++)
-	{
-		assert (m_pTG[i]);
-		m_pTG[i]->setGain (nVolume / 127.0);
-	}
+	assert (nTG < CConfig::ToneGenerators);
+	assert (m_pTG[nTG]);
+	m_pTG[nTG]->setGain (nVolume / 127.0);
 
-	m_UI.VolumeChanged (nVolume);
+	m_UI.VolumeChanged (nVolume, nTG);
 }
 
-void CMiniDexed::keyup (int16_t pitch)
+void CMiniDexed::keyup (int16_t pitch, unsigned nTG)
 {
-	for (unsigned i = 0; i < CConfig::ToneGenerators; i++)
-	{
-		assert (m_pTG[i]);
-		m_pTG[i]->keyup (pitch);
-	}
+	assert (nTG < CConfig::ToneGenerators);
+	assert (m_pTG[nTG]);
+	m_pTG[nTG]->keyup (pitch);
 }
 
-void CMiniDexed::keydown (int16_t pitch, uint8_t velocity)
+void CMiniDexed::keydown (int16_t pitch, uint8_t velocity, unsigned nTG)
 {
-	for (unsigned i = 0; i < CConfig::ToneGenerators; i++)
-	{
-		assert (m_pTG[i]);
-		m_pTG[i]->keydown (pitch, velocity);
-	}
+	assert (nTG < CConfig::ToneGenerators);
+	assert (m_pTG[nTG]);
+	m_pTG[nTG]->keydown (pitch, velocity);
 }
 
-void CMiniDexed::setSustain(bool sustain)
+void CMiniDexed::setSustain(bool sustain, unsigned nTG)
 {
-	for (unsigned i = 0; i < CConfig::ToneGenerators; i++)
-	{
-		assert (m_pTG[i]);
-		m_pTG[i]->setSustain (sustain);
-	}
+	assert (nTG < CConfig::ToneGenerators);
+	assert (m_pTG[nTG]);
+	m_pTG[nTG]->setSustain (sustain);
 }
 
-void CMiniDexed::setModWheel (uint8_t value)
+void CMiniDexed::setModWheel (uint8_t value, unsigned nTG)
 {
-	for (unsigned i = 0; i < CConfig::ToneGenerators; i++)
-	{
-		assert (m_pTG[i]);
-		m_pTG[i]->setModWheel (value);
-	}
+	assert (nTG < CConfig::ToneGenerators);
+	assert (m_pTG[nTG]);
+	m_pTG[nTG]->setModWheel (value);
 }
 
-void CMiniDexed::setPitchbend (int16_t value)
+void CMiniDexed::setPitchbend (int16_t value, unsigned nTG)
 {
-	for (unsigned i = 0; i < CConfig::ToneGenerators; i++)
-	{
-		assert (m_pTG[i]);
-		m_pTG[i]->setPitchbend (value);
-	}
+	assert (nTG < CConfig::ToneGenerators);
+	assert (m_pTG[nTG]);
+	m_pTG[nTG]->setPitchbend (value);
 }
 
-void CMiniDexed::ControllersRefresh (void)
+void CMiniDexed::ControllersRefresh (unsigned nTG)
 {
-	for (unsigned i = 0; i < CConfig::ToneGenerators; i++)
-	{
-		assert (m_pTG[i]);
-		m_pTG[i]->ControllersRefresh ();
-	}
+	assert (nTG < CConfig::ToneGenerators);
+	assert (m_pTG[nTG]);
+	m_pTG[nTG]->ControllersRefresh ();
 }
 
 std::string CMiniDexed::GetVoiceName (unsigned nTG)
 {
 	char VoiceName[11];
 	memset (VoiceName, 0, sizeof VoiceName);
+
+	assert (nTG < CConfig::ToneGenerators);
 	assert (m_pTG[nTG]);
 	m_pTG[nTG]->setName (VoiceName);
 

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -37,7 +37,7 @@ CMiniDexed::CMiniDexed (CConfig *pConfig, CInterruptSystem *pInterrupt,
 #endif
 	m_pConfig (pConfig),
 	m_UI (this, pGPIOManager, pConfig),
-	m_PCKeyboard (this),
+	m_PCKeyboard (this, pConfig),
 	m_SerialMIDI (this, pInterrupt, pConfig),
 	m_bUseSerial (false),
 	m_pSoundDevice (0),

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -49,6 +49,8 @@ CMiniDexed::CMiniDexed (CConfig *pConfig, CInterruptSystem *pInterrupt,
 
 	for (unsigned i = 0; i < CConfig::ToneGenerators; i++)
 	{
+		m_nVoiceBankID[i] = 0;
+
 		m_pTG[i] = new CDexedAdapter (CConfig::MaxNotes, pConfig->GetSampleRate ());
 		assert (m_pTG[i]);
 
@@ -250,7 +252,10 @@ void CMiniDexed::BankSelectLSB (unsigned nBankLSB)
 		return;
 	}
 
-	m_SysExFileLoader.SelectVoiceBank (nBankLSB);
+	for (unsigned i = 0; i < CConfig::ToneGenerators; i++)
+	{
+		m_nVoiceBankID[i] = nBankLSB;
+	}
 
 	m_UI.BankSelected (nBankLSB);
 }
@@ -262,10 +267,11 @@ void CMiniDexed::ProgramChange (unsigned nProgram)
 		return;
 	}
 
-	uint8_t Buffer[156];
-	m_SysExFileLoader.GetVoice (nProgram, Buffer);
 	for (unsigned i = 0; i < CConfig::ToneGenerators; i++)
 	{
+		uint8_t Buffer[156];
+		m_SysExFileLoader.GetVoice (m_nVoiceBankID[i], nProgram, Buffer);
+
 		assert (m_pTG[i]);
 		m_pTG[i]->loadVoiceParameters (Buffer);
 	}

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -88,6 +88,7 @@ private:
 	CConfig *m_pConfig;
 
 	CDexedAdapter *m_pTG[CConfig::ToneGenerators];
+	unsigned m_nVoiceBankID[CConfig::ToneGenerators];
 
 	CUserInterface m_UI;
 	CSysExFileLoader m_SysExFileLoader;

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -29,6 +29,7 @@
 #include "serialmididevice.h"
 #include "perftimer.h"
 #include <stdint.h>
+#include <string>
 #include <circle/types.h>
 #include <circle/interrupt.h>
 #include <circle/gpiomanager.h>
@@ -36,9 +37,9 @@
 #include <circle/multicore.h>
 #include <circle/soundbasedevice.h>
 
-class CMiniDexed : public CDexedAdapter
+class CMiniDexed
 #ifdef ARM_ALLOW_MULTI_CORE
-	, public CMultiCoreSupport
+:	public CMultiCoreSupport
 #endif
 {
 public:
@@ -59,11 +60,23 @@ public:
 	void ProgramChange (unsigned nProgram);
 	void SetVolume (unsigned nVolume);
 
+	void keyup (int16_t pitch);
+	void keydown (int16_t pitch, uint8_t velocity);
+
+	void setSustain (bool sustain);
+	void setModWheel (uint8_t value);
+	void setPitchbend (int16_t value);
+	void ControllersRefresh (void);
+
+	std::string GetVoiceName (unsigned nTG = 0);
+
 private:
 	void ProcessSound (void);
 
 private:
 	CConfig *m_pConfig;
+
+	CDexedAdapter *m_pTG[CConfig::ToneGenerators];
 
 	CUserInterface m_UI;
 	CSysExFileLoader m_SysExFileLoader;

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -59,6 +59,7 @@ public:
 	void BankSelectLSB (unsigned nBankLSB, unsigned nTG);
 	void ProgramChange (unsigned nProgram, unsigned nTG);
 	void SetVolume (unsigned nVolume, unsigned nTG);
+	void SetMIDIChannel (uint8_t uchChannel, unsigned nTG);
 
 	void keyup (int16_t pitch, unsigned nTG);
 	void keydown (int16_t pitch, uint8_t velocity, unsigned nTG);

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -73,6 +73,17 @@ public:
 private:
 	void ProcessSound (void);
 
+#ifdef ARM_ALLOW_MULTI_CORE
+	enum TCoreStatus
+	{
+		CoreStatusInit,
+		CoreStatusIdle,
+		CoreStatusBusy,
+		CoreStatusExit,
+		CoreStatusUnknown
+	};
+#endif
+
 private:
 	CConfig *m_pConfig;
 
@@ -88,6 +99,12 @@ private:
 
 	CSoundBaseDevice *m_pSoundDevice;
 	unsigned m_nQueueSizeFrames;
+
+#ifdef ARM_ALLOW_MULTI_CORE
+	volatile TCoreStatus m_CoreStatus[CORES];
+	volatile unsigned m_nFramesToProcess;
+	int16_t m_OutputLevel[CConfig::ToneGenerators][CConfig::MaxChunkSize];
+#endif
 
 	CPerformanceTimer m_GetChunkTimer;
 	bool m_bProfileEnabled;

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -56,19 +56,19 @@ public:
 
 	CSysExFileLoader *GetSysExFileLoader (void);
 
-	void BankSelectLSB (unsigned nBankLSB);
-	void ProgramChange (unsigned nProgram);
-	void SetVolume (unsigned nVolume);
+	void BankSelectLSB (unsigned nBankLSB, unsigned nTG);
+	void ProgramChange (unsigned nProgram, unsigned nTG);
+	void SetVolume (unsigned nVolume, unsigned nTG);
 
-	void keyup (int16_t pitch);
-	void keydown (int16_t pitch, uint8_t velocity);
+	void keyup (int16_t pitch, unsigned nTG);
+	void keydown (int16_t pitch, uint8_t velocity, unsigned nTG);
 
-	void setSustain (bool sustain);
-	void setModWheel (uint8_t value);
-	void setPitchbend (int16_t value);
-	void ControllersRefresh (void);
+	void setSustain (bool sustain, unsigned nTG);
+	void setModWheel (uint8_t value, unsigned nTG);
+	void setPitchbend (int16_t value, unsigned nTG);
+	void ControllersRefresh (unsigned nTG);
 
-	std::string GetVoiceName (unsigned nTG = 0);
+	std::string GetVoiceName (unsigned nTG);
 
 private:
 	void ProcessSound (void);

--- a/src/pckeyboard.cpp
+++ b/src/pckeyboard.cpp
@@ -19,6 +19,7 @@
 //
 #include "pckeyboard.h"
 #include "minidexed.h"
+#include "config.h"
 #include <circle/devicenameservice.h>
 #include <circle/util.h>
 #include <assert.h>
@@ -112,7 +113,10 @@ void CPCKeyboard::KeyStatusHandlerRaw (unsigned char ucModifiers, const unsigned
 			u8 ucKeyNumber = GetKeyNumber (ucKeyCode);
 			if (ucKeyNumber != 0)
 			{
-				s_pThis->m_pSynthesizer->keyup (ucKeyNumber);
+				for (unsigned nTG = 0; nTG < CConfig::ToneGenerators; nTG++)
+				{
+					s_pThis->m_pSynthesizer->keyup (ucKeyNumber, nTG);
+				}
 			}
 		}
 	}
@@ -127,7 +131,10 @@ void CPCKeyboard::KeyStatusHandlerRaw (unsigned char ucModifiers, const unsigned
 			u8 ucKeyNumber = GetKeyNumber (ucKeyCode);
 			if (ucKeyNumber != 0)
 			{
-				s_pThis->m_pSynthesizer->keydown (ucKeyNumber, 100);
+				for (unsigned nTG = 0; nTG < CConfig::ToneGenerators; nTG++)
+				{
+					s_pThis->m_pSynthesizer->keydown (ucKeyNumber, 100, nTG);
+				}
 			}
 		}
 	}

--- a/src/pckeyboard.h
+++ b/src/pckeyboard.h
@@ -20,16 +20,18 @@
 #ifndef _pckeyboard_h
 #define _pckeyboard_h
 
+#include "mididevice.h"
+#include "config.h"
 #include <circle/usb/usbkeyboard.h>
 #include <circle/device.h>
 #include <circle/types.h>
 
 class CMiniDexed;
 
-class CPCKeyboard
+class CPCKeyboard : public CMIDIDevice
 {
 public:
-	CPCKeyboard (CMiniDexed *pSynthesizer);
+	CPCKeyboard (CMiniDexed *pSynthesizer, CConfig *pConfig);
 	~CPCKeyboard (void);
 
 	void Process (boolean bPlugAndPlayUpdated);
@@ -44,8 +46,6 @@ private:
 	static void DeviceRemovedHandler (CDevice *pDevice, void *pContext);
 
 private:
-	CMiniDexed *m_pSynthesizer;
-
 	CUSBKeyboardDevice * volatile m_pKeyboard;
 
 	u8 m_LastKeys[6];

--- a/src/sysexfileloader.cpp
+++ b/src/sysexfileloader.cpp
@@ -45,8 +45,7 @@ uint8_t CSysExFileLoader::s_DefaultVoice[SizeSingleVoice] =	// FM-Piano
 };
 
 CSysExFileLoader::CSysExFileLoader (const char *pDirName)
-:	m_DirName (pDirName),
-	m_nBankID (0)
+:	m_DirName (pDirName)
 {
 	m_DirName += "/voice";
 
@@ -168,22 +167,14 @@ std::string CSysExFileLoader::GetBankName (unsigned nBankID)
 	return "NO NAME";
 }
 
-void CSysExFileLoader::SelectVoiceBank (unsigned nBankID)
+void CSysExFileLoader::GetVoice (unsigned nBankID, unsigned nVoiceID, uint8_t *pVoiceData)
 {
-	if (nBankID <= MaxVoiceBankID)
+	if (   nBankID <= MaxVoiceBankID
+	    && nVoiceID <= VoicesPerBank)
 	{
-		m_nBankID = nBankID;
-	}
-}
-
-void CSysExFileLoader::GetVoice (unsigned nVoiceID, uint8_t *pVoiceData)
-{
-	if (nVoiceID <= VoicesPerBank)
-	{
-		assert (m_nBankID <= MaxVoiceBankID);
-		if (m_pVoiceBank[m_nBankID])
+		if (m_pVoiceBank[nBankID])
 		{
-			DecodePackedVoice (m_pVoiceBank[m_nBankID]->Voice[nVoiceID], pVoiceData);
+			DecodePackedVoice (m_pVoiceBank[nBankID]->Voice[nVoiceID], pVoiceData);
 
 			return;
 		}
@@ -191,7 +182,7 @@ void CSysExFileLoader::GetVoice (unsigned nVoiceID, uint8_t *pVoiceData)
 		{
 			// Use default voices_bank instead of s_DefaultVoice for bank 0,
 			// if the bank was not successfully loaded from disk.
-			if (m_nBankID == 0)
+			if (nBankID == 0)
 			{
 				memcpy (pVoiceData, voices_bank[0][nVoiceID], SizeSingleVoice);
 

--- a/src/sysexfileloader.h
+++ b/src/sysexfileloader.h
@@ -58,9 +58,8 @@ public:
 
 	std::string GetBankName (unsigned nBankID);	// 0 .. 127
 
-	void SelectVoiceBank (unsigned nBankID);	// 0 .. 127
-
-	void GetVoice (unsigned nVoiceID,		// 0 .. 31
+	void GetVoice (unsigned nBankID,		// 0 .. 127
+		       unsigned nVoiceID,		// 0 .. 31
 		       uint8_t *pVoiceData);		// returns unpacked format (156 bytes)
 
 private:
@@ -71,8 +70,6 @@ private:
 
 	TVoiceBank *m_pVoiceBank[MaxVoiceBankID+1];
 	std::string m_BankFileName[MaxVoiceBankID+1];
-
-	unsigned m_nBankID;
 
 	static uint8_t s_DefaultVoice[SizeSingleVoice];
 };

--- a/src/userinterface.cpp
+++ b/src/userinterface.cpp
@@ -135,20 +135,17 @@ void CUserInterface::ProgramChanged (unsigned nProgram)
 
 	nProgram++;	// MIDI numbering starts with 0, user interface with 1
 
-	// fetch program name from Dexed instance
-	char ProgramName[11];
-	memset (ProgramName, 0, sizeof ProgramName);
 	assert (m_pMiniDexed);
-	m_pMiniDexed->setName (ProgramName);
+	std::string VoiceName = m_pMiniDexed->GetVoiceName ();
 
-	printf ("Loading voice %u: \"%s\"\n", nProgram, ProgramName);
+	printf ("Loading voice %u: \"%s\"\n", nProgram, VoiceName.c_str ());
 
 	if (m_UIMode == UIModeVoiceSelect)
 	{
 		CString String;
 		String.Format ("%u", nProgram);
 
-		DisplayWrite (String, "VOICE", ProgramName);
+		DisplayWrite (String, "VOICE", VoiceName.c_str ());
 	}
 }
 

--- a/src/userinterface.cpp
+++ b/src/userinterface.cpp
@@ -122,7 +122,7 @@ void CUserInterface::BankSelected (unsigned nBankLSB, unsigned  nTG)
 	std::string BankName = m_pMiniDexed->GetSysExFileLoader ()->GetBankName (nBankLSB);
 
 	// MIDI numbering starts with 0, user interface with 1
-	printf ("Select voice bank %u: \"%s\"\n", nBankLSB+1, BankName.c_str ());
+	printf ("TG%u: Select voice bank %u: \"%s\"\n", nTG+1, nBankLSB+1, BankName.c_str ());
 
 	if (   m_UIMode == UIModeBankSelect
 	    && m_nTG == nTG)
@@ -148,7 +148,7 @@ void CUserInterface::ProgramChanged (unsigned nProgram, unsigned  nTG)
 	assert (m_pMiniDexed);
 	std::string VoiceName = m_pMiniDexed->GetVoiceName (nTG);
 
-	printf ("Loading voice %u: \"%s\"\n", nProgram, VoiceName.c_str ());
+	printf ("TG%u: Loading voice %u: \"%s\"\n", nTG+1, nProgram, VoiceName.c_str ());
 
 	if (   m_UIMode == UIModeVoiceSelect
 	    && m_nTG == nTG)

--- a/src/userinterface.h
+++ b/src/userinterface.h
@@ -25,6 +25,7 @@
 #include <display/hd44780device.h>
 #include <circle/gpiomanager.h>
 #include <circle/writebuffer.h>
+#include <stdint.h>
 
 class CMiniDexed;
 
@@ -41,6 +42,7 @@ public:
 	void BankSelected (unsigned nBankLSB, unsigned  nTG);		// 0 .. 127
 	void ProgramChanged (unsigned nProgram, unsigned  nTG);		// 0 .. 127
 	void VolumeChanged (unsigned nVolume, unsigned  nTG);		// 0 .. 127
+	void MIDIChannelChanged (uint8_t uchChannel, unsigned  nTG);
 
 private:
 	// Print to display in this format:
@@ -63,6 +65,7 @@ private:
 		UIModeVoiceSelect = UIModeStart,
 		UIModeBankSelect,
 		UIModeVolume,
+		UIModeMIDI,
 		UIModeUnknown
 	};
 
@@ -82,6 +85,7 @@ private:
 	unsigned m_nBank[CConfig::ToneGenerators];
 	unsigned m_nProgram[CConfig::ToneGenerators];
 	unsigned m_nVolume[CConfig::ToneGenerators];
+	uint8_t m_uchMIDIChannel[CConfig::ToneGenerators];
 };
 
 #endif

--- a/src/userinterface.h
+++ b/src/userinterface.h
@@ -38,9 +38,9 @@ public:
 
 	void Process (void);
 
-	void BankSelected (unsigned nBankLSB);		// 0 .. 127
-	void ProgramChanged (unsigned nProgram);	// 0 .. 127
-	void VolumeChanged (unsigned nVolume);		// 0 .. 127
+	void BankSelected (unsigned nBankLSB, unsigned  nTG);		// 0 .. 127
+	void ProgramChanged (unsigned nProgram, unsigned  nTG);		// 0 .. 127
+	void VolumeChanged (unsigned nVolume, unsigned  nTG);		// 0 .. 127
 
 private:
 	// Print to display in this format:
@@ -78,9 +78,10 @@ private:
 
 	TUIMode m_UIMode;
 
-	unsigned m_nBank;
-	unsigned m_nProgram;
-	unsigned m_nVolume;
+	unsigned m_nTG;
+	unsigned m_nBank[CConfig::ToneGenerators];
+	unsigned m_nProgram[CConfig::ToneGenerators];
+	unsigned m_nVolume[CConfig::ToneGenerators];
 };
 
 #endif


### PR DESCRIPTION
This PR adds support for multiple Dexed instances (Tone Generators, TG). It's not possible to load the performance configuration from a file at the moment. I will add this soon.

Currently voice bank, voice number, volume and assigned MIDI channel (1-16, OMNI mode or OFF) can be selected from the UI for each TG. The TGs can be switched by double clicking the switch. When you hold the switch for one second, you will go back to the home position (TG1, VOICE) in the menu. By default TG1 is in OMNI mode, all other TGs are not assigned to a MIDI channel. The PC keyboard fakes MIDI events on channel 1.

The mixer is not perfect yet. That's why the volume is reduced, when only a few TGs are active. I had to reduce the `MaxNotes` value for Raspberry Pi 1 (8 now) and increased the chunk size default for RPi 1 to 1024. Otherwise there are audio drops. The chunk size is limited to a value of 4096 now.

I tested this on RPi 3B (with 32 and 64-bit and UI) and RPi 1 (without UI) only. It is noticeable, that the CPU load could rise to a critical level with eight active TGs. CPU core 1 handles two TGs, core 2 and 3 handle three TGs each. Core 0 is free to handle all other stuff (MIDI, sound driver, UI). `fast=true` in *cmdline.txt* may be required, at least on the RPi 2.

Let me know, when you need modifications.