### PR TITLE
I2C display support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
            set -ex
            cd circle-stdlib/libs/circle
-           git checkout ae22928 # develop
+           git checkout c9a4815 # develop
            cd -
     - name: Install toolchains
       run: |

--- a/src/config.h
+++ b/src/config.h
@@ -55,6 +55,8 @@ public:
 
 	static const unsigned LCDColumns = 16;		// HD44780 LCD
 	static const unsigned LCDRows = 2;
+	
+	static const unsigned LCDI2CAddress = 0x27;
 
 public:
 	CConfig (FATFS *pFileSystem);

--- a/src/userinterface.cpp
+++ b/src/userinterface.cpp
@@ -25,8 +25,6 @@
 #include <string.h>
 #include <assert.h>
 
-#define I2C_MASTER_DEVICE (CMachineInfo::Get ()->GetDevice (DeviceI2CMaster))
-
 LOGMODULE ("ui");
 
 CUserInterface::CUserInterface (CMiniDexed *pMiniDexed, CGPIOManager *pGPIOManager, CConfig *pConfig)
@@ -54,8 +52,7 @@ bool CUserInterface::Initialize (void)
 
 	if (m_pConfig->GetLCDEnabled ())
 	{
-		m_pI2CMaster = new CI2CMaster(I2C_MASTER_DEVICE);
-		m_pLCD = new CHD44780Device (&I2CMaster, CConfig::LCDI2CAddress, CConfig::LCDColumns, CConfig::LCDRows);
+		m_pLCD = new CHD44780Device (&m_I2CMaster, CConfig::LCDI2CAddress, CConfig::LCDColumns, CConfig::LCDRows);
 		/* TODO: Read configuration file to see whether i2c should be used for the display. Otherwise run:
 		m_pLCD = new CHD44780Device (CConfig::LCDColumns, CConfig::LCDRows,
 					     m_pConfig->GetLCDPinData4 (),

--- a/src/userinterface.cpp
+++ b/src/userinterface.cpp
@@ -25,6 +25,8 @@
 #include <string.h>
 #include <assert.h>
 
+#define I2C_MASTER_DEVICE (CMachineInfo::Get ()->GetDevice (DeviceI2CMaster))
+
 LOGMODULE ("ui");
 
 CUserInterface::CUserInterface (CMiniDexed *pMiniDexed, CGPIOManager *pGPIOManager, CConfig *pConfig)
@@ -52,6 +54,9 @@ bool CUserInterface::Initialize (void)
 
 	if (m_pConfig->GetLCDEnabled ())
 	{
+		m_pI2CMaster = new CI2CMaster(I2C_MASTER_DEVICE);
+		m_pLCD = new CHD44780Device (&I2CMaster, CConfig::LCDI2CAddress, CConfig::LCDColumns, CConfig::LCDRows);
+		/* TODO: Read configuration file to see whether i2c should be used for the display. Otherwise run:
 		m_pLCD = new CHD44780Device (CConfig::LCDColumns, CConfig::LCDRows,
 					     m_pConfig->GetLCDPinData4 (),
 					     m_pConfig->GetLCDPinData5 (),
@@ -60,6 +65,7 @@ bool CUserInterface::Initialize (void)
 					     m_pConfig->GetLCDPinEnable (),
 					     m_pConfig->GetLCDPinRegisterSelect (),
 					     m_pConfig->GetLCDPinReadWrite ());
+		*/
 		assert (m_pLCD);
 
 		if (!m_pLCD->Initialize ())


### PR DESCRIPTION
Closes https://github.com/probonopd/MiniDexed/issues/169
Thanks @diyelectromusic

TODO to make this proper:
 
- [ ] In https://github.com/probonopd/MiniDexed/blob/i2c/src/config.h change `LCDI2CAddress` to `GetLCDI2CAddress`, implement reading this value from the ini file in `config.c`
- [ ] In `userinterface.cpp` only use i2c for the display if `LCDDevice=44780i2c` in `minidexed.ini` and non-i2c if `LCDDevice=44780`
- [ ] Have reasonable defaults in the software and in the `minidexed.ini` file