### PR TITLE
Implement IgnoreAllNotesOff=1

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -69,7 +69,7 @@ void CConfig::Load (void)
 	}
 	
 	m_bMIDIRXProgramChange = m_Properties.GetNumber ("MIDIRXProgramChange", 1) != 0;
-
+	m_bIgnoreAllNotesOff = m_Properties.GetNumber ("IgnoreAllNotesOff", 0) != 0;
 
 	m_bLCDEnabled = m_Properties.GetNumber ("LCDEnabled", 0) != 0;
 	m_nLCDPinEnable = m_Properties.GetNumber ("LCDPinEnable", 4);
@@ -156,6 +156,11 @@ const char *CConfig::GetMIDIThruOut (void) const
 bool CConfig::GetMIDIRXProgramChange (void) const
 {
 	return m_bMIDIRXProgramChange;
+}
+
+bool CConfig::GetIgnoreAllNotesOff (void) const
+{
+	return m_bIgnoreAllNotesOff;
 }
 
 bool CConfig::GetLCDEnabled (void) const

--- a/src/config.h
+++ b/src/config.h
@@ -75,7 +75,7 @@ public:
 	const char *GetMIDIThruIn (void) const;	// "" if not specified
 	const char *GetMIDIThruOut (void) const;	// "" if not specified
 	bool GetMIDIRXProgramChange (void) const;	// true if not specified
-	
+	bool GetIgnoreAllNotesOff (void) const;
 
 	// HD44780 LCD
 	// GPIO pin numbers are chip numbers, not header positions
@@ -143,6 +143,7 @@ private:
 	std::string m_MIDIThruIn;
 	std::string m_MIDIThruOut;
 	bool m_bMIDIRXProgramChange;
+	bool m_bIgnoreAllNotesOff;
 
 	bool m_bLCDEnabled;
 	unsigned m_nLCDPinEnable;

--- a/src/mididevice.cpp
+++ b/src/mididevice.cpp
@@ -303,7 +303,10 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 							break;
 		
 						case MIDI_CC_ALL_NOTES_OFF:
-							m_pSynthesizer->notesOff (pMessage[2], nTG);
+							if (!m_pConfig->GetIgnoreAllNotesOff ())
+							{
+								m_pSynthesizer->notesOff (pMessage[2], nTG);
+							}
 							break;
 						}
 						break;

--- a/src/minidexed.ini
+++ b/src/minidexed.ini
@@ -15,6 +15,7 @@ ChannelsSwapped=0
 MIDIBaudRate=31250
 #MIDIThru=umidi1,ttyS1
 MIDIRXProgramChange=1
+IgnoreAllNotesOff=0
 
 # HD44780 LCD
 LCDEnabled=1


### PR DESCRIPTION
Implement `IgnoreAllNotesOff=1` in `minidexed.ini`, closes #356

According to https://community.cantabilesoftware.com/t/roland-d-50-midi-cc-123-all-notes-off/2157/6, certain Roland devices send CC 123 ("All Notes Off") when the last key is released. This is probably a bug or a misinterpretation of the MIDI standard by Roland at the time.

Apparently Roland owners just filter out CC 123.