### PR TITLE
Switchable performance files improvements + Poly/Mono  + Fix to #298 and #83 issues

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -103,7 +103,7 @@ void CConfig::Load (void)
 
 	m_bMIDIDumpEnabled  = m_Properties.GetNumber ("MIDIDumpEnabled", 0) != 0;
 	m_bProfileEnabled = m_Properties.GetNumber ("ProfileEnabled", 0) != 0;
-	m_bPerformanceSelectToLoad = m_Properties.GetNumber ("PerformanceSelectToLoad", 0) != 0;
+	m_bPerformanceSelectToLoad = m_Properties.GetNumber ("PerformanceSelectToLoad", 1) != 0;
 }
 
 const char *CConfig::GetSoundDevice (void) const

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -88,6 +88,7 @@ void CConfig::Load (void)
 
 	m_bMIDIDumpEnabled  = m_Properties.GetNumber ("MIDIDumpEnabled", 0) != 0;
 	m_bProfileEnabled = m_Properties.GetNumber ("ProfileEnabled", 0) != 0;
+	m_bPerformanceSelectToLoad = m_Properties.GetNumber ("PerformanceSelectToLoad", 0) != 0;
 }
 
 const char *CConfig::GetSoundDevice (void) const
@@ -208,4 +209,9 @@ bool CConfig::GetMIDIDumpEnabled (void) const
 bool CConfig::GetProfileEnabled (void) const
 {
 	return m_bProfileEnabled;
+}
+
+bool CConfig::GetPerformanceSelectToLoad (void) const
+{
+	return m_bPerformanceSelectToLoad;
 }

--- a/src/config.h
+++ b/src/config.h
@@ -98,6 +98,9 @@ public:
 	// Debug
 	bool GetMIDIDumpEnabled (void) const;
 	bool GetProfileEnabled (void) const;
+	
+	// Load performance mode. 0 for load just rotating encoder, 1 load just when Select is pushed
+	bool GetPerformanceSelectToLoad (void) const;
 
 private:
 	CPropertiesFatFsFile m_Properties;
@@ -130,6 +133,7 @@ private:
 
 	bool m_bMIDIDumpEnabled;
 	bool m_bProfileEnabled;
+	bool m_bPerformanceSelectToLoad;
 };
 
 #endif

--- a/src/mididevice.cpp
+++ b/src/mididevice.cpp
@@ -33,9 +33,12 @@ LOGMODULE ("mididevice");
 #define MIDI_NOTE_OFF		0b1000
 #define MIDI_NOTE_ON		0b1001
 #define MIDI_AFTERTOUCH		0b1010			// TODO
+#define MIDI_CHANNEL_AFTERTOUCH 0b1101   // right now Synth_Dexed just manage Channel Aftertouch not Polyphonic AT -> 0b1010
 #define MIDI_CONTROL_CHANGE	0b1011
 	#define MIDI_CC_BANK_SELECT_MSB		0	// TODO
 	#define MIDI_CC_MODULATION			1
+	#define MIDI_CC_BREATH_CONTROLLER	2 
+	#define MIDI_CC_FOOT_PEDAL 		4
 	#define MIDI_CC_VOLUME				7
 	#define MIDI_CC_PAN_POSITION		10
 	#define MIDI_CC_BANK_SELECT_LSB		32
@@ -226,6 +229,12 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 						m_pSynthesizer->keyup (pMessage[1], nTG);
 						break;
 		
+					case MIDI_CHANNEL_AFTERTOUCH:
+						
+						m_pSynthesizer->setAftertouch (pMessage[1], nTG);
+						m_pSynthesizer->ControllersRefresh (nTG);
+						break;
+							
 					case MIDI_CONTROL_CHANGE:
 						if (nLength < 3)
 						{
@@ -238,7 +247,17 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 							m_pSynthesizer->setModWheel (pMessage[2], nTG);
 							m_pSynthesizer->ControllersRefresh (nTG);
 							break;
-		
+								
+						case MIDI_CC_FOOT_PEDAL:
+							m_pSynthesizer->setFootController (pMessage[2], nTG);
+							m_pSynthesizer->ControllersRefresh (nTG);
+							break;
+
+						case MIDI_CC_BREATH_CONTROLLER:
+							m_pSynthesizer->setBreathController (pMessage[2], nTG);
+							m_pSynthesizer->ControllersRefresh (nTG);
+							break;
+								
 						case MIDI_CC_VOLUME:
 							m_pSynthesizer->SetVolume (pMessage[2], nTG);
 							break;

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -52,7 +52,8 @@ CMiniDexed::CMiniDexed (CConfig *pConfig, CInterruptSystem *pInterrupt,
 	m_bProfileEnabled (m_pConfig->GetProfileEnabled ()),
 	m_bSavePerformance (false),
 	m_bSavePerformanceNewFile (false),
-	m_bSetNewPerformance (false) 
+	m_bSetNewPerformance (false),
+	m_bDeletePerformance (false)
 {
 	assert (m_pConfig);
 

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -1283,8 +1283,7 @@ bool CMiniDexed::SavePerformanceNewFile ()
 
 bool CMiniDexed::DoSavePerformanceNewFile (void)
 {
-	std::string nPerformanceName=""; // for future enhacements: capability to write performance name - Not implemented, delete and modify CreateNewPerformanceFile(Name) to CreateNewPerformanceFile(void)
-	if (m_PerformanceConfig.CreateNewPerformanceFile(nPerformanceName))
+	if (m_PerformanceConfig.CreateNewPerformanceFile())
 	{
 		if(SavePerformance())
 		{

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -1261,7 +1261,7 @@ void CMiniDexed::SetMenuSelectedPerformanceID(unsigned nID)
 {
 	m_PerformanceConfig.SetMenuSelectedPerformanceID(nID);
 }
-/* 
+*/ 
 //  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%5
 
 bool CMiniDexed::SetNewPerformance(unsigned nID)

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -72,7 +72,7 @@ CMiniDexed::CMiniDexed (CConfig *pConfig, CInterruptSystem *pInterrupt,
 		m_nPortamentoMode[i] = 0;
 		m_nPortamentoGlissando[i] = 0;
 		m_nPortamentoTime[i] = 0;
-
+		m_bMonoMode[i]=0; 
 		m_nNoteLimitLow[i] = 0;
 		m_nNoteLimitHigh[i] = 127;
 		m_nNoteShift[i] = 0;
@@ -676,6 +676,7 @@ void CMiniDexed::SetTGParameter (TTGParameter Parameter, int nValue, unsigned nT
 	case TGParameterPortamentoMode:		setPortamentoMode (nValue, nTG);	break;
 	case TGParameterPortamentoGlissando:	setPortamentoGlissando (nValue, nTG);	break;
 	case TGParameterPortamentoTime:		setPortamentoTime (nValue, nTG);	break;
+	case TGParameterMonoMode:		setMonoMode (nValue , nTG);	break; 
 
 	case TGParameterMIDIChannel:
 		assert (0 <= nValue && nValue <= 255);
@@ -710,7 +711,7 @@ int CMiniDexed::GetTGParameter (TTGParameter Parameter, unsigned nTG)
 	case TGParameterPortamentoMode:		return m_nPortamentoMode[nTG];
 	case TGParameterPortamentoGlissando:	return m_nPortamentoGlissando[nTG];
 	case TGParameterPortamentoTime:		return m_nPortamentoTime[nTG];
-
+	case TGParameterMonoMode:		return m_bMonoMode[nTG] ? 1 : 0; 
 	default:
 		assert (0);
 		return 0;
@@ -983,6 +984,7 @@ bool CMiniDexed::DoSavePerformance (void)
 		m_PerformanceConfig.SetNoteShift (m_nNoteShift[nTG], nTG);
 		m_pTG[nTG]->getVoiceData(m_nRawVoiceData);  
  		m_PerformanceConfig.SetVoiceDataToTxt (m_nRawVoiceData, nTG); 
+		m_PerformanceConfig.SetMonoMode (m_bMonoMode[nTG], nTG); 
 		
 		m_PerformanceConfig.SetReverbSend (m_nReverbSend[nTG], nTG);
 	}
@@ -1003,7 +1005,7 @@ void CMiniDexed::setMonoMode(uint8_t mono, uint8_t nTG)
 {
 	assert (nTG < CConfig::ToneGenerators);
 	assert (m_pTG[nTG]);
-
+	m_bMonoMode[nTG]= mono != 0; 
 	m_pTG[nTG]->setMonoMode(constrain(mono, 0, 1));
 	m_pTG[nTG]->doRefreshVoice();
 	m_UI.ParameterChanged ();
@@ -1331,7 +1333,7 @@ void CMiniDexed::LoadPerformanceParameters(void)
 			uint8_t* tVoiceData = m_PerformanceConfig.GetVoiceDataFromTxt(nTG);
 			m_pTG[nTG]->loadVoiceParameters(tVoiceData); 
 			}
-			
+			setMonoMode(m_PerformanceConfig.GetMonoMode(nTG) ? 1 : 0, nTG); 
 			SetReverbSend (m_PerformanceConfig.GetReverbSend (nTG), nTG);
 		
 		}

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -190,6 +190,10 @@ bool CMiniDexed::Initialize (void)
 		m_pTG[i]->setPBController (2, 0);
 		m_pTG[i]->setMWController (99, 1, 0); 
 
+		m_pTG[i]->setFCController (99, 1, 0); 
+		m_pTG[i]->setBCController (99, 1, 0);
+		m_pTG[i]->setATController (99, 1, 0);
+		
 		tg_mixer->pan(i,mapfloat(m_nPan[i],0,127,0.0f,1.0f));
 		tg_mixer->gain(i,1.0f);
 		reverb_send_mixer->pan(i,mapfloat(m_nPan[i],0,127,0.0f,1.0f));
@@ -578,6 +582,28 @@ void CMiniDexed::setModWheel (uint8_t value, unsigned nTG)
 	assert (nTG < CConfig::ToneGenerators);
 	assert (m_pTG[nTG]);
 	m_pTG[nTG]->setModWheel (value);
+}
+
+
+void CMiniDexed::setFootController (uint8_t value, unsigned nTG)
+{
+	assert (nTG < CConfig::ToneGenerators);
+	assert (m_pTG[nTG]);
+	m_pTG[nTG]->setFootController (value);
+}
+
+void CMiniDexed::setBreathController (uint8_t value, unsigned nTG)
+{
+	assert (nTG < CConfig::ToneGenerators);
+	assert (m_pTG[nTG]);
+	m_pTG[nTG]->setBreathController (value);
+}
+
+void CMiniDexed::setAftertouch (uint8_t value, unsigned nTG)
+{
+	assert (nTG < CConfig::ToneGenerators);
+	assert (m_pTG[nTG]);
+	m_pTG[nTG]->setAftertouch (value);
 }
 
 void CMiniDexed::setPitchbend (int16_t value, unsigned nTG)

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -268,6 +268,13 @@ void CMiniDexed::Process (bool bPlugAndPlayUpdated)
 		DoSetNewPerformance ();
 		m_bSetNewPerformance = false;
 	}
+	// %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+	if(m_bDeletePerformance)
+	{
+		DoDeletePerformance ();
+		m_bDeletePerformance = false;
+	}
+	// %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	
 	if (m_bProfileEnabled)
 	{
@@ -1244,6 +1251,7 @@ void CMiniDexed::SetActualPerformanceID(unsigned nID)
 	m_PerformanceConfig.SetActualPerformanceID(nID);
 }
 
+/* %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%5
 unsigned CMiniDexed::GetMenuSelectedPerformanceID()
 {
 	return m_PerformanceConfig.GetMenuSelectedPerformanceID();
@@ -1253,7 +1261,8 @@ void CMiniDexed::SetMenuSelectedPerformanceID(unsigned nID)
 {
 	m_PerformanceConfig.SetMenuSelectedPerformanceID(nID);
 }
-
+/* 
+//  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%5
 
 bool CMiniDexed::SetNewPerformance(unsigned nID)
 {
@@ -1288,7 +1297,7 @@ bool CMiniDexed::SavePerformanceNewFile ()
 
 bool CMiniDexed::DoSavePerformanceNewFile (void)
 {
-	std::string nPerformanceName=""; // for future enhacements: capability to write performance name
+	std::string nPerformanceName=""; // for future enhacements: capability to write performance name - %%%%%%%%%%%%%%%5 Not implemented delete and modify CreateNewPerformanceFile
 	if (m_PerformanceConfig.CreateNewPerformanceFile(nPerformanceName))
 	{
 		if(SavePerformance())
@@ -1351,4 +1360,52 @@ void CMiniDexed::LoadPerformanceParameters(void)
 		SetParameter (ParameterReverbDiffusion, m_PerformanceConfig.GetReverbDiffusion ());
 		SetParameter (ParameterReverbLevel, m_PerformanceConfig.GetReverbLevel ());
 }
+
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%Name
+std::string CMiniDexed::GetNewPerformanceDefaultName(void)	
+{
+	return m_PerformanceConfig.GetNewPerformanceDefaultName();
+}
+
+void CMiniDexed::SetNewPerformanceName(std::string nName)
+{
+	m_PerformanceConfig.SetNewPerformanceName(nName);
+}
+
+void CMiniDexed::SetVoiceName (std::string VoiceName, unsigned nTG)
+{
+	assert (nTG < CConfig::ToneGenerators);
+	assert (m_pTG[nTG]);
+	char Name[10];
+	strncpy(Name, VoiceName.c_str(),10);
+	m_pTG[nTG]->getName (Name);
+}
+
+bool CMiniDexed::DeletePerformance(unsigned nID)
+{
+	m_bDeletePerformance = true;
+	m_nDeletePerformanceID = nID;
+
+	return true;
+}
+
+bool CMiniDexed::DoDeletePerformance(void)
+{
+	unsigned nID = m_nDeletePerformanceID;
+	if(m_PerformanceConfig.DeletePerformance(nID))
+	{
+		if (m_PerformanceConfig.Load ())
+		{
+			LoadPerformanceParameters();
+			return true;
+		}
+		else
+		{
+			SetMIDIChannel (CMIDIDevice::OmniMode, 0);
+		}
+	}
+	
+	return false;
+}
+
 

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -268,14 +268,13 @@ void CMiniDexed::Process (bool bPlugAndPlayUpdated)
 		DoSetNewPerformance ();
 		m_bSetNewPerformance = false;
 	}
-	// %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+	
 	if(m_bDeletePerformance)
 	{
 		DoDeletePerformance ();
 		m_bDeletePerformance = false;
 	}
-	// %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-	
+		
 	if (m_bProfileEnabled)
 	{
 		m_GetChunkTimer.Dump ();
@@ -1251,19 +1250,6 @@ void CMiniDexed::SetActualPerformanceID(unsigned nID)
 	m_PerformanceConfig.SetActualPerformanceID(nID);
 }
 
-/* %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%5
-unsigned CMiniDexed::GetMenuSelectedPerformanceID()
-{
-	return m_PerformanceConfig.GetMenuSelectedPerformanceID();
-}
-
-void CMiniDexed::SetMenuSelectedPerformanceID(unsigned nID)
-{
-	m_PerformanceConfig.SetMenuSelectedPerformanceID(nID);
-}
-*/ 
-//  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%5
-
 bool CMiniDexed::SetNewPerformance(unsigned nID)
 {
 	m_bSetNewPerformance = true;
@@ -1297,7 +1283,7 @@ bool CMiniDexed::SavePerformanceNewFile ()
 
 bool CMiniDexed::DoSavePerformanceNewFile (void)
 {
-	std::string nPerformanceName=""; // for future enhacements: capability to write performance name - %%%%%%%%%%%%%%%5 Not implemented delete and modify CreateNewPerformanceFile
+	std::string nPerformanceName=""; // for future enhacements: capability to write performance name - Not implemented, delete and modify CreateNewPerformanceFile(Name) to CreateNewPerformanceFile(void)
 	if (m_PerformanceConfig.CreateNewPerformanceFile(nPerformanceName))
 	{
 		if(SavePerformance())
@@ -1361,7 +1347,6 @@ void CMiniDexed::LoadPerformanceParameters(void)
 		SetParameter (ParameterReverbLevel, m_PerformanceConfig.GetReverbLevel ());
 }
 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%Name
 std::string CMiniDexed::GetNewPerformanceDefaultName(void)	
 {
 	return m_PerformanceConfig.GetNewPerformanceDefaultName();

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -102,6 +102,9 @@ public:
 	void setVoiceDataElement(uint8_t data, uint8_t number, uint8_t nTG);
 	void getSysExVoiceDump(uint8_t* dest, uint8_t nTG);
 
+	void setModController (unsigned controller, unsigned parameter, uint8_t value, uint8_t nTG);
+	unsigned getModController (unsigned controller, unsigned parameter, uint8_t nTG);
+
 	int16_t checkSystemExclusive(const uint8_t* pMessage, const uint16_t nLength, uint8_t nTG);
 
 	std::string GetPerformanceFileName(unsigned nID);
@@ -156,6 +159,27 @@ public:
 		TGParameterPortamentoGlissando,
 		TGParameterPortamentoTime,
 		TGParameterMonoMode,  
+				
+		TGParameterMWRange,
+		TGParameterMWPitch,
+		TGParameterMWAmplitude,
+		TGParameterMWEGBias,
+		
+		TGParameterFCRange,
+		TGParameterFCPitch,
+		TGParameterFCAmplitude,
+		TGParameterFCEGBias,
+		
+		TGParameterBCRange,
+		TGParameterBCPitch,
+		TGParameterBCAmplitude,
+		TGParameterBCEGBias,
+		
+		TGParameterATRange,
+		TGParameterATPitch,
+		TGParameterATAmplitude,
+		TGParameterATEGBias,
+		
 		TGParameterUnknown
 	};
 
@@ -212,7 +236,16 @@ private:
 	unsigned m_nPortamentoGlissando[CConfig::ToneGenerators];	
 	unsigned m_nPortamentoTime[CConfig::ToneGenerators];	
 	bool m_bMonoMode[CConfig::ToneGenerators]; 
-	
+				
+	unsigned m_nModulationWheelRange[CConfig::ToneGenerators];
+	unsigned m_nModulationWheelTarget[CConfig::ToneGenerators];
+	unsigned m_nFootControlRange[CConfig::ToneGenerators];
+	unsigned m_nFootControlTarget[CConfig::ToneGenerators];
+	unsigned m_nBreathControlRange[CConfig::ToneGenerators];	
+	unsigned m_nBreathControlTarget[CConfig::ToneGenerators];	
+	unsigned m_nAftertouchRange[CConfig::ToneGenerators];	
+	unsigned m_nAftertouchTarget[CConfig::ToneGenerators];
+		
 	unsigned m_nNoteLimitLow[CConfig::ToneGenerators];
 	unsigned m_nNoteLimitHigh[CConfig::ToneGenerators];
 	int m_nNoteShift[CConfig::ToneGenerators];

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -114,6 +114,8 @@ public:
 	
 	bool DoSavePerformanceNewFile (void);
 	bool DoSetNewPerformance (void);
+	bool GetPerformanceSelectToLoad(void);
+	bool SavePerformance (bool bSaveAsDeault);
 	
 	enum TParameter
 	{
@@ -259,6 +261,8 @@ private:
 	CSpinLock m_ReverbSpinLock;
 
 	bool m_bSavePerformance;
+	bool m_bLoadPerformanceBusy;
+	bool m_bSaveAsDeault;
 };
 
 #endif

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -153,6 +153,7 @@ public:
 		TGParameterPortamentoMode,
 		TGParameterPortamentoGlissando,
 		TGParameterPortamentoTime,
+		TGParameterMonoMode,  
 		TGParameterUnknown
 	};
 
@@ -208,7 +209,8 @@ private:
 	unsigned m_nPortamentoMode[CConfig::ToneGenerators];	
 	unsigned m_nPortamentoGlissando[CConfig::ToneGenerators];	
 	unsigned m_nPortamentoTime[CConfig::ToneGenerators];	
-
+	bool m_bMonoMode[CConfig::ToneGenerators]; 
+	
 	unsigned m_nNoteLimitLow[CConfig::ToneGenerators];
 	unsigned m_nNoteLimitHigh[CConfig::ToneGenerators];
 	int m_nNoteShift[CConfig::ToneGenerators];

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -111,8 +111,6 @@ public:
 	void SetActualPerformanceID(unsigned nID);
 	bool SetNewPerformance(unsigned nID);
 	bool SavePerformanceNewFile ();
-	// unsigned GetMenuSelectedPerformanceID(); %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-	// void SetMenuSelectedPerformanceID(unsigned nID); %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	
 	bool DoSavePerformanceNewFile (void);
 	bool DoSetNewPerformance (void);
@@ -132,13 +130,13 @@ public:
 
 	void SetParameter (TParameter Parameter, int nValue);
 	int GetParameter (TParameter Parameter);
-	//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 	std::string GetNewPerformanceDefaultName(void);
 	void SetNewPerformanceName(std::string nName);
 	void SetVoiceName (std::string VoiceName, unsigned nTG);
 	bool DeletePerformance(unsigned nID);
 	bool DoDeletePerformance(void);
-	//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 	enum TTGParameter
 	{
 		TGParameterVoiceBank,
@@ -226,10 +224,8 @@ private:
 	
 	float32_t nMasterVolume;
 
-	//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	bool	m_bDeletePerformance;
 	unsigned m_nDeletePerformanceID;
-	//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 	CUserInterface m_UI;
 	CSysExFileLoader m_SysExFileLoader;

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -82,6 +82,10 @@ public:
 	void setPitchbend (int16_t value, unsigned nTG);
 	void ControllersRefresh (unsigned nTG);
 
+	void setFootController (uint8_t value, unsigned nTG);
+	void setBreathController (uint8_t value, unsigned nTG);
+	void setAftertouch (uint8_t value, unsigned nTG);
+
 	void SetReverbSend (unsigned nReverbSend, unsigned nTG);			// 0 .. 127
 
 	void setMonoMode(uint8_t mono, uint8_t nTG);

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -111,8 +111,8 @@ public:
 	void SetActualPerformanceID(unsigned nID);
 	bool SetNewPerformance(unsigned nID);
 	bool SavePerformanceNewFile ();
-	unsigned GetMenuSelectedPerformanceID();
-	void SetMenuSelectedPerformanceID(unsigned nID);
+	// unsigned GetMenuSelectedPerformanceID(); %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+	// void SetMenuSelectedPerformanceID(unsigned nID); %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	
 	bool DoSavePerformanceNewFile (void);
 	bool DoSetNewPerformance (void);
@@ -132,7 +132,13 @@ public:
 
 	void SetParameter (TParameter Parameter, int nValue);
 	int GetParameter (TParameter Parameter);
-
+	//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+	std::string GetNewPerformanceDefaultName(void);
+	void SetNewPerformanceName(std::string nName);
+	void SetVoiceName (std::string VoiceName, unsigned nTG);
+	bool DeletePerformance(unsigned nID);
+	bool DoDeletePerformance(void);
+	//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	enum TTGParameter
 	{
 		TGParameterVoiceBank,
@@ -220,7 +226,10 @@ private:
 	
 	float32_t nMasterVolume;
 
-
+	//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+	bool	m_bDeletePerformance;
+	unsigned m_nDeletePerformanceID;
+	//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 	CUserInterface m_UI;
 	CSysExFileLoader m_SysExFileLoader;

--- a/src/minidexed.ini
+++ b/src/minidexed.ini
@@ -36,3 +36,6 @@ EncoderPinSwitch=11
 # Debug
 MIDIDumpEnabled=0
 ProfileEnabled=0
+
+# Performance
+PerformanceSelectToLoad=1

--- a/src/performance.ini
+++ b/src/performance.ini
@@ -22,6 +22,14 @@
 #PortamentoTime#=0 # 0 .. 99
 #VoiceData#= # space separated hex numbers of 156 voice parameters. Example: 5F 1D 14 32 63 [....] 20 55 
 #MonoMode#=0 # 0-off .. 1-On
+#ModulationWheelRange#=99 # 0..99
+#ModulationWheelTarget#=1 # 0..7
+#FootControlRange#=99 # 0..99
+#FootControlTarget#=0 # 0..7
+#BreathControlRange#=99 # 0..99
+#BreathControlTarget#=0 # 0..7
+#AftertouchRange#=99 # 0..99
+#AftertouchTarget#=0 # 0..7
 
 # TG1
 BankNumber1=0
@@ -43,6 +51,14 @@ PortamentoGlissando1=0
 PortamentoTime1=0
 VoiceData1=
 MonoMode1=0 
+ModulationWheelRange1=99
+ModulationWheelTarget1=1 
+FootControlRange1=99 
+FootControlTarget1=0 
+BreathControlRange1=99 
+BreathControlTarget1=0 
+AftertouchRange1=99 
+AftertouchTarget1=0 
 
 # TG2
 BankNumber2=0
@@ -64,6 +80,14 @@ PortamentoGlissando2=0
 PortamentoTime2=0
 VoiceData2=
 MonoMode2=0 
+ModulationWheelRange2=99
+ModulationWheelTarget2=1 
+FootControlRange2=99 
+FootControlTarget2=0 
+BreathControlRange2=99 
+BreathControlTarget2=0 
+AftertouchRange2=99 
+AftertouchTarget2=0 
 
 # TG3
 BankNumber3=0
@@ -85,6 +109,14 @@ PortamentoGlissando3=0
 PortamentoTime3=0
 VoiceData3=
 MonoMode3=0 
+ModulationWheelRange3=99
+ModulationWheelTarget3=1 
+FootControlRange3=99 
+FootControlTarget3=0 
+BreathControlRange3=99 
+BreathControlTarget3=0 
+AftertouchRange3=99 
+AftertouchTarget3=0 
 
 # TG4
 BankNumber4=0
@@ -106,6 +138,14 @@ PortamentoGlissando4=0
 PortamentoTime4=0
 VoiceData4=
 MonoMode4=0 
+ModulationWheelRange4=99
+ModulationWheelTarget4=1 
+FootControlRange4=99 
+FootControlTarget4=0 
+BreathControlRange4=99 
+BreathControlTarget4=0 
+AftertouchRange4=99 
+AftertouchTarget4=0 
 
 # TG5
 BankNumber5=0
@@ -127,6 +167,14 @@ PortamentoGlissando5=0
 PortamentoTime5=0
 VoiceData5=
 MonoMode5=0 
+ModulationWheelRange5=99
+ModulationWheelTarget5=1 
+FootControlRange5=99 
+FootControlTarget5=0 
+BreathControlRange5=99 
+BreathControlTarget5=0 
+AftertouchRange5=99 
+AftertouchTarget5=0 
 
 # TG6
 BankNumber6=0
@@ -148,6 +196,14 @@ PortamentoGlissando6=0
 PortamentoTime6=0
 VoiceData6=
 MonoMode6=0 
+ModulationWheelRange6=99
+ModulationWheelTarget6=1 
+FootControlRange6=99 
+FootControlTarget6=0 
+BreathControlRange6=99 
+BreathControlTarget6=0 
+AftertouchRange6=99 
+AftertouchTarget6=0 
 
 # TG7
 BankNumber7=0
@@ -169,6 +225,14 @@ PortamentoGlissando7=0
 PortamentoTime7=0
 VoiceData7=
 MonoMode7=0 
+ModulationWheelRange7=99
+ModulationWheelTarget7=1 
+FootControlRange7=99 
+FootControlTarget7=0 
+BreathControlRange7=99 
+BreathControlTarget7=0 
+AftertouchRange7=99 
+AftertouchTarget7=0 
 
 # TG8
 BankNumber8=0
@@ -190,6 +254,14 @@ PortamentoGlissando8=0
 PortamentoTime8=0
 VoiceData8=
 MonoMode8=0 
+ModulationWheelRange8=99
+ModulationWheelTarget8=1 
+FootControlRange8=99 
+FootControlTarget8=0 
+BreathControlRange8=99 
+BreathControlTarget8=0 
+AftertouchRange8=99 
+AftertouchTarget8=0 
 
 # Effects
 #CompressorEnable=1	# 0: off, 1: on

--- a/src/performance.ini
+++ b/src/performance.ini
@@ -21,6 +21,7 @@
 #PortamentoGlissando#=0 # 0 .. 1
 #PortamentoTime#=0 # 0 .. 99
 #VoiceData#= # space separated hex numbers of 156 voice parameters. Example: 5F 1D 14 32 63 [....] 20 55 
+#MonoMode#=0 # 0-off .. 1-On
 
 # TG1
 BankNumber1=0
@@ -41,6 +42,7 @@ PortamentoMode1=0
 PortamentoGlissando1=0
 PortamentoTime1=0
 VoiceData1=
+MonoMode1=0 
 
 # TG2
 BankNumber2=0
@@ -61,6 +63,7 @@ PortamentoMode2=0
 PortamentoGlissando2=0
 PortamentoTime2=0
 VoiceData2=
+MonoMode2=0 
 
 # TG3
 BankNumber3=0
@@ -81,6 +84,7 @@ PortamentoMode3=0
 PortamentoGlissando3=0
 PortamentoTime3=0
 VoiceData3=
+MonoMode3=0 
 
 # TG4
 BankNumber4=0
@@ -101,6 +105,7 @@ PortamentoMode4=0
 PortamentoGlissando4=0
 PortamentoTime4=0
 VoiceData4=
+MonoMode4=0 
 
 # TG5
 BankNumber5=0
@@ -121,6 +126,7 @@ PortamentoMode5=0
 PortamentoGlissando5=0
 PortamentoTime5=0
 VoiceData5=
+MonoMode5=0 
 
 # TG6
 BankNumber6=0
@@ -141,6 +147,7 @@ PortamentoMode6=0
 PortamentoGlissando6=0
 PortamentoTime6=0
 VoiceData6=
+MonoMode6=0 
 
 # TG7
 BankNumber7=0
@@ -161,6 +168,7 @@ PortamentoMode7=0
 PortamentoGlissando7=0
 PortamentoTime7=0
 VoiceData7=
+MonoMode7=0 
 
 # TG8
 BankNumber8=0
@@ -181,6 +189,7 @@ PortamentoMode8=0
 PortamentoGlissando8=0
 PortamentoTime8=0
 VoiceData8=
+MonoMode8=0 
 
 # Effects
 #CompressorEnable=1	# 0: off, 1: on

--- a/src/performanceconfig.cpp
+++ b/src/performanceconfig.cpp
@@ -579,6 +579,7 @@ void CPerformanceConfig::SetActualPerformanceID(unsigned nID)
 	nActualPerformance = nID;
 }
 
+/* %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% have to be deleted
 unsigned CPerformanceConfig::GetMenuSelectedPerformanceID()
 {
 	return nMenuSelectedPerformance;
@@ -588,6 +589,8 @@ void CPerformanceConfig::SetMenuSelectedPerformanceID(unsigned nID)
 {
 	nMenuSelectedPerformance = nID;
 }
+*/ 
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% have to be deleted
 
 bool CPerformanceConfig::GetInternalFolderOk()
 {
@@ -597,7 +600,8 @@ bool CPerformanceConfig::GetInternalFolderOk()
 bool CPerformanceConfig::CreateNewPerformanceFile(std::string sPerformanceName)
 {
 	// sPerformanceName for future improvements when user can enter a name via UI
-	
+	sPerformanceName = NewPerformanceName; //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+	NewPerformanceName=""; //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	nActualPerformance=nLastPerformance;
 	std::string nFileName;
 	std::string nPath;
@@ -697,7 +701,7 @@ bool CPerformanceConfig::ListPerformances()
 		// sort by performance number-name
 		if (nLastPerformance > 2)
 		{
-		sort (m_nPerformanceFileName+1, m_nPerformanceFileName + nLastPerformance - 1); // default is always on first place. 
+		sort (m_nPerformanceFileName+1, m_nPerformanceFileName + nLastPerformance); // default is always on first place. %%%%%%%%%%%%%%%%
 		}
 	}
 	
@@ -717,4 +721,57 @@ void CPerformanceConfig::SetNewPerformance (unsigned nID)
 		FileN += m_nPerformanceFileName[nID];
 		new (&m_Properties) CPropertiesFatFsFile(FileN.c_str(), m_pFileSystem);
 		
+}
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%55
+
+std::string CPerformanceConfig::GetNewPerformanceDefaultName(void)
+{
+	std::string nIndex = "000000";
+	nIndex += std::to_string(nLastFileIndex+1);
+	nIndex = nIndex.substr(nIndex.length()-6,6);
+	return "Perf" + nIndex;
+}
+
+void CPerformanceConfig::SetNewPerformanceName(std::string nName)
+{
+	int  i = nName.length();
+	do
+	{
+		--i;
+	}
+	while (i>=0 && nName[i] == 32);
+	nName=nName.substr(0,i+1)  ;
+	
+	NewPerformanceName = nName;
+}
+
+bool CPerformanceConfig::DeletePerformance(unsigned nID)
+{
+	bool bOK = false;
+	if(nID == 0){return bOK;} // default (performance.ini at root directory) can't be deleted
+	DIR Directory;
+	FILINFO FileInfo;
+	std::string FileN = "SD:/";
+	FileN += PERFORMANCE_DIR;
+
+	
+	FRESULT Result = f_findfirst (&Directory, &FileInfo, FileN.c_str(), m_nPerformanceFileName[nID].c_str());
+	if (Result == FR_OK && FileInfo.fname[0])
+	{
+		FileN += "/";
+		FileN += m_nPerformanceFileName[nID];
+		Result=f_unlink (FileN.c_str());
+		if (Result == FR_OK)
+		{
+			SetNewPerformance(0);
+			nActualPerformance =0;
+			//nMenuSelectedPerformance=0;
+			m_nPerformanceFileName[nID]="ZZZZZZ";
+			sort (m_nPerformanceFileName+1, m_nPerformanceFileName + nLastPerformance); // test si va con -1 o no
+			--nLastPerformance;
+			m_nPerformanceFileName[nLastPerformance]=nullptr;
+			bOK=true;
+		}
+	}
+	return bOK;
 }

--- a/src/performanceconfig.cpp
+++ b/src/performanceconfig.cpp
@@ -127,7 +127,7 @@ bool CPerformanceConfig::Load (void)
 		m_nModulationWheelRange[nTG] = m_Properties.GetNumber (PropertyName, 99); 
 		
 		PropertyName.Format ("ModulationWheelTarget%u", nTG+1);
-		m_nModulationWheelTarget[nTG] = m_Properties.GetNumber (PropertyName, 7);
+		m_nModulationWheelTarget[nTG] = m_Properties.GetNumber (PropertyName, 1);
 		
 		PropertyName.Format ("FootControlRange%u", nTG+1);
 		m_nFootControlRange[nTG] = m_Properties.GetNumber (PropertyName, 99); 

--- a/src/performanceconfig.cpp
+++ b/src/performanceconfig.cpp
@@ -579,29 +579,15 @@ void CPerformanceConfig::SetActualPerformanceID(unsigned nID)
 	nActualPerformance = nID;
 }
 
-/* %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% have to be deleted
-unsigned CPerformanceConfig::GetMenuSelectedPerformanceID()
-{
-	return nMenuSelectedPerformance;
-}
-
-void CPerformanceConfig::SetMenuSelectedPerformanceID(unsigned nID)
-{
-	nMenuSelectedPerformance = nID;
-}
-*/ 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% have to be deleted
-
 bool CPerformanceConfig::GetInternalFolderOk()
 {
 	return nInternalFolderOk;
 }
 
-bool CPerformanceConfig::CreateNewPerformanceFile(std::string sPerformanceName)
+bool CPerformanceConfig::CreateNewPerformanceFile(void)
 {
-	// sPerformanceName for future improvements when user can enter a name via UI
-	sPerformanceName = NewPerformanceName; //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-	NewPerformanceName=""; //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+	std::string sPerformanceName = NewPerformanceName;
+	NewPerformanceName=""; 
 	nActualPerformance=nLastPerformance;
 	std::string nFileName;
 	std::string nPath;
@@ -722,7 +708,6 @@ void CPerformanceConfig::SetNewPerformance (unsigned nID)
 		new (&m_Properties) CPropertiesFatFsFile(FileN.c_str(), m_pFileSystem);
 		
 }
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%55
 
 std::string CPerformanceConfig::GetNewPerformanceDefaultName(void)
 {

--- a/src/performanceconfig.cpp
+++ b/src/performanceconfig.cpp
@@ -119,6 +119,10 @@ bool CPerformanceConfig::Load (void)
 		
 		PropertyName.Format ("VoiceData%u", nTG+1); 
 		m_nVoiceDataTxt[nTG] = m_Properties.GetString (PropertyName, "");
+		
+		PropertyName.Format ("MonoMode%u", nTG+1);
+		m_bMonoMode[nTG] = m_Properties.GetNumber (PropertyName, 0) != 0;
+		
 		}
 
 	m_bCompressorEnable = m_Properties.GetNumber ("CompressorEnable", 1) != 0;
@@ -209,6 +213,10 @@ bool CPerformanceConfig::Save (void)
 		PropertyName.Format ("VoiceData%u", nTG+1);
 		char *cstr = &m_nVoiceDataTxt[nTG][0];
 		m_Properties.SetString (PropertyName, cstr);
+		
+		PropertyName.Format ("MonoMode%u", nTG+1);
+		m_Properties.SetNumber (PropertyName, m_bMonoMode[nTG] ? 1 : 0);
+		
 		}
 
 	m_Properties.SetNumber ("CompressorEnable", m_bCompressorEnable ? 1 : 0);
@@ -510,6 +518,17 @@ unsigned CPerformanceConfig::GetPortamentoTime (unsigned nTG) const
 {
 	assert (nTG < CConfig::ToneGenerators);
 	return m_nPortamentoTime[nTG];
+}
+
+void CPerformanceConfig::SetMonoMode (bool bValue, unsigned nTG)
+{
+	assert (nTG < CConfig::ToneGenerators);
+	m_bMonoMode[nTG] = bValue;
+}
+
+bool CPerformanceConfig::GetMonoMode (unsigned nTG) const
+{
+	return m_bMonoMode[nTG];
 }
 
 void CPerformanceConfig::SetVoiceDataToTxt (const uint8_t *pData, unsigned nTG)  

--- a/src/performanceconfig.cpp
+++ b/src/performanceconfig.cpp
@@ -122,6 +122,30 @@ bool CPerformanceConfig::Load (void)
 		
 		PropertyName.Format ("MonoMode%u", nTG+1);
 		m_bMonoMode[nTG] = m_Properties.GetNumber (PropertyName, 0) != 0;
+				
+		PropertyName.Format ("ModulationWheelRange%u", nTG+1);
+		m_nModulationWheelRange[nTG] = m_Properties.GetNumber (PropertyName, 99); 
+		
+		PropertyName.Format ("ModulationWheelTarget%u", nTG+1);
+		m_nModulationWheelTarget[nTG] = m_Properties.GetNumber (PropertyName, 7);
+		
+		PropertyName.Format ("FootControlRange%u", nTG+1);
+		m_nFootControlRange[nTG] = m_Properties.GetNumber (PropertyName, 99); 
+		
+		PropertyName.Format ("FootControlTarget%u", nTG+1);
+		m_nFootControlTarget[nTG] = m_Properties.GetNumber (PropertyName, 0);
+		
+		PropertyName.Format ("BreathControlRange%u", nTG+1);
+		m_nBreathControlRange[nTG] = m_Properties.GetNumber (PropertyName, 99); 
+		
+		PropertyName.Format ("BreathControlTarget%u", nTG+1);
+		m_nBreathControlTarget[nTG] = m_Properties.GetNumber (PropertyName, 0);
+		
+		PropertyName.Format ("AftertouchRange%u", nTG+1);
+		m_nAftertouchRange[nTG] = m_Properties.GetNumber (PropertyName, 99); 
+		
+		PropertyName.Format ("AftertouchTarget%u", nTG+1);
+		m_nAftertouchTarget[nTG] = m_Properties.GetNumber (PropertyName, 0);
 		
 		}
 
@@ -216,7 +240,31 @@ bool CPerformanceConfig::Save (void)
 		
 		PropertyName.Format ("MonoMode%u", nTG+1);
 		m_Properties.SetNumber (PropertyName, m_bMonoMode[nTG] ? 1 : 0);
+				
+		PropertyName.Format ("ModulationWheelRange%u", nTG+1);
+		m_Properties.SetNumber (PropertyName, m_nModulationWheelRange[nTG]);
+	
+		PropertyName.Format ("ModulationWheelTarget%u", nTG+1);
+		m_Properties.SetNumber (PropertyName, m_nModulationWheelTarget[nTG]);	
+			
+		PropertyName.Format ("FootControlRange%u", nTG+1);
+		m_Properties.SetNumber (PropertyName, m_nFootControlRange[nTG]);	
 		
+		PropertyName.Format ("FootControlTarget%u", nTG+1);
+		m_Properties.SetNumber (PropertyName, m_nFootControlTarget[nTG]);	
+		
+		PropertyName.Format ("BreathControlRange%u", nTG+1);
+		m_Properties.SetNumber (PropertyName, m_nBreathControlRange[nTG]);	
+		
+		PropertyName.Format ("BreathControlTarget%u", nTG+1);
+		m_Properties.SetNumber (PropertyName, m_nBreathControlTarget[nTG]);	
+		
+		PropertyName.Format ("AftertouchRange%u", nTG+1);
+		m_Properties.SetNumber (PropertyName, m_nAftertouchRange[nTG]);	
+		
+		PropertyName.Format ("AftertouchTarget%u", nTG+1);
+		m_Properties.SetNumber (PropertyName, m_nAftertouchTarget[nTG]);			
+
 		}
 
 	m_Properties.SetNumber ("CompressorEnable", m_bCompressorEnable ? 1 : 0);
@@ -529,6 +577,102 @@ void CPerformanceConfig::SetMonoMode (bool bValue, unsigned nTG)
 bool CPerformanceConfig::GetMonoMode (unsigned nTG) const
 {
 	return m_bMonoMode[nTG];
+}
+
+void CPerformanceConfig::SetModulationWheelRange (unsigned nValue, unsigned nTG)
+{
+	assert (nTG < CConfig::ToneGenerators);
+	m_nModulationWheelRange[nTG] = nValue;
+}
+
+unsigned CPerformanceConfig::GetModulationWheelRange (unsigned nTG) const
+{
+	assert (nTG < CConfig::ToneGenerators);
+	return m_nModulationWheelRange[nTG];
+}
+
+void CPerformanceConfig::SetModulationWheelTarget (unsigned nValue, unsigned nTG)
+{
+	assert (nTG < CConfig::ToneGenerators);
+	m_nModulationWheelTarget[nTG] = nValue;
+}
+
+unsigned CPerformanceConfig::GetModulationWheelTarget (unsigned nTG) const
+{
+	assert (nTG < CConfig::ToneGenerators);
+	return m_nModulationWheelTarget[nTG];
+}
+
+void CPerformanceConfig::SetFootControlRange (unsigned nValue, unsigned nTG)
+{
+	assert (nTG < CConfig::ToneGenerators);
+	m_nFootControlRange[nTG] = nValue;
+}
+
+unsigned CPerformanceConfig::GetFootControlRange (unsigned nTG) const
+{
+	assert (nTG < CConfig::ToneGenerators);
+	return m_nFootControlRange[nTG];
+}
+
+void CPerformanceConfig::SetFootControlTarget (unsigned nValue, unsigned nTG)
+{
+	assert (nTG < CConfig::ToneGenerators);
+	m_nFootControlTarget[nTG] = nValue;
+}
+
+unsigned CPerformanceConfig::GetFootControlTarget (unsigned nTG) const
+{
+	assert (nTG < CConfig::ToneGenerators);
+	return m_nFootControlTarget[nTG];
+}
+
+void CPerformanceConfig::SetBreathControlRange (unsigned nValue, unsigned nTG)
+{
+	assert (nTG < CConfig::ToneGenerators);
+	m_nBreathControlRange[nTG] = nValue;
+}
+
+unsigned CPerformanceConfig::GetBreathControlRange (unsigned nTG) const
+{
+	assert (nTG < CConfig::ToneGenerators);
+	return m_nBreathControlRange[nTG];
+}
+
+void CPerformanceConfig::SetBreathControlTarget (unsigned nValue, unsigned nTG)
+{
+	assert (nTG < CConfig::ToneGenerators);
+	m_nBreathControlTarget[nTG] = nValue;
+}
+
+unsigned CPerformanceConfig::GetBreathControlTarget (unsigned nTG) const
+{
+	assert (nTG < CConfig::ToneGenerators);
+	return m_nBreathControlTarget[nTG];
+}
+
+void CPerformanceConfig::SetAftertouchRange (unsigned nValue, unsigned nTG)
+{
+	assert (nTG < CConfig::ToneGenerators);
+	m_nAftertouchRange[nTG] = nValue;
+}
+
+unsigned CPerformanceConfig::GetAftertouchRange (unsigned nTG) const
+{
+	assert (nTG < CConfig::ToneGenerators);
+	return m_nAftertouchRange[nTG];
+}
+
+void CPerformanceConfig::SetAftertouchTarget (unsigned nValue, unsigned nTG)
+{
+	assert (nTG < CConfig::ToneGenerators);
+	m_nAftertouchTarget[nTG] = nValue;
+}
+
+unsigned CPerformanceConfig::GetAftertouchTarget (unsigned nTG) const
+{
+	assert (nTG < CConfig::ToneGenerators);
+	return m_nAftertouchTarget[nTG];
 }
 
 void CPerformanceConfig::SetVoiceDataToTxt (const uint8_t *pData, unsigned nTG)  

--- a/src/performanceconfig.h
+++ b/src/performanceconfig.h
@@ -106,7 +106,7 @@ public:
 	unsigned GetLastPerformance();
 	void SetActualPerformanceID(unsigned nID);
 	unsigned GetActualPerformanceID();
-	bool CreateNewPerformanceFile(std::string sPerformanceName);
+	bool CreateNewPerformanceFile(void);
 	bool GetInternalFolderOk(); 
 	std::string GetNewPerformanceDefaultName(void);
 	void SetNewPerformanceName(std::string nName);

--- a/src/performanceconfig.h
+++ b/src/performanceconfig.h
@@ -106,11 +106,15 @@ public:
 	unsigned GetLastPerformance();
 	void SetActualPerformanceID(unsigned nID);
 	unsigned GetActualPerformanceID();
-	void SetMenuSelectedPerformanceID(unsigned nID);
-	unsigned GetMenuSelectedPerformanceID();
+	//void SetMenuSelectedPerformanceID(unsigned nID); %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%5 Deleted
+	//unsigned GetMenuSelectedPerformanceID(); %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%5 Deleted
 	bool CreateNewPerformanceFile(std::string sPerformanceName);
 	bool GetInternalFolderOk(); 
-
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+	std::string GetNewPerformanceDefaultName(void);
+	void SetNewPerformanceName(std::string nName);
+	bool DeletePerformance(unsigned nID);
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 private:
 	CPropertiesFatFsFile m_Properties;
 
@@ -136,13 +140,15 @@ private:
 	unsigned nLastPerformance;  
 	unsigned nLastFileIndex;
 	unsigned nActualPerformance = 0;  
-	unsigned nMenuSelectedPerformance = 0;
+	//unsigned nMenuSelectedPerformance = 0; %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	std::string m_nPerformanceFileName[40];
 	FATFS *m_pFileSystem; 
 
 	bool nInternalFolderOk=false;
 	bool nExternalFolderOk=false; // for future USB implementation
-
+// %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+	std::string NewPerformanceName="";
+// %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	bool m_bCompressorEnable;
 	bool m_bReverbEnable;
 	unsigned m_nReverbSize;

--- a/src/performanceconfig.h
+++ b/src/performanceconfig.h
@@ -106,15 +106,12 @@ public:
 	unsigned GetLastPerformance();
 	void SetActualPerformanceID(unsigned nID);
 	unsigned GetActualPerformanceID();
-	//void SetMenuSelectedPerformanceID(unsigned nID); %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%5 Deleted
-	//unsigned GetMenuSelectedPerformanceID(); %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%5 Deleted
 	bool CreateNewPerformanceFile(std::string sPerformanceName);
 	bool GetInternalFolderOk(); 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	std::string GetNewPerformanceDefaultName(void);
 	void SetNewPerformanceName(std::string nName);
 	bool DeletePerformance(unsigned nID);
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 private:
 	CPropertiesFatFsFile m_Properties;
 
@@ -140,15 +137,14 @@ private:
 	unsigned nLastPerformance;  
 	unsigned nLastFileIndex;
 	unsigned nActualPerformance = 0;  
-	//unsigned nMenuSelectedPerformance = 0; %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+	//unsigned nMenuSelectedPerformance = 0; 
 	std::string m_nPerformanceFileName[40];
 	FATFS *m_pFileSystem; 
 
 	bool nInternalFolderOk=false;
 	bool nExternalFolderOk=false; // for future USB implementation
-// %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	std::string NewPerformanceName="";
-// %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+	
 	bool m_bCompressorEnable;
 	bool m_bReverbEnable;
 	unsigned m_nReverbSize;

--- a/src/performanceconfig.h
+++ b/src/performanceconfig.h
@@ -59,6 +59,15 @@ public:
 	unsigned GetPortamentoTime (unsigned nTG) const;		// 0 .. 99
 	bool GetMonoMode (unsigned nTG) const; 				// 0 .. 1
 	
+	unsigned GetModulationWheelRange (unsigned nTG) const; // 0 .. 99
+	unsigned GetModulationWheelTarget (unsigned nTG) const; // 0 .. 7
+	unsigned GetFootControlRange (unsigned nTG) const; // 0 .. 99
+	unsigned GetFootControlTarget (unsigned nTG) const;  // 0 .. 7
+	unsigned GetBreathControlRange (unsigned nTG) const; // 0 .. 99
+	unsigned GetBreathControlTarget (unsigned nTG) const;  // 0 .. 7
+	unsigned GetAftertouchRange (unsigned nTG) const; // 0 .. 99
+	unsigned GetAftertouchTarget (unsigned nTG) const;  // 0 .. 7
+
 	void SetBankNumber (unsigned nValue, unsigned nTG);
 	void SetVoiceNumber (unsigned nValue, unsigned nTG);
 	void SetMIDIChannel (unsigned nValue, unsigned nTG);
@@ -79,7 +88,16 @@ public:
 	void SetVoiceDataToTxt (const uint8_t *pData, unsigned nTG); 
 	uint8_t *GetVoiceDataFromTxt (unsigned nTG);
 	void SetMonoMode (bool bOKValue, unsigned nTG); 
-	
+
+	void SetModulationWheelRange (unsigned nValue, unsigned nTG);
+	void SetModulationWheelTarget (unsigned nValue, unsigned nTG);
+	void SetFootControlRange (unsigned nValue, unsigned nTG);
+	void SetFootControlTarget (unsigned nValue, unsigned nTG);
+	void SetBreathControlRange (unsigned nValue, unsigned nTG);
+	void SetBreathControlTarget (unsigned nValue, unsigned nTG);
+	void SetAftertouchRange (unsigned nValue, unsigned nTG);
+	void SetAftertouchTarget (unsigned nValue, unsigned nTG);
+
 	// Effects
 	bool GetCompressorEnable (void) const;
 	bool GetReverbEnable (void) const;
@@ -136,7 +154,16 @@ private:
 	unsigned m_nPortamentoTime[CConfig::ToneGenerators];
 	std::string m_nVoiceDataTxt[CConfig::ToneGenerators]; 
 	bool m_bMonoMode[CConfig::ToneGenerators]; 
-	
+
+	unsigned m_nModulationWheelRange[CConfig::ToneGenerators];
+	unsigned m_nModulationWheelTarget[CConfig::ToneGenerators];
+	unsigned m_nFootControlRange[CConfig::ToneGenerators];	
+	unsigned m_nFootControlTarget[CConfig::ToneGenerators];	
+	unsigned m_nBreathControlRange[CConfig::ToneGenerators];	
+	unsigned m_nBreathControlTarget[CConfig::ToneGenerators];	
+	unsigned m_nAftertouchRange[CConfig::ToneGenerators];	
+	unsigned m_nAftertouchTarget[CConfig::ToneGenerators];	
+
 	unsigned nLastPerformance;  
 	unsigned nLastFileIndex;
 	unsigned nActualPerformance = 0;  

--- a/src/performanceconfig.h
+++ b/src/performanceconfig.h
@@ -57,6 +57,7 @@ public:
 	unsigned GetPortamentoMode (unsigned nTG) const;		// 0 .. 1
 	unsigned GetPortamentoGlissando (unsigned nTG) const;		// 0 .. 1
 	unsigned GetPortamentoTime (unsigned nTG) const;		// 0 .. 99
+	bool GetMonoMode (unsigned nTG) const; 				// 0 .. 1
 	
 	void SetBankNumber (unsigned nValue, unsigned nTG);
 	void SetVoiceNumber (unsigned nValue, unsigned nTG);
@@ -77,6 +78,7 @@ public:
 	void SetPortamentoTime (unsigned nValue, unsigned nTG);
 	void SetVoiceDataToTxt (const uint8_t *pData, unsigned nTG); 
 	uint8_t *GetVoiceDataFromTxt (unsigned nTG);
+	void SetMonoMode (bool bOKValue, unsigned nTG); 
 	
 	// Effects
 	bool GetCompressorEnable (void) const;
@@ -133,6 +135,7 @@ private:
 	unsigned m_nPortamentoGlissando[CConfig::ToneGenerators];
 	unsigned m_nPortamentoTime[CConfig::ToneGenerators];
 	std::string m_nVoiceDataTxt[CConfig::ToneGenerators]; 
+	bool m_bMonoMode[CConfig::ToneGenerators]; 
 	
 	unsigned nLastPerformance;  
 	unsigned nLastFileIndex;

--- a/src/serialmididevice.cpp
+++ b/src/serialmididevice.cpp
@@ -130,7 +130,8 @@ void CSerialMIDIDevice::Process (void)
 				m_SerialMessage[m_nSerialState++] = uchData;
 	
 				if (   (m_SerialMessage[0] & 0xE0) == 0xC0
-				    || m_nSerialState == 3)		// message is complete
+				    || m_nSerialState == 3		// message is complete
+				    || (m_SerialMessage[0] & 0xF0) == 0xD0)   // channel aftertouch
 				{
 					MIDIMessageHandler (m_SerialMessage, m_nSerialState);
 	

--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -144,7 +144,7 @@ const CUIMenu::TMenuItem CUIMenu::s_EditVoiceMenu[] =
 	{"LFO Wave",	EditVoiceParameter,	0,		DEXED_LFO_WAVE},
 	{"P Mod Sens.",	EditVoiceParameter,	0,		DEXED_LFO_PITCH_MOD_SENS},
 	{"Transpose",	EditVoiceParameter,	0,		DEXED_TRANSPOSE},
-	{"\E[?25lName",	InputTxt,0 , 3}, //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+	{"\E[?25lName",	InputTxt,0 , 3}, // escape code \E[?25l is for turnoff cursor
 	{0}
 };
 
@@ -178,7 +178,7 @@ const CUIMenu::TMenuItem CUIMenu::s_OperatorMenu[] =
 const CUIMenu::TMenuItem CUIMenu::s_SaveMenu[] =
 {
 	{"Overwrite",	SavePerformance}, 
-	{"\E[?25lNew",	InputTxt,0 , 1}, //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+	{"\E[?25lNew",	InputTxt,0 , 1}, // escape code \E[?25l is for turnoff cursor
 	{0}
 };
 
@@ -236,7 +236,7 @@ const CUIMenu::TParameter CUIMenu::s_VoiceParameter[] =
 	{0,	5,	1,	ToLFOWaveform},		// DEXED_LFO_WAVE
 	{0,	7,	1},				// DEXED_LFO_PITCH_MOD_SENS
 	{0,	48,	1,	ToTransposeNote},	// DEXED_TRANSPOSE
-	{0,	1,	1}				// Voice Name - Dummy parameters for in case new item would be added in future %%%%%%%%%%%%%%%%%%%%%%
+	{0,	1,	1}				// Voice Name - Dummy parameters for in case new item would be added in future 
 };
 
 // must match DexedVoiceOPParameters in Synth_Dexed
@@ -1090,7 +1090,6 @@ void CUIMenu::TimerHandler (TKernelTimerHandle hTimer, void *pParam, void *pCont
 	pThis->EventHandler (MenuEventBack);
 }
 
-// %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 void CUIMenu::TimerHandlerNoBack (TKernelTimerHandle hTimer, void *pParam, void *pContext)
 {
 	CUIMenu *pThis = static_cast<CUIMenu *> (pContext);
@@ -1101,7 +1100,7 @@ void CUIMenu::TimerHandlerNoBack (TKernelTimerHandle hTimer, void *pParam, void 
 	pThis->EventHandler (MenuEventUpdate);
 }
 
-void CUIMenu::PerformanceMenu (CUIMenu *pUIMenu, TMenuEvent Event) //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+void CUIMenu::PerformanceMenu (CUIMenu *pUIMenu, TMenuEvent Event)
 {
 	unsigned nValue = pUIMenu->m_nSelectedPerformanceID;
 	std::string Value;
@@ -1211,28 +1210,6 @@ void CUIMenu::PerformanceMenu (CUIMenu *pUIMenu, TMenuEvent Event) //%%%%%%%%%%%
 		pUIMenu->m_pUI->DisplayWrite ("", "Delete?", pUIMenu->m_bConfirmDeletePerformance ? "Yes" : "No", false, false);
 	}
 }
-/* %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%5 delete it
-void CUIMenu::SavePerformanceNewFile (CUIMenu *pUIMenu, TMenuEvent Event)
-{
-	if (Event != MenuEventUpdate)
-	{
-		return;
-	}
-
-	bool bOK = pUIMenu->m_pMiniDexed->SavePerformanceNewFile ();
-
-	const char *pMenuName =
-		pUIMenu->m_MenuStackParent[pUIMenu->m_nCurrentMenuDepth-1]
-			[pUIMenu->m_nMenuStackItem[pUIMenu->m_nCurrentMenuDepth-1]].Name;
-
-	pUIMenu->m_pUI->DisplayWrite (pMenuName,
-				      pUIMenu->m_pParentMenu[pUIMenu->m_nCurrentMenuItem].Name,
-				      bOK ? "Completed" : "Error",
-				      false, false);
-
-	CTimer::Get ()->StartKernelTimer (MSEC2HZ (1500), TimerHandler, 0, pUIMenu);
-}
-*/
 
 void CUIMenu::InputTxt (CUIMenu *pUIMenu, TMenuEvent Event)
 {
@@ -1336,7 +1313,7 @@ void CUIMenu::InputTxt (CUIMenu *pUIMenu, TMenuEvent Event)
 		
 		
 	case MenuEventSelect:	
-		if(pUIMenu->m_nCurrentParameter == 1 || pUIMenu->m_nCurrentParameter == 2)
+		if(pUIMenu->m_nCurrentParameter == 1)
 		{	
 			pUIMenu->m_pMiniDexed->SetNewPerformanceName(pUIMenu->m_InputText);
 			bOK = pUIMenu->m_pMiniDexed->SavePerformanceNewFile ();
@@ -1347,7 +1324,7 @@ void CUIMenu::InputTxt (CUIMenu *pUIMenu, TMenuEvent Event)
 		}
 		else
 		{
-			break;
+			break; // Voice Name Edit
 		}
 	
 	case MenuEventPressAndStepDown:
@@ -1377,7 +1354,7 @@ void CUIMenu::InputTxt (CUIMenu *pUIMenu, TMenuEvent Event)
 	// \E[?25h	Normal cursor visible
 	// \E[?25l	Cursor invisible
 	
-	std::string escCursor="\E[?25h\E[2;";
+	std::string escCursor="\E[?25h\E[2;"; // this is to locate cursor
 	escCursor += to_string(nPosition + 2);
 	escCursor += "H";
 	

--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -71,6 +71,7 @@ const CUIMenu::TMenuItem CUIMenu::s_TGMenu[] =
 	{"Resonance",	EditTGParameter,	0,	CMiniDexed::TGParameterResonance},
 	{"Pitch Bend",	MenuHandler,		s_EditPitchBendMenu},
 	{"Portamento",		MenuHandler,		s_EditPortamentoMenu},
+	{"Poly/Mono",		EditTGParameter,	0,	CMiniDexed::TGParameterMonoMode}, 
 	{"Channel",	EditTGParameter,	0,	CMiniDexed::TGParameterMIDIChannel},
 	{"Edit Voice",	MenuHandler,		s_EditVoiceMenu},
 	{0}
@@ -209,9 +210,10 @@ const CUIMenu::TParameter CUIMenu::s_TGParameter[CMiniDexed::TGParameterUnknown]
 	{0, 99, 1},								// TGParameterReverbSend
 	{0,	12,					1},			// TGParameterPitchBendRange
 	{0,	12,					1},			// TGParameterPitchBendStep
-	{0,	1,					1, ToPortaMode},			// TGParameterPortamentoMode
-	{0,	1,					1, ToPortaGlissando},			// TGParameterPortamentoGlissando
-	{0,	99,					1}			// TGParameterPortamentoTime
+	{0,	1,					1, ToPortaMode},	// TGParameterPortamentoMode
+	{0,	1,					1, ToPortaGlissando},	// TGParameterPortamentoGlissando
+	{0,	99,					1},			// TGParameterPortamentoTime
+	{0,	1,					1, ToPolyMono} 		// TGParameterMonoMode 
 };
 
 // must match DexedVoiceParameters in Synth_Dexed
@@ -1021,6 +1023,16 @@ string CUIMenu::ToPortaGlissando (int nValue)
 	default:	return to_string (nValue);
 	}
 };
+
+string CUIMenu::ToPolyMono (int nValue)
+{
+	switch (nValue)
+	{
+	case 0:		return "Poly";
+	case 1:		return "Mono";
+	default:	return to_string (nValue);
+	}
+}
 
 void CUIMenu::TGShortcutHandler (TMenuEvent Event)
 {

--- a/src/uimenu.h
+++ b/src/uimenu.h
@@ -112,7 +112,11 @@ private:
 	void OPShortcutHandler (TMenuEvent Event);
 
 	static void TimerHandler (TKernelTimerHandle hTimer, void *pParam, void *pContext);
-
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+	static void InputTxt (CUIMenu *pUIMenu, TMenuEvent Event);
+	static void TimerHandlerNoBack (TKernelTimerHandle hTimer, void *pParam, void *pContext);
+	 
+//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 private:
 	CUserInterface *m_pUI;
 	CMiniDexed *m_pMiniDexed;
@@ -147,6 +151,15 @@ private:
 	static const TParameter s_OPParameter[];
 
 	static const char s_NoteName[100][4];
+	//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%5
+	std::string m_InputText="1234567890ABCD";
+	unsigned m_InputTextPosition=0;
+	unsigned m_InputTextChar=32;
+	bool m_bPerformanceDeleteMode=false;
+	bool m_bConfirmDeletePerformance=false;
+	unsigned m_nSelectedPerformanceID =0;
+	bool m_bSplashShow=false;
+	//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%5
 };
 
 #endif

--- a/src/uimenu.h
+++ b/src/uimenu.h
@@ -52,7 +52,7 @@ public:
 	CUIMenu (CUserInterface *pUI, CMiniDexed *pMiniDexed);
 
 	void EventHandler (TMenuEvent Event);
-
+	
 private:
 	typedef void TMenuHandler (CUIMenu *pUIMenu, TMenuEvent Event);
 
@@ -144,6 +144,7 @@ private:
 	static const TMenuItem s_SaveMenu[];
 	static const TMenuItem s_EditPitchBendMenu[];
 	static const TMenuItem s_EditPortamentoMenu[];
+	static const TMenuItem s_PerformanceMenu[];
 		
 	static const TParameter s_GlobalParameter[];
 	static const TParameter s_TGParameter[];

--- a/src/uimenu.h
+++ b/src/uimenu.h
@@ -84,7 +84,7 @@ private:
 	static void EditOPParameter (CUIMenu *pUIMenu, TMenuEvent Event);
 	static void SavePerformance (CUIMenu *pUIMenu, TMenuEvent Event);
 	static void EditTGParameter2 (CUIMenu *pUIMenu, TMenuEvent Event);
-	
+	static void EditTGParameterModulation (CUIMenu *pUIMenu, TMenuEvent Event); 	
 	static void PerformanceMenu (CUIMenu *pUIMenu, TMenuEvent Event);
 	static void SavePerformanceNewFile (CUIMenu *pUIMenu, TMenuEvent Event);
 	
@@ -145,7 +145,10 @@ private:
 	static const TMenuItem s_EditPitchBendMenu[];
 	static const TMenuItem s_EditPortamentoMenu[];
 	static const TMenuItem s_PerformanceMenu[];
-		
+	
+	static const TMenuItem s_ModulationMenu[];
+	static const TMenuItem s_ModulationMenuParameters[];
+			
 	static const TParameter s_GlobalParameter[];
 	static const TParameter s_TGParameter[];
 	static const TParameter s_VoiceParameter[];

--- a/src/uimenu.h
+++ b/src/uimenu.h
@@ -112,11 +112,10 @@ private:
 	void OPShortcutHandler (TMenuEvent Event);
 
 	static void TimerHandler (TKernelTimerHandle hTimer, void *pParam, void *pContext);
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 	static void InputTxt (CUIMenu *pUIMenu, TMenuEvent Event);
 	static void TimerHandlerNoBack (TKernelTimerHandle hTimer, void *pParam, void *pContext);
 	 
-//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 private:
 	CUserInterface *m_pUI;
 	CMiniDexed *m_pMiniDexed;
@@ -151,7 +150,7 @@ private:
 	static const TParameter s_OPParameter[];
 
 	static const char s_NoteName[100][4];
-	//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%5
+
 	std::string m_InputText="1234567890ABCD";
 	unsigned m_InputTextPosition=0;
 	unsigned m_InputTextChar=32;
@@ -159,7 +158,7 @@ private:
 	bool m_bConfirmDeletePerformance=false;
 	unsigned m_nSelectedPerformanceID =0;
 	bool m_bSplashShow=false;
-	//%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%5
+
 };
 
 #endif

--- a/src/uimenu.h
+++ b/src/uimenu.h
@@ -107,6 +107,7 @@ private:
 	static std::string ToOscillatorDetune (int nValue);
 	static std::string ToPortaMode (int nValue);  
 	static std::string ToPortaGlissando (int nValue);   
+	static std::string ToPolyMono (int nValue);
 
 	void TGShortcutHandler (TMenuEvent Event);
 	void OPShortcutHandler (TMenuEvent Event);

--- a/src/userinterface.cpp
+++ b/src/userinterface.cpp
@@ -128,7 +128,7 @@ void CUserInterface::DisplayWrite (const char *pMenu, const char *pParam, const 
 	assert (pParam);
 	assert (pValue);
 
-	CString Msg ("\x1B[H");		// cursor home
+	CString Msg ("\x1B[H\E[?25l");		// cursor home and off
 
 	// first line
 	Msg.Append (pParam);


### PR DESCRIPTION
Hi @probonopd , in order to complement the swichable Performance solution, I have added these additional features to improve the usability of the solution:
-Custom defined new performance name: predefined Performance name can be modified. Characters are input by the rotary encoder, to move the cursor, hold down the encoder and turn right or left. Then just double click to confirm.
-Delete Performance files: This allows to delete perfomance files from the list. To do that, just double click on the already loaded performance and confirm yes or no. The default performance.ini file in the root directory can't be deleted.
-Change voice name: Edited voice can have a custom name (and will be saved on performance file).
-Some minor improvements on related Methods. 