### PR TITLE
Keep all build artifacts for 90 days

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,8 +68,8 @@ jobs:
            echo "usbspeed=full" > sdcard/cmdline.txt
            cd sdcard
            cp ../kernels/* . || true
-           zip -r ../MiniDexed_$GITHUB_RUN_NUMBER_$(date +%Y-%m-%d).zip *
-           echo "artifactName=MiniDexed_$GITHUB_RUN_NUMBER_$(date +%Y-%m-%d).zip" >> $GITHUB_ENV
+           zip -r ../MiniDexed_$GITHUB_RUN_NUMBER_$(date +%Y-%m-%d)-$(git rev-parse --short HEAD).zip *
+           echo "artifactName=MiniDexed_$GITHUB_RUN_NUMBER_$(date +%Y-%m-%d)-$(git rev-parse --short HEAD).zip" >> $GITHUB_ENV
     - uses: actions/upload-artifact@v3
       with:
         name: ${{ env.artifactName }} # Exported above

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,11 +69,11 @@ jobs:
            cd sdcard
            cp ../kernels/* . || true
            zip -r ../MiniDexed_$GITHUB_RUN_NUMBER_$(date +%Y-%m-%d).zip *
+           echo "artifactName=MiniDexed_$GITHUB_RUN_NUMBER_$(date +%Y-%m-%d).zip" >> $GITHUB_ENV
     - uses: actions/upload-artifact@v3
-      if: ${{ github.ref != 'refs/heads/main' }}
       with:
-        name: Upload to GitHub Artifacts (when not building from main branch)
-        path: ./MiniDexed*.zip
+        name: ${{ env.artifactName }} # Exported above
+        path: ./sdcard/*
     - name: Upload to GitHub Releases (only when building from main branch)
       if: ${{ github.ref == 'refs/heads/main' }}
       run: |


### PR DESCRIPTION
Keep all build artifacts for 90 days (which is the maximum allowed by GitHub).
Also those on the master branch.

https://github.com/probonopd/MiniDexed/issues/140#issuecomment-1106752484