### PR TITLE
Simplified click behaviour

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -67,6 +67,9 @@ void CConfig::Load (void)
 			}
 		}
 	}
+	
+	m_bMIDIRXProgramChange = m_Properties.GetNumber ("MIDIRXProgramChange", 1) != 0;
+
 
 	m_bLCDEnabled = m_Properties.GetNumber ("LCDEnabled", 0) != 0;
 	m_nLCDPinEnable = m_Properties.GetNumber ("LCDPinEnable", 17);
@@ -124,6 +127,11 @@ const char *CConfig::GetMIDIThruIn (void) const
 const char *CConfig::GetMIDIThruOut (void) const
 {
 	return m_MIDIThruOut.c_str ();
+}
+
+bool CConfig::GetMIDIRXProgramChange (void) const
+{
+	return m_bMIDIRXProgramChange;
 }
 
 bool CConfig::GetLCDEnabled (void) const

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -84,6 +84,7 @@ void CConfig::Load (void)
 	m_nEncoderPinClock = m_Properties.GetNumber ("EncoderPinClock", 5);
 	m_nEncoderPinData = m_Properties.GetNumber ("EncoderPinData", 6);
 	m_nEncoderPinSwitch = m_Properties.GetNumber ("EncoderPinSwitch", 26);
+	m_bEncoderClickIsConfirm = m_Properties.GetNumber ("EncoderClickIsConfirm", 0) != 0;
 
 	m_bMIDIDumpEnabled  = m_Properties.GetNumber ("MIDIDumpEnabled", 0) != 0;
 	m_bProfileEnabled = m_Properties.GetNumber ("ProfileEnabled", 0) != 0;
@@ -192,6 +193,11 @@ unsigned CConfig::GetEncoderPinData (void) const
 unsigned CConfig::GetEncoderPinSwitch (void) const
 {
 	return m_nEncoderPinSwitch;
+}
+
+bool CConfig::GetEncoderClickIsConfirm (void) const
+{
+	return m_bEncoderClickIsConfirm;
 }
 
 bool CConfig::GetMIDIDumpEnabled (void) const

--- a/src/config.h
+++ b/src/config.h
@@ -73,6 +73,8 @@ public:
 	unsigned GetMIDIBaudRate (void) const;
 	const char *GetMIDIThruIn (void) const;	// "" if not specified
 	const char *GetMIDIThruOut (void) const;	// "" if not specified
+	bool GetMIDIRXProgramChange (void) const;	// true if not specified
+	
 
 	// HD44780 LCD
 	// GPIO pin numbers are chip numbers, not header positions
@@ -108,6 +110,7 @@ private:
 	unsigned m_nMIDIBaudRate;
 	std::string m_MIDIThruIn;
 	std::string m_MIDIThruOut;
+	bool m_bMIDIRXProgramChange;
 
 	bool m_bLCDEnabled;
 	unsigned m_nLCDPinEnable;

--- a/src/config.h
+++ b/src/config.h
@@ -93,6 +93,7 @@ public:
 	unsigned GetEncoderPinClock (void) const;
 	unsigned GetEncoderPinData (void) const;
 	unsigned GetEncoderPinSwitch (void) const;
+	bool GetEncoderClickIsConfirm (void) const;
 
 	// Debug
 	bool GetMIDIDumpEnabled (void) const;
@@ -125,6 +126,7 @@ private:
 	unsigned m_nEncoderPinClock;
 	unsigned m_nEncoderPinData;
 	unsigned m_nEncoderPinSwitch;
+	bool m_bEncoderClickIsConfirm;
 
 	bool m_bMIDIDumpEnabled;
 	bool m_bProfileEnabled;

--- a/src/mididevice.cpp
+++ b/src/mididevice.cpp
@@ -208,15 +208,7 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 					break;
 
 				case MIDI_CC_DETUNE_LEVEL:
-					if (pMessage[2] == 0)
-					{
-						// "0 to 127, with 0 being no celeste (detune) effect applied at all."
-						m_pSynthesizer->SetMasterTune (0, nTG);
-					}
-					else
-					{
-						m_pSynthesizer->SetMasterTune (maplong (pMessage[2], 1, 127, -99, 99), nTG);
-					}
+					m_pSynthesizer->SetMasterTune (maplong (pMessage[2], 0, 127, -99, 99), nTG);
 					break;
 
 				case MIDI_CC_ALL_SOUND_OFF:
@@ -230,7 +222,9 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 				break;
 
 			case MIDI_PROGRAM_CHANGE:
-				m_pSynthesizer->ProgramChange (pMessage[1], nTG);
+				// do program change only if enabled in config
+				if( m_pConfig->GetMIDIRXProgramChange() )
+					m_pSynthesizer->ProgramChange (pMessage[1], nTG);
 				break;
 
 			case MIDI_PITCH_BEND: {

--- a/src/minidexed.ini
+++ b/src/minidexed.ini
@@ -14,6 +14,7 @@ ChannelsSwapped=0
 # MIDI
 MIDIBaudRate=31250
 #MIDIThru=umidi1,ttyS1
+MIDIRXProgramChange=1
 
 # HD44780 LCD
 LCDEnabled=1

--- a/src/minidexed.ini
+++ b/src/minidexed.ini
@@ -14,7 +14,7 @@ ChannelsSwapped=0
 # MIDI
 MIDIBaudRate=31250
 #MIDIThru=umidi1,ttyS1
-MIDIRXProgramChange=0
+MIDIRXProgramChange=1
 
 # HD44780 LCD
 LCDEnabled=1

--- a/src/minidexed.ini
+++ b/src/minidexed.ini
@@ -14,7 +14,7 @@ ChannelsSwapped=0
 # MIDI
 MIDIBaudRate=31250
 #MIDIThru=umidi1,ttyS1
-MIDIRXProgramChange=1
+MIDIRXProgramChange=0
 
 # HD44780 LCD
 LCDEnabled=1
@@ -31,6 +31,7 @@ EncoderEnabled=1
 EncoderPinClock=5
 EncoderPinData=6
 EncoderPinSwitch=26
+EncoderClickIsConfirm=0
 
 # Debug
 MIDIDumpEnabled=0

--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -254,9 +254,10 @@ const char CUIMenu::s_NoteName[100][4] =
 };
 static const unsigned NoteC3 = 27;
 
-CUIMenu::CUIMenu (CUserInterface *pUI, CMiniDexed *pMiniDexed)
+CUIMenu::CUIMenu (CUserInterface *pUI, CMiniDexed *pMiniDexed, CConfig *pConfig)
 :	m_pUI (pUI),
 	m_pMiniDexed (pMiniDexed),
+	m_pConfig (pConfig),
 	m_pParentMenu (s_MenuRoot),
 	m_pCurrentMenu (s_MainMenu),
 	m_nCurrentMenuItem (0),
@@ -395,8 +396,11 @@ void CUIMenu::EditGlobalParameter (CUIMenu *pUIMenu, TMenuEvent Event)
 		break;
 		
 	case MenuEventSelect:
-		// when a parameter is selected --> accept change and return one level up
-		pUIMenu->EventHandler( CUIMenu::MenuEventBack );
+		if( pUIMenu->m_pConfig->GetEncoderClickIsConfirm() )
+		{
+			// when a parameter is selected --> accept change and return one level up
+			pUIMenu->EventHandler( CUIMenu::MenuEventBack );
+		}
 		return;
 
 	default:
@@ -450,8 +454,11 @@ void CUIMenu::EditVoiceBankNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 		return;
 
 	case MenuEventSelect:
-		// when a parameter is selected --> accept change and return one level up
-		pUIMenu->EventHandler( CUIMenu::MenuEventBack );
+		if( pUIMenu->m_pConfig->GetEncoderClickIsConfirm() )
+		{
+			// when a parameter is selected --> accept change and return one level up
+			pUIMenu->EventHandler( CUIMenu::MenuEventBack );
+		}
 		return;
 
 	default:
@@ -503,8 +510,11 @@ void CUIMenu::EditProgramNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 		return;
 
 	case MenuEventSelect:
-		// when a parameter is selected --> accept change and return one level up
-		pUIMenu->EventHandler( CUIMenu::MenuEventBack );
+		if( pUIMenu->m_pConfig->GetEncoderClickIsConfirm() )
+		{
+			// when a parameter is selected --> accept change and return one level up
+			pUIMenu->EventHandler( CUIMenu::MenuEventBack );
+		}
 		return;
 
 	default:
@@ -560,8 +570,11 @@ void CUIMenu::EditTGParameter (CUIMenu *pUIMenu, TMenuEvent Event)
 		return;
 
 	case MenuEventSelect:
-		// when a parameter is selected --> accept change and return one level up
-		pUIMenu->EventHandler( CUIMenu::MenuEventBack );
+		if( pUIMenu->m_pConfig->GetEncoderClickIsConfirm() )
+		{
+			// when a parameter is selected --> accept change and return one level up
+			pUIMenu->EventHandler( CUIMenu::MenuEventBack );
+		}
 		return;
 
 	default:
@@ -614,6 +627,14 @@ void CUIMenu::EditVoiceParameter (CUIMenu *pUIMenu, TMenuEvent Event)
 	case MenuEventPressAndStepDown:
 	case MenuEventPressAndStepUp:
 		pUIMenu->TGShortcutHandler (Event);
+		return;
+
+	case MenuEventSelect:
+		if( pUIMenu->m_pConfig->GetEncoderClickIsConfirm() )
+		{
+			// when a parameter is selected --> accept change and return one level up
+			pUIMenu->EventHandler( CUIMenu::MenuEventBack );
+		}
 		return;
 
 	default:
@@ -670,8 +691,11 @@ void CUIMenu::EditOPParameter (CUIMenu *pUIMenu, TMenuEvent Event)
 		return;
 
 	case MenuEventSelect:
-		// when a parameter is selected --> accept change and return one level up
-		pUIMenu->EventHandler( CUIMenu::MenuEventBack );
+		if( pUIMenu->m_pConfig->GetEncoderClickIsConfirm() )
+		{
+			// when a parameter is selected --> accept change and return one level up
+			pUIMenu->EventHandler( CUIMenu::MenuEventBack );
+		}
 		return;
 
 	default:

--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -393,6 +393,11 @@ void CUIMenu::EditGlobalParameter (CUIMenu *pUIMenu, TMenuEvent Event)
 		}
 		pUIMenu->m_pMiniDexed->SetParameter (Param, nValue);
 		break;
+		
+	case MenuEventSelect:
+		// when a parameter is selected --> accept change and return one level up
+		pUIMenu->EventHandler( CUIMenu::MenuEventBack );
+		return;
 
 	default:
 		return;
@@ -444,6 +449,11 @@ void CUIMenu::EditVoiceBankNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 		pUIMenu->TGShortcutHandler (Event);
 		return;
 
+	case MenuEventSelect:
+		// when a parameter is selected --> accept change and return one level up
+		pUIMenu->EventHandler( CUIMenu::MenuEventBack );
+		return;
+
 	default:
 		return;
 	}
@@ -490,6 +500,11 @@ void CUIMenu::EditProgramNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 	case MenuEventPressAndStepDown:
 	case MenuEventPressAndStepUp:
 		pUIMenu->TGShortcutHandler (Event);
+		return;
+
+	case MenuEventSelect:
+		// when a parameter is selected --> accept change and return one level up
+		pUIMenu->EventHandler( CUIMenu::MenuEventBack );
 		return;
 
 	default:
@@ -542,6 +557,11 @@ void CUIMenu::EditTGParameter (CUIMenu *pUIMenu, TMenuEvent Event)
 	case MenuEventPressAndStepDown:
 	case MenuEventPressAndStepUp:
 		pUIMenu->TGShortcutHandler (Event);
+		return;
+
+	case MenuEventSelect:
+		// when a parameter is selected --> accept change and return one level up
+		pUIMenu->EventHandler( CUIMenu::MenuEventBack );
 		return;
 
 	default:
@@ -647,6 +667,11 @@ void CUIMenu::EditOPParameter (CUIMenu *pUIMenu, TMenuEvent Event)
 	case MenuEventPressAndStepDown:
 	case MenuEventPressAndStepUp:
 		pUIMenu->OPShortcutHandler (Event);
+		return;
+
+	case MenuEventSelect:
+		// when a parameter is selected --> accept change and return one level up
+		pUIMenu->EventHandler( CUIMenu::MenuEventBack );
 		return;
 
 	default:

--- a/src/uimenu.h
+++ b/src/uimenu.h
@@ -28,6 +28,7 @@
 
 class CMiniDexed;
 class CUserInterface;
+class CConfig;
 
 class CUIMenu
 {
@@ -49,7 +50,7 @@ public:
 	};
 
 public:
-	CUIMenu (CUserInterface *pUI, CMiniDexed *pMiniDexed);
+	CUIMenu (CUserInterface *pUI, CMiniDexed *pMiniDexed, CConfig *pConfig);
 
 	void EventHandler (TMenuEvent Event);
 
@@ -110,6 +111,7 @@ private:
 private:
 	CUserInterface *m_pUI;
 	CMiniDexed *m_pMiniDexed;
+	CConfig *m_pConfig;
 
 	const TMenuItem *m_pParentMenu;
 	const TMenuItem *m_pCurrentMenu;

--- a/src/userinterface.cpp
+++ b/src/userinterface.cpp
@@ -35,7 +35,7 @@ CUserInterface::CUserInterface (CMiniDexed *pMiniDexed, CGPIOManager *pGPIOManag
 	m_pLCDBuffered (0),
 	m_pRotaryEncoder (0),
 	m_bSwitchPressed (false),
-	m_Menu (this, pMiniDexed)
+	m_Menu (this, pMiniDexed, pConfig)
 {
 }
 
@@ -91,6 +91,8 @@ bool CUserInterface::Initialize (void)
 		m_pRotaryEncoder->RegisterEventHandler (EncoderEventStub, this);
 
 		LOGDBG ("Rotary encoder initialized");
+		if( m_pConfig->GetEncoderClickIsConfirm() )
+			LOGDBG ("Encoder click is Confirm, dbl click is up");
 	}
 
 	m_Menu.EventHandler (CUIMenu::MenuEventUpdate);
@@ -197,13 +199,19 @@ void CUserInterface::EncoderEventHandler (CKY040::TEvent Event)
 		break;
 
 	case CKY040::EventSwitchClick:
-		// m_Menu.EventHandler (CUIMenu::MenuEventBack);
-		m_Menu.EventHandler (CUIMenu::MenuEventSelect);
+		// Click = Select / Confirm (option) or Back / Up (Default)
+		if( m_pConfig->GetEncoderClickIsConfirm() )
+			m_Menu.EventHandler (CUIMenu::MenuEventSelect);
+		else 
+			m_Menu.EventHandler (CUIMenu::MenuEventBack);
 		break;
 
 	case CKY040::EventSwitchDoubleClick:
-		// m_Menu.EventHandler (CUIMenu::MenuEventSelect);
-		m_Menu.EventHandler (CUIMenu::MenuEventBack);
+		// Double Click = Back / Up (option) or Select (Default)
+		if( m_pConfig->GetEncoderClickIsConfirm() )
+			m_Menu.EventHandler (CUIMenu::MenuEventBack);
+		else
+			m_Menu.EventHandler (CUIMenu::MenuEventSelect);
 		break;
 
 	case CKY040::EventSwitchTripleClick:

--- a/src/userinterface.cpp
+++ b/src/userinterface.cpp
@@ -197,11 +197,13 @@ void CUserInterface::EncoderEventHandler (CKY040::TEvent Event)
 		break;
 
 	case CKY040::EventSwitchClick:
-		m_Menu.EventHandler (CUIMenu::MenuEventBack);
+		// m_Menu.EventHandler (CUIMenu::MenuEventBack);
+		m_Menu.EventHandler (CUIMenu::MenuEventSelect);
 		break;
 
 	case CKY040::EventSwitchDoubleClick:
-		m_Menu.EventHandler (CUIMenu::MenuEventSelect);
+		// m_Menu.EventHandler (CUIMenu::MenuEventSelect);
+		m_Menu.EventHandler (CUIMenu::MenuEventBack);
 		break;
 
 	case CKY040::EventSwitchTripleClick:


### PR DESCRIPTION
The current implementation for the menu navigation is following a "GUI" approach with a mouse with Double Click for selecting an item & Single Click for upwards navigation. With just a rotary encoder, especially changing Operator behaviour needs a lot of clicking. I tried to optimize the behaviour towards less clicks with the following rules:

Single click: "Confirm", i.e.
- if the currently selected item is a menu, it selects the menu and goes "down" into the menu
- if the currently selcted item is a parameter (e.g. "Volume"), it confirms the current value and returns the the menu level above
Double click: "Up", i.e. goto into the previous menu
Triple click: "Home", i.e. goto the root menu (no change here)

Here a typical use case on how this reduces the number of necessary clicks:  Select a new voice and adjust "Volume"  & "Pan" for it, e.g. for TG1
- previously: DblClick on "TG1", select "voice", DblClick, select a voice, Click for Up, select "volume", DblClick, Change Volume, Click for Up, select "Pan", DblClick, Select Pan --> 10 clicks
- now: Click on "TG1", select "voice", Click, select a voice, Click for confirm, select "Volume", Click, change Volume, Click for confirm, select "Pan", Click "Pan", Select Pan --> 6 clicks

As user interface behaviour is sometimes very tied to the user and the inventor, I will not fight for this pull. This change works for me very good, I have the feeling that I am much faster at tweeking paramenters. But before rejecting it, give a try, start a jam session for 1 hour, where you experiment with the voices and the parameter settings, tweaking operators etc. 

Otherwise: awesome project, keep developing it. With that, I do not have a dedicated hardware "DX7" in my setup!