### PR TITLE
Add MIDI through feature

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -48,6 +48,26 @@ void CConfig::Load (void)
 
 	m_nMIDIBaudRate = m_Properties.GetNumber ("MIDIBaudRate", 31250);
 
+	const char *pMIDIThrough = m_Properties.GetString ("MIDIThrough");
+	if (pMIDIThrough)
+	{
+		std::string Arg (pMIDIThrough);
+
+		size_t nPos = Arg.find (',');
+		if (nPos != std::string::npos)
+		{
+			m_MIDIThroughIn = Arg.substr (0, nPos);
+			m_MIDIThroughOut = Arg.substr (nPos+1);
+
+			if (   m_MIDIThroughIn.empty ()
+			    || m_MIDIThroughOut.empty ())
+			{
+				m_MIDIThroughIn.clear ();
+				m_MIDIThroughOut.clear ();
+			}
+		}
+	}
+
 	m_bLCDEnabled = m_Properties.GetNumber ("LCDEnabled", 0) != 0;
 	m_nLCDPinEnable = m_Properties.GetNumber ("LCDPinEnable", 17);
 	m_nLCDPinRegisterSelect = m_Properties.GetNumber ("LCDPinRegisterSelect", 27);
@@ -94,6 +114,16 @@ bool CConfig::GetChannelsSwapped (void) const
 unsigned CConfig::GetMIDIBaudRate (void) const
 {
 	return m_nMIDIBaudRate;
+}
+
+const char *CConfig::GetMIDIThroughIn (void) const
+{
+	return m_MIDIThroughIn.c_str ();
+}
+
+const char *CConfig::GetMIDIThroughOut (void) const
+{
+	return m_MIDIThroughOut.c_str ();
 }
 
 bool CConfig::GetLCDEnabled (void) const

--- a/src/config.h
+++ b/src/config.h
@@ -71,6 +71,8 @@ public:
 
 	// MIDI
 	unsigned GetMIDIBaudRate (void) const;
+	const char *GetMIDIThroughIn (void) const;	// "" if not specified
+	const char *GetMIDIThroughOut (void) const;	// "" if not specified
 
 	// HD44780 LCD
 	// GPIO pin numbers are chip numbers, not header positions
@@ -104,6 +106,8 @@ private:
 	bool m_bChannelsSwapped;
 
 	unsigned m_nMIDIBaudRate;
+	std::string m_MIDIThroughIn;
+	std::string m_MIDIThroughOut;
 
 	bool m_bLCDEnabled;
 	unsigned m_nLCDPinEnable;

--- a/src/mididevice.cpp
+++ b/src/mididevice.cpp
@@ -46,6 +46,8 @@
 #define MIDI_TIMING_CLOCK	0xF8
 #define MIDI_ACTIVE_SENSING	0xFE
 
+CMIDIDevice::TDeviceMap CMIDIDevice::s_DeviceMap;
+
 CMIDIDevice::CMIDIDevice (CMiniDexed *pSynthesizer, CConfig *pConfig)
 :	m_pSynthesizer (pSynthesizer),
 	m_pConfig (pConfig)
@@ -102,6 +104,18 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 				(unsigned) pMessage[0], (unsigned) pMessage[1],
 				(unsigned) pMessage[2]);
 			break;
+		}
+	}
+
+	// handle MIDI through
+	if (m_DeviceName.compare (m_pConfig->GetMIDIThroughIn ()) == 0)
+	{
+		TDeviceMap::const_iterator Iterator;
+
+		Iterator = s_DeviceMap.find (m_pConfig->GetMIDIThroughOut ());
+		if (Iterator != s_DeviceMap.end ())
+		{
+			Iterator->second->Send (pMessage, nLength, nCable);
 		}
 	}
 
@@ -219,4 +233,15 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 			}
 		}
 	}
+}
+
+void CMIDIDevice::AddDevice (const char *pDeviceName)
+{
+	assert (pDeviceName);
+
+	assert (m_DeviceName.empty ());
+	m_DeviceName = pDeviceName;
+	assert (!m_DeviceName.empty ());
+
+	s_DeviceMap.insert (std::pair<std::string, CMIDIDevice *> (pDeviceName, this));
 }

--- a/src/mididevice.h
+++ b/src/mididevice.h
@@ -24,6 +24,8 @@
 #define _mididevice_h
 
 #include "config.h"
+#include <string>
+#include <unordered_map>
 #include <circle/types.h>
 
 class CMiniDexed;
@@ -41,19 +43,28 @@ public:
 
 public:
 	CMIDIDevice (CMiniDexed *pSynthesizer, CConfig *pConfig);
-	~CMIDIDevice (void);
+	virtual ~CMIDIDevice (void);
 
 	void SetChannel (u8 ucChannel, unsigned nTG);
 	u8 GetChannel (unsigned nTG) const;
 
+	virtual void Send (const u8 *pMessage, size_t nLength, unsigned nCable = 0) {}
+
 protected:
 	void MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsigned nCable = 0);
+
+	void AddDevice (const char *pDeviceName);
 
 private:
 	CMiniDexed *m_pSynthesizer;
 	CConfig *m_pConfig;
 
 	u8 m_ChannelMap[CConfig::ToneGenerators];
+
+	std::string m_DeviceName;
+
+	typedef std::unordered_map<std::string, CMIDIDevice *> TDeviceMap;
+	static TDeviceMap s_DeviceMap;
 };
 
 #endif

--- a/src/midikeyboard.h
+++ b/src/midikeyboard.h
@@ -29,6 +29,7 @@
 #include <circle/device.h>
 #include <circle/string.h>
 #include <circle/types.h>
+#include <queue>
 
 class CMiniDexed;
 
@@ -43,6 +44,8 @@ public:
 
 	void Process (boolean bPlugAndPlayUpdated);
 
+	void Send (const u8 *pMessage, size_t nLength, unsigned nCable = 0) override;
+
 private:
 	static void MIDIPacketHandler0 (unsigned nCable, u8 *pPacket, unsigned nLength);
 	static void MIDIPacketHandler1 (unsigned nCable, u8 *pPacket, unsigned nLength);
@@ -52,10 +55,20 @@ private:
 	static void DeviceRemovedHandler (CDevice *pDevice, void *pContext);
 
 private:
+	struct TSendQueueEntry
+	{
+		u8	*pMessage;
+		size_t	 nLength;
+		unsigned nCable;
+	};
+
+private:
 	unsigned m_nInstance;
 	CString m_DeviceName;
 
 	CUSBMIDIDevice * volatile m_pMIDIDevice;
+
+	std::queue<TSendQueueEntry> m_SendQueue;
 
 	static CMIDIKeyboard *s_pThis[MaxInstances];
 

--- a/src/minidexed.ini
+++ b/src/minidexed.ini
@@ -13,6 +13,7 @@ ChannelsSwapped=0
 
 # MIDI
 MIDIBaudRate=31250
+#MIDIThrough=umidi1,ttyS1
 
 # HD44780 LCD
 LCDEnabled=1

--- a/src/pckeyboard.cpp
+++ b/src/pckeyboard.cpp
@@ -67,6 +67,8 @@ CPCKeyboard::CPCKeyboard (CMiniDexed *pSynthesizer, CConfig *pConfig)
 	s_pThis = this;
 
 	memset (m_LastKeys, 0, sizeof m_LastKeys);
+
+	AddDevice ("ukbd1");
 }
 
 CPCKeyboard::~CPCKeyboard (void)

--- a/src/serialmididevice.cpp
+++ b/src/serialmididevice.cpp
@@ -28,8 +28,10 @@ CSerialMIDIDevice::CSerialMIDIDevice (CMiniDexed *pSynthesizer, CInterruptSystem
 :	CMIDIDevice (pSynthesizer, pConfig),
 	m_pConfig (pConfig),
 	m_Serial (pInterrupt, TRUE),
-	m_nSerialState (0)
+	m_nSerialState (0),
+	m_SendBuffer (&m_Serial)
 {
+	AddDevice ("ttyS1");
 }
 
 CSerialMIDIDevice::~CSerialMIDIDevice (void)
@@ -45,6 +47,8 @@ boolean CSerialMIDIDevice::Initialize (void)
 
 void CSerialMIDIDevice::Process (void)
 {
+	m_SendBuffer.Update ();
+
 	// Read serial MIDI data
 	u8 Buffer[100];
 	int nResult = m_Serial.Read (Buffer, sizeof Buffer);
@@ -95,4 +99,9 @@ void CSerialMIDIDevice::Process (void)
 			break;
 		}
 	}
+}
+
+void CSerialMIDIDevice::Send (const u8 *pMessage, size_t nLength, unsigned nCable)
+{
+	m_SendBuffer.Write (pMessage, nLength);
 }

--- a/src/serialmididevice.h
+++ b/src/serialmididevice.h
@@ -27,6 +27,7 @@
 #include "config.h"
 #include <circle/interrupt.h>
 #include <circle/serial.h>
+#include <circle/writebuffer.h>
 #include <circle/types.h>
 
 class CMiniDexed;
@@ -41,12 +42,16 @@ public:
 
 	void Process (void);
 
+	void Send (const u8 *pMessage, size_t nLength, unsigned nCable = 0) override;
+
 private:
 	CConfig *m_pConfig;
 
 	CSerialDevice m_Serial;
 	unsigned m_nSerialState;
 	u8 m_SerialMessage[3];
+
+	CWriteBufferDevice m_SendBuffer;
 };
 
 #endif


### PR DESCRIPTION
* Option "MIDIThrough=from,to" in minidexed.ini to enable
* This forwards MIDI events from the device "from" to "to"
* from/to can be:
	* umidiN (USB MIDI keyboard, N = 1..4)
	* ttyS1 (serial interface)
	* ukbd1 (PC keyboard)
* See src/minidexed.ini for an example