### PR TITLE
Improve compressor and reverb effects

### DIFF
--- a/src/dexedadapter.h
+++ b/src/dexedadapter.h
@@ -33,11 +33,6 @@ public:
 	CDexedAdapter (uint8_t maxnotes, int rate)
 	: Dexed (maxnotes, rate)
 	{
-		Dexed::setCompressor(true);
-		if(Dexed::getCompressor()==true)
-			printf("Dexed-Compressor: enabled\n");
-		else
-			printf("Dexed-Compressor: disabled\n");
 	}
 
 	void loadVoiceParameters (uint8_t* data)

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -77,6 +77,8 @@ public:
 
 	enum TParameter
 	{
+		ParameterCompressorEnable,
+		ParameterReverbEnable,
 		ParameterReverbSize,
 		ParameterReverbHighDamp,
 		ParameterReverbLowDamp,

--- a/src/performance.ini
+++ b/src/performance.ini
@@ -100,3 +100,23 @@ Detune8=0
 NoteLimitLow8=0
 NoteLimitHigh8=127
 NoteShift8=0
+
+# Effects
+#CompressorEnable=1	# 0: off, 1: on
+#ReverbEnable=1		# 0: off, 1: on
+#ReverbSize=70		# 0 .. 99
+#ReverbHighDamp=50	# 0 .. 99
+#ReverbLowDamp=50	# 0 .. 99
+#ReverbLowPass=30	# 0 .. 99
+#ReverbDiffusion=65	# 0 .. 99
+#ReverbSend=80		# 0 .. 99
+
+# Effects
+CompressorEnable=1
+ReverbEnable=1
+ReverbSize=70
+ReverbHighDamp=50
+ReverbLowDamp=50
+ReverbLowPass=30
+ReverbDiffusion=65
+ReverbSend=80

--- a/src/performanceconfig.cpp
+++ b/src/performanceconfig.cpp
@@ -91,6 +91,16 @@ bool CPerformanceConfig::Load (void)
 		m_nNoteShift[nTG] = m_Properties.GetSignedNumber (PropertyName, 0);
 	}
 
+	m_bCompressorEnable = m_Properties.GetNumber ("CompressorEnable", 1) != 0;
+
+	m_bReverbEnable = m_Properties.GetNumber ("ReverbEnable", 1) != 0;
+	m_nReverbSize = m_Properties.GetNumber ("ReverbSize", 70);
+	m_nReverbHighDamp = m_Properties.GetNumber ("ReverbHighDamp", 50);
+	m_nReverbLowDamp = m_Properties.GetNumber ("ReverbLowDamp", 50);
+	m_nReverbLowPass = m_Properties.GetNumber ("ReverbLowPass", 30);
+	m_nReverbDiffusion = m_Properties.GetNumber ("ReverbDiffusion", 65);
+	m_nReverbSend = m_Properties.GetNumber ("ReverbSend", 80);
+
 	return bResult;
 }
 
@@ -146,4 +156,44 @@ int CPerformanceConfig::GetNoteShift (unsigned nTG) const
 {
 	assert (nTG < CConfig::ToneGenerators);
 	return m_nNoteShift[nTG];
+}
+
+bool CPerformanceConfig::GetCompressorEnable (void) const
+{
+	return m_bCompressorEnable;
+}
+
+bool CPerformanceConfig::GetReverbEnable (void) const
+{
+	return m_bReverbEnable;
+}
+
+unsigned CPerformanceConfig::GetReverbSize (void) const
+{
+	return m_nReverbSize;
+}
+
+unsigned CPerformanceConfig::GetReverbHighDamp (void) const
+{
+	return m_nReverbHighDamp;
+}
+
+unsigned CPerformanceConfig::GetReverbLowDamp (void) const
+{
+	return m_nReverbLowDamp;
+}
+
+unsigned CPerformanceConfig::GetReverbLowPass (void) const
+{
+	return m_nReverbLowPass;
+}
+
+unsigned CPerformanceConfig::GetReverbDiffusion (void) const
+{
+	return m_nReverbDiffusion;
+}
+
+unsigned CPerformanceConfig::GetReverbSend (void) const
+{
+	return m_nReverbSend;
 }

--- a/src/performanceconfig.h
+++ b/src/performanceconfig.h
@@ -46,6 +46,16 @@ public:
 	unsigned GetNoteLimitHigh (unsigned nTG) const;		// 0 .. 127
 	int GetNoteShift (unsigned nTG) const;			// -24 .. 24
 
+	// Effects
+	bool GetCompressorEnable (void) const;
+	bool GetReverbEnable (void) const;
+	unsigned GetReverbSize (void) const;			// 0 .. 99
+	unsigned GetReverbHighDamp (void) const;		// 0 .. 99
+	unsigned GetReverbLowDamp (void) const;			// 0 .. 99
+	unsigned GetReverbLowPass (void) const;			// 0 .. 99
+	unsigned GetReverbDiffusion (void) const;		// 0 .. 99
+	unsigned GetReverbSend (void) const;			// 0 .. 99
+
 private:
 	CPropertiesFatFsFile m_Properties;
 
@@ -58,6 +68,15 @@ private:
 	unsigned m_nNoteLimitLow[CConfig::ToneGenerators];
 	unsigned m_nNoteLimitHigh[CConfig::ToneGenerators];
 	int m_nNoteShift[CConfig::ToneGenerators];
+
+	bool m_bCompressorEnable;
+	bool m_bReverbEnable;
+	unsigned m_nReverbSize;
+	unsigned m_nReverbHighDamp;
+	unsigned m_nReverbLowDamp;
+	unsigned m_nReverbLowPass;
+	unsigned m_nReverbDiffusion;
+	unsigned m_nReverbSend;
 };
 
 #endif

--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -48,8 +48,8 @@ const CUIMenu::TMenuItem CUIMenu::s_MainMenu[] =
 	{"TG6",		MenuHandler,	s_TGMenu, 5},
 	{"TG7",		MenuHandler,	s_TGMenu, 6},
 	{"TG8",		MenuHandler,	s_TGMenu, 7},
-	{"Reverb",	MenuHandler,	s_ReverbMenu},
 #endif
+	{"Effects",	MenuHandler,	s_EffectsMenu},
 	{0}
 };
 
@@ -67,10 +67,20 @@ const CUIMenu::TMenuItem CUIMenu::s_TGMenu[] =
 	{0}
 };
 
+const CUIMenu::TMenuItem CUIMenu::s_EffectsMenu[] =
+{
+	{"Compress",	EditGlobalParameter,	0,	CMiniDexed::ParameterCompressorEnable},
+#ifdef ARM_ALLOW_MULTI_CORE
+	{"Reverb",	MenuHandler,		s_ReverbMenu},
+#endif
+	{0}
+};
+
 #ifdef ARM_ALLOW_MULTI_CORE
 
 const CUIMenu::TMenuItem CUIMenu::s_ReverbMenu[] =
 {
+	{"Enable",	EditGlobalParameter,	0,	CMiniDexed::ParameterReverbEnable},
 	{"Size",	EditGlobalParameter,	0,	CMiniDexed::ParameterReverbSize},
 	{"High damp",	EditGlobalParameter,	0,	CMiniDexed::ParameterReverbHighDamp},
 	{"Low damp",	EditGlobalParameter,	0,	CMiniDexed::ParameterReverbLowDamp},
@@ -139,14 +149,16 @@ const CUIMenu::TMenuItem CUIMenu::s_OperatorMenu[] =
 };
 
 // must match CMiniDexed::TParameter
-const CUIMenu::TParameter CUIMenu::s_GlobalParameter[CMiniDexed::TGParameterUnknown] =
+const CUIMenu::TParameter CUIMenu::s_GlobalParameter[CMiniDexed::ParameterUnknown] =
 {
-	{0,	99,	1},		// ParameterReverbSize
-	{0,	99,	1},		// ParameterReverbHighDamp
-	{0,	99,	1},		// ParameterReverbLowDamp
-	{0,	99,	1},		// ParameterReverbLowPass
-	{0,	99,	1},		// ParameterReverbDiffusion
-	{0,	99,	1},		// ParameterReverbSend
+	{0,	1,	1,	ToOnOff},		// ParameterCompessorEnable
+	{0,	1,	1,	ToOnOff},		// ParameterReverbEnable
+	{0,	99,	1},				// ParameterReverbSize
+	{0,	99,	1},				// ParameterReverbHighDamp
+	{0,	99,	1},				// ParameterReverbLowDamp
+	{0,	99,	1},				// ParameterReverbLowPass
+	{0,	99,	1},				// ParameterReverbDiffusion
+	{0,	99,	1}				// ParameterReverbSend
 };
 
 // must match CMiniDexed::TTGParameter

--- a/src/uimenu.h
+++ b/src/uimenu.h
@@ -118,6 +118,7 @@ private:
 	static const TMenuItem s_MenuRoot[];
 	static const TMenuItem s_MainMenu[];
 	static const TMenuItem s_TGMenu[];
+	static const TMenuItem s_EffectsMenu[];
 	static const TMenuItem s_ReverbMenu[];
 	static const TMenuItem s_EditVoiceMenu[];
 	static const TMenuItem s_OperatorMenu[];


### PR DESCRIPTION
* Can be switched on/off in "Effects" sub-menu in UI
* Compressor is switched on/off for all TGs
* Read effects parameters from performance.ini

Unfortunately I had to change the suggested menus a little bit, because for instance "Edit Reverb" and "Diffusion" does not fit on one LCD line. So there is only one "Reverb" menu, which covers all reverb parameters.