### PR TITLE
Fix Stereo channel swap with HDMI

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -44,6 +44,7 @@ void CConfig::Load (void)
 	m_nChunkSize = m_Properties.GetNumber ("ChunkSize", m_SoundDevice == "hdmi" ? 384*6 : 1024);
 #endif
 	m_nDACI2CAddress = m_Properties.GetNumber ("DACI2CAddress", 0);
+	m_bChannelsSwapped = m_Properties.GetNumber ("ChannelsSwapped", 0) != 0;
 
 	m_nMIDIBaudRate = m_Properties.GetNumber ("MIDIBaudRate", 31250);
 
@@ -83,6 +84,11 @@ unsigned CConfig::GetChunkSize (void) const
 unsigned CConfig::GetDACI2CAddress (void) const
 {
 	return m_nDACI2CAddress;
+}
+
+bool CConfig::GetChannelsSwapped (void) const
+{
+	return m_bChannelsSwapped;
 }
 
 unsigned CConfig::GetMIDIBaudRate (void) const

--- a/src/config.h
+++ b/src/config.h
@@ -67,6 +67,7 @@ public:
 	unsigned GetSampleRate (void) const;
 	unsigned GetChunkSize (void) const;
 	unsigned GetDACI2CAddress (void) const;		// 0 for auto probing
+	bool GetChannelsSwapped (void) const;
 
 	// MIDI
 	unsigned GetMIDIBaudRate (void) const;
@@ -100,6 +101,7 @@ private:
 	unsigned m_nSampleRate;
 	unsigned m_nChunkSize;
 	unsigned m_nDACI2CAddress;
+	bool m_bChannelsSwapped;
 
 	unsigned m_nMIDIBaudRate;
 

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -103,6 +103,7 @@ private:
 	bool m_bUseSerial;
 
 	CSoundBaseDevice *m_pSoundDevice;
+	bool m_bChannelsSwapped;
 	unsigned m_nQueueSizeFrames;
 
 #ifdef ARM_ALLOW_MULTI_CORE

--- a/src/minidexed.ini
+++ b/src/minidexed.ini
@@ -7,6 +7,7 @@ SoundDevice=pwm
 SampleRate=48000
 #ChunkSize=256
 DACI2CAddress=0
+ChannelsSwapped=0
 
 # MIDI
 MIDIBaudRate=31250


### PR DESCRIPTION
There has been a swap of the Stereo channels with HDMI. With the new
option "ChannelsSwapped=0|1" in minidexed.ini one can swap the channels
again, in case it is needed.