### PR TITLE
Scale more CCs

### DIFF
--- a/src/mididevice.cpp
+++ b/src/mididevice.cpp
@@ -196,11 +196,11 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 					break;
 
 				case MIDI_CC_RESONANCE:
-					m_pSynthesizer->SetResonance (pMessage[2], nTG);
+					m_pSynthesizer->SetResonance (maplong (pMessage[2], 0, 127, 0, 99), nTG);
 					break;
 					
 				case MIDI_CC_FREQUENCY_CUTOFF:
-					m_pSynthesizer->SetCutoff (pMessage[2], nTG);
+					m_pSynthesizer->SetCutoff (maplong (pMessage[2], 0, 127, 0, 99), nTG);
 					break;
 
 				case MIDI_CC_REVERB_LEVEL:
@@ -208,7 +208,7 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 					break;
 
 				case MIDI_CC_DETUNE_LEVEL:
-					m_pSynthesizer->SetMasterTune (pMessage[2], nTG);
+					m_pSynthesizer->SetMasterTune (maplong (pMessage[2], 0, 127, -99, 99), nTG);
 					break;
 
 				case MIDI_CC_ALL_SOUND_OFF:


### PR DESCRIPTION
- 10 = Pan: 0-127 (= no scaling needed)
- 71 = Resonance: 0-99
- 74 = Frequency Cutoff: 0-99
- 91 = Reverb Send: 0-99
- 94 = Detune Level: -99-99

https://github.com/probonopd/MiniDexed/pull/122#issuecomment-1105686599

Closes https://github.com/probonopd/MiniDexed/issues/121