### PR TITLE
Add call to set Serial options to prevent CR to CRLF conversion

### DIFF
--- a/src/serialmididevice.cpp
+++ b/src/serialmididevice.cpp
@@ -49,7 +49,12 @@ CSerialMIDIDevice::~CSerialMIDIDevice (void)
 boolean CSerialMIDIDevice::Initialize (void)
 {
 	assert (m_pConfig);
-	return m_Serial.Initialize (m_pConfig->GetMIDIBaudRate ());
+	boolean res = m_Serial.Initialize (m_pConfig->GetMIDIBaudRate ());
+	unsigned ser_options = m_Serial.GetOptions();
+	// Ensure CR->CRLF translation is disabled for MIDI links
+	ser_options &= ~(SERIAL_OPTION_ONLCR);
+	m_Serial.SetOptions(ser_options);
+	return res;
 }
 
 void CSerialMIDIDevice::Process (void)


### PR DESCRIPTION
Initial attempt at a fix for https://github.com/probonopd/MiniDexed/issues/282

Grateful if someone could review, test and advise...

Kevin