### PR TITLE
uimenu: Fix: Edit OP parameter from selected TG

### DIFF
--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -564,7 +564,7 @@ void CUIMenu::EditVoiceParameter (CUIMenu *pUIMenu, TMenuEvent Event)
 
 void CUIMenu::EditOPParameter (CUIMenu *pUIMenu, TMenuEvent Event)
 {
-	unsigned nTG = pUIMenu->m_nMenuStackParameter[pUIMenu->m_nCurrentMenuDepth-2];
+	unsigned nTG = pUIMenu->m_nMenuStackParameter[pUIMenu->m_nCurrentMenuDepth-3];
 	unsigned nOP = pUIMenu->m_nMenuStackParameter[pUIMenu->m_nCurrentMenuDepth-1];
 
 	unsigned nParam = pUIMenu->m_nCurrentParameter;


### PR DESCRIPTION
When editing an OP parameter, the selected TG was not used,
but always TG1 instead.