### PR TITLE
Allow MIDI notes to be used as navigation buttons for MiniDexed

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -105,6 +105,7 @@ void CConfig::Load (void)
 	m_nLongPressTimeout = m_Properties.GetNumber ("LongPressTimeout", 600);
 
 	m_nMIDIButtonCh = m_Properties.GetNumber ("MIDIButtonCh", 0);
+	m_nMIDIButtonNotes = m_Properties.GetNumber ("MIDIButtonNotes", 0);
 	m_nMIDIButtonPrev = m_Properties.GetNumber ("MIDIButtonPrev", 0);
 	m_nMIDIButtonNext = m_Properties.GetNumber ("MIDIButtonNext", 0);
 	m_nMIDIButtonBack = m_Properties.GetNumber ("MIDIButtonBack", 0);
@@ -303,6 +304,11 @@ unsigned CConfig::GetLongPressTimeout (void) const
 unsigned CConfig::GetMIDIButtonCh (void) const
 {
 	return m_nMIDIButtonCh;
+}
+
+unsigned CConfig::GetMIDIButtonNotes (void) const
+{
+	return m_nMIDIButtonNotes;
 }
 
 unsigned CConfig::GetMIDIButtonPrev (void) const

--- a/src/config.h
+++ b/src/config.h
@@ -119,6 +119,7 @@ public:
 
 	// MIDI Button Navigation
 	unsigned GetMIDIButtonCh   (void) const;
+	unsigned GetMIDIButtonNotes (void) const;
 	unsigned GetMIDIButtonPrev (void) const;
 	unsigned GetMIDIButtonNext (void) const;
 	unsigned GetMIDIButtonBack (void) const;
@@ -186,6 +187,7 @@ private:
 	unsigned m_nLongPressTimeout;
 
 	unsigned m_nMIDIButtonCh;
+	unsigned m_nMIDIButtonNotes;
 	unsigned m_nMIDIButtonPrev;
 	unsigned m_nMIDIButtonNext;
 	unsigned m_nMIDIButtonBack;

--- a/src/mididevice.cpp
+++ b/src/mididevice.cpp
@@ -187,11 +187,13 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 		switch (ucType)
 		{
 		case MIDI_CONTROL_CHANGE:
+		case MIDI_NOTE_OFF:
+		case MIDI_NOTE_ON:
 			if (nLength < 3)
 			{
-				break;
+				break;	
 			}
-			m_pUI->UIMIDICCHandler (ucChannel, pMessage[1], pMessage[2]);
+			m_pUI->UIMIDICmdHandler (ucChannel, ucStatus & 0xF0, pMessage[1], pMessage[2]);
 			break;
 		}
 

--- a/src/minidexed.ini
+++ b/src/minidexed.ini
@@ -61,7 +61,10 @@ LongPressTimeout=400
 #  Specify MIDI CC to act as a button
 #  NB: Off < 64 < ON
 # CC channel: 0=OFF; 1-16 MIDI Ch; >16 Omni
+# If MIDIButtonNotes>0 then treat MIDIButton
+# numbers as MIDI Note numbers note CC numbers.
 MIDIButtonCh=0
+MIDIButtonNotes=1
 MIDIButtonPrev=00
 MIDIButtonNext=02
 MIDIButtonBack=03

--- a/src/uibuttons.h
+++ b/src/uibuttons.h
@@ -114,7 +114,7 @@ public:
 			unsigned selectPin, const char *selectAction,
 			unsigned homePin, const char *homeAction,
 			unsigned doubleClickTimeout, unsigned longPressTimeout,
-			unsigned prevMidi, unsigned nextMidi, unsigned backMidi, unsigned selectMidi, unsigned homeMidi
+			unsigned notesMidi, unsigned prevMidi, unsigned nextMidi, unsigned backMidi, unsigned selectMidi, unsigned homeMidi
 	);
 	~CUIButtons (void);
 	
@@ -126,7 +126,7 @@ public:
 
 	void ResetButton (unsigned pinNumber);
 
-	void BtnMIDICCHandler (unsigned nMidiCC, unsigned nMidiData);
+	void BtnMIDICmdHandler (unsigned nMidiCmd, unsigned nMidiData1, unsigned nMidiData2);
 	
 private:
 	// Array of normal GPIO buttons and "MIDI buttons"
@@ -150,6 +150,7 @@ private:
 	CUIButton::BtnTrigger m_homeAction;
 	
 	// MIDI button configuration
+	unsigned m_notesMidi;
 	unsigned m_prevMidi;
 	unsigned m_nextMidi;
 	unsigned m_backMidi;

--- a/src/userinterface.cpp
+++ b/src/userinterface.cpp
@@ -115,6 +115,7 @@ bool CUserInterface::Initialize (void)
 									m_pConfig->GetButtonActionHome (),
 									m_pConfig->GetDoubleClickTimeout (),
 									m_pConfig->GetLongPressTimeout (),
+									m_pConfig->GetMIDIButtonNotes (),
 									m_pConfig->GetMIDIButtonPrev (),
 									m_pConfig->GetMIDIButtonNext (),
 									m_pConfig->GetMIDIButtonBack (),
@@ -129,7 +130,7 @@ bool CUserInterface::Initialize (void)
 	}
 
 	m_pUIButtons->RegisterEventHandler (UIButtonsEventStub, this);
-	UISetMIDICCChannel (m_pConfig->GetMIDIButtonCh ());
+	UISetMIDIButtonChannel (m_pConfig->GetMIDIButtonCh ());
 
 	LOGDBG ("Button User Interface initialized");
 
@@ -330,7 +331,7 @@ void CUserInterface::UIButtonsEventStub (CUIButton::BtnEvent Event, void *pParam
 	pThis->UIButtonsEventHandler (Event);
 }
 
-void CUserInterface::UIMIDICCHandler (unsigned nMidiCh, unsigned nMidiCC, unsigned nMidiData)
+void CUserInterface::UIMIDICmdHandler (unsigned nMidiCh, unsigned nMidiCmd, unsigned nMidiData1, unsigned nMidiData2)
 {
 	if (m_nMIDIButtonCh == CMIDIDevice::Disabled)
 	{
@@ -345,11 +346,11 @@ void CUserInterface::UIMIDICCHandler (unsigned nMidiCh, unsigned nMidiCC, unsign
 	
 	if (m_pUIButtons)
 	{
-		m_pUIButtons->BtnMIDICCHandler (nMidiCC, nMidiData);
+		m_pUIButtons->BtnMIDICmdHandler (nMidiCmd, nMidiData1, nMidiData2);
 	}
 }
 
-void CUserInterface::UISetMIDICCChannel (unsigned uCh)
+void CUserInterface::UISetMIDIButtonChannel (unsigned uCh)
 {
 	// Mirrors the logic in Performance Config for handling MIDI channel configuration
 	if (uCh == 0)

--- a/src/userinterface.h
+++ b/src/userinterface.h
@@ -53,7 +53,7 @@ public:
 			   bool bArrowDown, bool bArrowUp);
 
 	// To be called from the MIDI device on reception of a MIDI CC message
-	void UIMIDICCHandler (unsigned nMidiCh, unsigned nMidiCC, unsigned nMidiData);
+	void UIMIDICmdHandler (unsigned nMidiCh, unsigned nMidiCmd, unsigned nMidiData1, unsigned nMidiData2);
 
 private:
 	void LCDWrite (const char *pString);		// Print to optional HD44780 display
@@ -62,7 +62,7 @@ private:
 	static void EncoderEventStub (CKY040::TEvent Event, void *pParam);
 	void UIButtonsEventHandler (CUIButton::BtnEvent Event);
 	static void UIButtonsEventStub (CUIButton::BtnEvent Event, void *pParam);
-	void UISetMIDICCChannel (unsigned uCh);
+	void UISetMIDIButtonChannel (unsigned uCh);
 
 private:
 	CMiniDexed *m_pMiniDexed;


### PR DESCRIPTION
Allow MIDI notes (note keys on MIDI keyboards) to be used as navigation buttons for MiniDexed instead of/in addition to rotary encoder and/or GPIO buttons.

@diyelectromusic in https://github.com/probonopd/MiniDexed/discussions/360#discussioncomment-3796775:
>  use NoteOn/NoteOff messages as "MIDI buttons" too. Just turn it on with:
> MIDIButtonNotes=1
> and then set the MIDIButton values to MIDI note numbers instead - e.g. 60, 62, 64, 65, 67 for C4-G4.
> 
> Of course if you're using a MIDI channel that you're playing on then things will get, er, interesting...