### PR TITLE
Add shortcut for changing the TG in parameter edit

### DIFF
--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -37,6 +37,7 @@ const CUIMenu::TMenuItem CUIMenu::s_MenuRoot[] =
 	{0}
 };
 
+// inserting menu items before "TG1" affect TGShortcutHandler()
 const CUIMenu::TMenuItem CUIMenu::s_MainMenu[] =
 {
 	{"TG1",		MenuHandler,	s_TGMenu, 0},
@@ -316,8 +317,7 @@ void CUIMenu::MenuHandler (CUIMenu *pUIMenu, TMenuEvent Event)
 		break;
 
 	default:
-		assert (0);
-		break;
+		return;
 	}
 
 	if (pUIMenu->m_pCurrentMenu)				// if this is another menu?
@@ -410,6 +410,11 @@ void CUIMenu::EditVoiceBankNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 			CMiniDexed::TGParameterVoiceBank, nValue, nTG);
 		break;
 
+	case MenuEventPressAndStepDown:
+	case MenuEventPressAndStepUp:
+		pUIMenu->TGShortcutHandler (Event);
+		return;
+
 	default:
 		return;
 	}
@@ -452,6 +457,11 @@ void CUIMenu::EditProgramNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 		}
 		pUIMenu->m_pMiniDexed->SetTGParameter (CMiniDexed::TGParameterProgram, nValue, nTG);
 		break;
+
+	case MenuEventPressAndStepDown:
+	case MenuEventPressAndStepUp:
+		pUIMenu->TGShortcutHandler (Event);
+		return;
 
 	default:
 		return;
@@ -500,6 +510,11 @@ void CUIMenu::EditTGParameter (CUIMenu *pUIMenu, TMenuEvent Event)
 		pUIMenu->m_pMiniDexed->SetTGParameter (Param, nValue, nTG);
 		break;
 
+	case MenuEventPressAndStepDown:
+	case MenuEventPressAndStepUp:
+		pUIMenu->TGShortcutHandler (Event);
+		return;
+
 	default:
 		return;
 	}
@@ -546,6 +561,11 @@ void CUIMenu::EditVoiceParameter (CUIMenu *pUIMenu, TMenuEvent Event)
 		}
 		pUIMenu->m_pMiniDexed->SetVoiceParameter (nParam, nValue, CMiniDexed::NoOP, nTG);
 		break;
+
+	case MenuEventPressAndStepDown:
+	case MenuEventPressAndStepUp:
+		pUIMenu->TGShortcutHandler (Event);
+		return;
 
 	default:
 		return;
@@ -594,6 +614,11 @@ void CUIMenu::EditOPParameter (CUIMenu *pUIMenu, TMenuEvent Event)
 		}
 		pUIMenu->m_pMiniDexed->SetVoiceParameter (nParam, nValue, nOP, nTG);
 		break;
+
+	case MenuEventPressAndStepDown:
+	case MenuEventPressAndStepUp:
+		pUIMenu->TGShortcutHandler (Event);
+		return;
 
 	default:
 		return;
@@ -795,4 +820,34 @@ string CUIMenu::ToOscillatorDetune (int nValue)
 	}
 
 	return Result;
+}
+
+void CUIMenu::TGShortcutHandler (TMenuEvent Event)
+{
+	assert (m_nCurrentMenuDepth >= 2);
+	assert (m_MenuStackMenu[0] = s_MainMenu);
+	unsigned nTG = m_nMenuStackSelection[0];
+	assert (nTG < CConfig::ToneGenerators);
+	assert (m_nMenuStackItem[1] == nTG);
+	assert (m_nMenuStackParameter[1] == nTG);
+
+	assert (   Event == MenuEventPressAndStepDown
+		|| Event == MenuEventPressAndStepUp);
+	if (Event == MenuEventPressAndStepDown)
+	{
+		nTG--;
+	}
+	else
+	{
+		nTG++;
+	}
+
+	if (nTG < CConfig::ToneGenerators)
+	{
+		m_nMenuStackSelection[0] = nTG;
+		m_nMenuStackItem[1] = nTG;
+		m_nMenuStackParameter[1] = nTG;
+
+		EventHandler (MenuEventUpdate);
+	}
 }

--- a/src/uimenu.h
+++ b/src/uimenu.h
@@ -42,6 +42,8 @@ public:
 		MenuEventHome,
 		MenuEventStepDown,
 		MenuEventStepUp,
+		MenuEventPressAndStepDown,
+		MenuEventPressAndStepUp,
 		MenuEventUnknown
 	};
 
@@ -97,6 +99,8 @@ private:
 	static std::string ToKeyboardCurve (int nValue);
 	static std::string ToOscillatorMode (int nValue);
 	static std::string ToOscillatorDetune (int nValue);
+
+	void TGShortcutHandler (TMenuEvent Event);
 
 private:
 	CUserInterface *m_pUI;

--- a/src/userinterface.cpp
+++ b/src/userinterface.cpp
@@ -34,6 +34,7 @@ CUserInterface::CUserInterface (CMiniDexed *pMiniDexed, CGPIOManager *pGPIOManag
 	m_pLCD (0),
 	m_pLCDBuffered (0),
 	m_pRotaryEncoder (0),
+	m_bSwitchPressed (false),
 	m_Menu (this, pMiniDexed)
 {
 }
@@ -177,12 +178,22 @@ void CUserInterface::EncoderEventHandler (CKY040::TEvent Event)
 {
 	switch (Event)
 	{
+	case CKY040::EventSwitchDown:
+		m_bSwitchPressed = true;
+		break;
+
+	case CKY040::EventSwitchUp:
+		m_bSwitchPressed = false;
+		break;
+
 	case CKY040::EventClockwise:
-		m_Menu.EventHandler (CUIMenu::MenuEventStepUp);
+		m_Menu.EventHandler (m_bSwitchPressed ? CUIMenu::MenuEventPressAndStepUp
+						      : CUIMenu::MenuEventStepUp);
 		break;
 
 	case CKY040::EventCounterclockwise:
-		m_Menu.EventHandler (CUIMenu::MenuEventStepDown);
+		m_Menu.EventHandler (m_bSwitchPressed ? CUIMenu::MenuEventPressAndStepDown
+						      : CUIMenu::MenuEventStepDown);
 		break;
 
 	case CKY040::EventSwitchClick:
@@ -193,16 +204,16 @@ void CUserInterface::EncoderEventHandler (CKY040::TEvent Event)
 		m_Menu.EventHandler (CUIMenu::MenuEventSelect);
 		break;
 
+	case CKY040::EventSwitchTripleClick:
+		m_Menu.EventHandler (CUIMenu::MenuEventHome);
+		break;
+
 	case CKY040::EventSwitchHold:
-		if (m_pRotaryEncoder->GetHoldSeconds () >= 3)
+		if (m_pRotaryEncoder->GetHoldSeconds () >= 10)
 		{
 			delete m_pLCD;		// reset LCD
 
 			reboot ();
-		}
-		else
-		{
-			m_Menu.EventHandler (CUIMenu::MenuEventHome);
 		}
 		break;
 

--- a/src/userinterface.h
+++ b/src/userinterface.h
@@ -64,6 +64,7 @@ private:
 	CWriteBufferDevice *m_pLCDBuffered;
 
 	CKY040 *m_pRotaryEncoder;
+	bool m_bSwitchPressed;
 
 	CUIMenu m_Menu;
 };


### PR DESCRIPTION
When a parameter is edited in the UI, the current TG can be changed
by pressing the switch and turning the knob left or right. The
selected TG remains active, when the parameter editor is left. The
menu home position is entered by triple click now, reboot after
holding the switch for ten seconds.