### PR TITLE
Initial support for SSD1306 128x32 or 128x64 OLED displays

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
            set -ex
            cd circle-stdlib/libs/circle
-           git checkout c9a4815 # develop
+           git checkout a8e8c9f # develop
            cd -
     - name: Install toolchains
       run: |

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -81,6 +81,13 @@ void CConfig::Load (void)
 	m_nLCDPinData7 = m_Properties.GetNumber ("LCDPinData7", 25);
 	m_nLCDI2CAddress = m_Properties.GetNumber ("LCDI2CAddress", 0);
 
+	m_nSSD1306LCDI2CAddress = m_Properties.GetNumber ("SSD1306LCDI2CAddress", 0);
+	m_nSSD1306LCDWidth = m_Properties.GetNumber ("SSD1306LCDWidth", 128);
+	m_nSSD1306LCDHeight = m_Properties.GetNumber ("SSD1306LCDHeight", 32);
+
+	m_nLCDColumns = m_Properties.GetNumber ("LCDColumns", 16);
+	m_nLCDRows = m_Properties.GetNumber ("LCDRows", 2);
+
 	m_nButtonPinPrev = m_Properties.GetNumber ("ButtonPinPrev", 0);
 	m_nButtonPinNext = m_Properties.GetNumber ("ButtonPinNext", 0);
 	m_nButtonPinBack = m_Properties.GetNumber ("ButtonPinBack", 11);
@@ -193,6 +200,31 @@ unsigned CConfig::GetLCDPinData7 (void) const
 unsigned CConfig::GetLCDI2CAddress (void) const
 {
 	return m_nLCDI2CAddress;
+}
+
+unsigned CConfig::GetSSD1306LCDI2CAddress (void) const
+{
+	return m_nSSD1306LCDI2CAddress;
+}
+
+unsigned CConfig::GetSSD1306LCDWidth (void) const
+{
+	return m_nSSD1306LCDWidth;
+}
+
+unsigned CConfig::GetSSD1306LCDHeight (void) const
+{
+	return m_nSSD1306LCDHeight;
+}
+
+unsigned CConfig::GetLCDColumns (void) const
+{
+	return m_nLCDColumns;
+}
+
+unsigned CConfig::GetLCDRows (void) const
+{
+	return m_nLCDRows;
 }
 
 unsigned CConfig::GetButtonPinPrev (void) const

--- a/src/config.h
+++ b/src/config.h
@@ -53,6 +53,7 @@ public:
 	static const unsigned MaxUSBMIDIDevices = 4;
 #endif
 
+	// TODO - Leave this for uimenu.cpp for now, but it will need to be dynamic at some point...
 	static const unsigned LCDColumns = 16;		// HD44780 LCD
 	static const unsigned LCDRows = 2;
 
@@ -88,6 +89,14 @@ public:
 	unsigned GetLCDPinData7 (void) const;
 	unsigned GetLCDI2CAddress (void) const;
 	
+	// SSD1306 LCD
+	unsigned GetSSD1306LCDI2CAddress (void) const;
+	unsigned GetSSD1306LCDWidth (void) const;
+	unsigned GetSSD1306LCDHeight (void) const;
+
+	unsigned GetLCDColumns (void) const;
+	unsigned GetLCDRows (void) const;
+
 	// GPIO Button Navigation
 	// GPIO pin numbers are chip numbers, not header positions
 	unsigned GetButtonPinPrev (void) const;
@@ -141,6 +150,13 @@ private:
 	unsigned m_nLCDPinData6;
 	unsigned m_nLCDPinData7;
 	unsigned m_nLCDI2CAddress;
+	
+	unsigned m_nSSD1306LCDI2CAddress;
+	unsigned m_nSSD1306LCDWidth;
+	unsigned m_nSSD1306LCDHeight;
+	
+	unsigned m_nLCDColumns;
+	unsigned m_nLCDRows;
 	
 	unsigned m_nButtonPinPrev;
 	unsigned m_nButtonPinNext;

--- a/src/minidexed.ini
+++ b/src/minidexed.ini
@@ -27,6 +27,17 @@ LCDPinData6=24
 LCDPinData7=25
 LCDI2CAddress=0x00
 
+# SSD1306 LCD
+# For a 128x32 display, set LCDColumns=20; LCDRows=2
+# For a 128x64 display, set LCDColumns=20; LCDRows=4
+SSD1306LCDI2CAddress=0x0
+SSD1306LCDWidth=128
+SSD1306LCDHeight=32
+
+# Default is 16x2 display (e.g. HD44780)
+LCDColumns=16
+LCDRows=2
+
 # GPIO Button Navigation
 #  Any buttons set to 0 will be ignored
 ButtonPinPrev=0

--- a/src/userinterface.h
+++ b/src/userinterface.h
@@ -25,6 +25,7 @@
 #include "uibuttons.h"
 #include <sensor/ky040.h>
 #include <display/hd44780device.h>
+#include <display/ssd1306device.h>
 #include <circle/gpiomanager.h>
 #include <circle/writebuffer.h>
 #include <circle/i2cmaster.h>
@@ -65,7 +66,9 @@ private:
 	CI2CMaster *m_pI2CMaster;
 	CConfig *m_pConfig;
 
-	CHD44780Device *m_pLCD;
+	CCharDevice    *m_pLCD;
+	CHD44780Device *m_pHD44780;
+	CSSD1306Device *m_pSSD1306;
 	CWriteBufferDevice *m_pLCDBuffered;
 	
 	CUIButtons *m_pUIButtons;


### PR DESCRIPTION
Initial support for SSD1306 OLED I2C displays. Note: This requires latest develop branch of Circle.

Submitted for experimentation and initial testing.  All comments welcome!

Kevin