### PR TITLE
Automatic bank jumping from voice menu

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -118,6 +118,7 @@ void CConfig::Load (void)
 	m_bMIDIDumpEnabled  = m_Properties.GetNumber ("MIDIDumpEnabled", 0) != 0;
 	m_bProfileEnabled = m_Properties.GetNumber ("ProfileEnabled", 0) != 0;
 	m_bPerformanceSelectToLoad = m_Properties.GetNumber ("PerformanceSelectToLoad", 1) != 0;
+	m_bAutoBankSkip = m_Properties.GetNumber ("AutoBankSkip", 1) != 0;
 }
 
 const char *CConfig::GetSoundDevice (void) const
@@ -358,4 +359,9 @@ bool CConfig::GetProfileEnabled (void) const
 bool CConfig::GetPerformanceSelectToLoad (void) const
 {
 	return m_bPerformanceSelectToLoad;
+}
+
+bool CConfig::GetAutoBankSkip (void) const
+{
+	return m_bAutoBankSkip;
 }

--- a/src/config.h
+++ b/src/config.h
@@ -137,6 +137,7 @@ public:
 	
 	// Load performance mode. 0 for load just rotating encoder, 1 load just when Select is pushed
 	bool GetPerformanceSelectToLoad (void) const;
+	bool GetAutoBankSkip (void) const;
 
 private:
 	CPropertiesFatFsFile m_Properties;
@@ -199,6 +200,7 @@ private:
 	bool m_bMIDIDumpEnabled;
 	bool m_bProfileEnabled;
 	bool m_bPerformanceSelectToLoad;
+	bool m_bAutoBankSkip;
 };
 
 #endif

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -1531,6 +1531,11 @@ bool CMiniDexed::GetPerformanceSelectToLoad(void)
 	return m_pConfig->GetPerformanceSelectToLoad();
 }
 
+bool CMiniDexed::GetAutoBankSkip(void)
+{
+	return m_pConfig->GetAutoBankSkip ();
+}
+
 void CMiniDexed::setModController (unsigned controller, unsigned parameter, uint8_t value, uint8_t nTG)
 {
 	 uint8_t nBits;

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -123,6 +123,7 @@ public:
 	bool DoSetNewPerformance (void);
 	bool GetPerformanceSelectToLoad(void);
 	bool SavePerformance (bool bSaveAsDeault);
+	bool GetAutoBankSkip(void);
 	
 	enum TParameter
 	{

--- a/src/minidexed.ini
+++ b/src/minidexed.ini
@@ -77,5 +77,8 @@ EncoderPinData=9
 MIDIDumpEnabled=0
 ProfileEnabled=0
 
+# Auto Bank Skipping
+AutoBankSkip=1
+
 # Performance
 PerformanceSelectToLoad=1

--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -540,6 +540,7 @@ void CUIMenu::EditProgramNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 	int nValue = pUIMenu->m_pMiniDexed->GetTGParameter (CMiniDexed::TGParameterProgram, nTG);
 	
 	bool bAutoBankSkip=true; 
+	
 	int nBankNumber = pUIMenu->m_pMiniDexed->GetTGParameter (CMiniDexed::TGParameterVoiceBank, nTG);
 	
 	switch (Event)

--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -553,7 +553,7 @@ void CUIMenu::EditProgramNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 		{
 			if(bAutoBankSkip && nBankNumber > 0)
 			{
-				pUIMenu->m_pMiniDexed->SetTGParameter (CMiniDexed::TGParameterVoiceBank, nBankNumber-1, nTG);
+				pUIMenu->m_pMiniDexed->SetTGParameter (CMiniDexed::TGParameterVoiceBank, --nBankNumber, nTG);
 				nValue=(int) CSysExFileLoader::VoicesPerBank-1;
 			}
 			else
@@ -569,8 +569,8 @@ void CUIMenu::EditProgramNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 		{
 			if(bAutoBankSkip && nBankNumber < (int) CSysExFileLoader::MaxVoiceBankID)
 			{
-				pUIMenu->m_pMiniDexed->SetTGParameter (CMiniDexed::TGParameterVoiceBank, nBankNumber+1, nTG);
-				nValue=(int) CSysExFileLoader::VoicesPerBank-1;	
+				pUIMenu->m_pMiniDexed->SetTGParameter (CMiniDexed::TGParameterVoiceBank, ++nBankNumber, nTG);
+				nValue=0;	
 			}
 			else
 			{
@@ -596,13 +596,13 @@ void CUIMenu::EditProgramNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 
 	if(bAutoBankSkip)
 	{
-	string uchBankName = "" + pUIMenu->m_pMiniDexed->GetSysExFileLoader ()->GetBankName (nBankNumber);
-	uchBankName = uchBankName.substr(0,11);
+	string uchBankName = pUIMenu->m_pMiniDexed->GetSysExFileLoader ()->GetBankName (nBankNumber);
+	uchBankName = uchBankName.substr(0,12);
 	
 	pUIMenu->m_pUI->DisplayWrite (TG.c_str (),
-				      uchBankName,
+				      uchBankName.c_str (),
 				      Value.c_str (),
-				      nValue > 0, nValue < (int) CSysExFileLoader::VoicesPerBank-1) && nBankNumber < (int) CSysExFileLoader::MaxVoiceBankID);	
+				      nValue > 0 || nBankNumber > 0, nValue < (int) CSysExFileLoader::VoicesPerBank-1 || nBankNumber < (int) CSysExFileLoader::MaxVoiceBankID);	
 	}
 	else
 	{

--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -539,7 +539,7 @@ void CUIMenu::EditProgramNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 
 	int nValue = pUIMenu->m_pMiniDexed->GetTGParameter (CMiniDexed::TGParameterProgram, nTG);
 	
-	bool bAutoBankSkip = pUIMenu->m_pMiniDexed-GetAutoBankSkip(); 
+	bool bAutoBankSkip = pUIMenu->m_pMiniDexed->GetAutoBankSkip(); 
 	
 	int nBankNumber = pUIMenu->m_pMiniDexed->GetTGParameter (CMiniDexed::TGParameterVoiceBank, nTG);
 	

--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -600,7 +600,7 @@ void CUIMenu::EditProgramNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 	uchBankName = uchBankName.substr(0,11);
 	
 	pUIMenu->m_pUI->DisplayWrite (TG.c_str (),
-				      uchBankName.c_str(),
+				      uchBankName,
 				      Value.c_str (),
 				      nValue > 0, nValue < (int) CSysExFileLoader::VoicesPerBank-1) && nBankNumber < (int) CSysExFileLoader::MaxVoiceBankID);	
 	}

--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -596,11 +596,11 @@ void CUIMenu::EditProgramNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 
 	if(bAutoBankSkip)
 	{
-	string uchBankName = pUIMenu->m_pMiniDexed->GetSysExFileLoader ()->GetBankName (nBankNumber);
+	string uchBankName = "" + pUIMenu->m_pMiniDexed->GetSysExFileLoader ()->GetBankName (nBankNumber);
 	uchBankName = uchBankName.substr(0,11);
 	
 	pUIMenu->m_pUI->DisplayWrite (TG.c_str (),
-				      uchBankName,
+				      uchBankName.c_str(),
 				      Value.c_str (),
 				      nValue > 0, nValue < (int) CSysExFileLoader::VoicesPerBank-1) && nBankNumber < (int) CSysExFileLoader::MaxVoiceBankID);	
 	}

--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -539,7 +539,7 @@ void CUIMenu::EditProgramNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 
 	int nValue = pUIMenu->m_pMiniDexed->GetTGParameter (CMiniDexed::TGParameterProgram, nTG);
 	
-	bool bAutoBankSkip=true; 
+	bool bAutoBankSkip = pUIMenu->m_pMiniDexed-GetAutoBankSkip(); 
 	
 	int nBankNumber = pUIMenu->m_pMiniDexed->GetTGParameter (CMiniDexed::TGParameterVoiceBank, nTG);
 	


### PR DESCRIPTION
Hi everybody, this PR allows to jump to the next or previous Bank from Voice menu when move beyond the last (32) or the first (1) voice in a continues way. This avoid to go back and forth between Voice and Bank menus when exploring different patches.

This solve #338 posted by @diyelectromusic 