### PR TITLE
Ignore clock and active sensing on serial MIDI

### DIFF
--- a/src/serialmididevice.cpp
+++ b/src/serialmididevice.cpp
@@ -109,6 +109,10 @@ void CSerialMIDIDevice::Process (void)
 			}
 			continue;
 		}
+		else if(uchData == 0xF8 || uchData == 0xFE)
+		{
+			continue;
+		}
 		else
 		{
 			switch (m_nSerialState)

--- a/src/serialmididevice.cpp
+++ b/src/serialmididevice.cpp
@@ -98,7 +98,13 @@ void CSerialMIDIDevice::Process (void)
 			continue;
 		}
 
-		if(m_nSysEx > 0)
+		// System Real Time messages may appear anywhere in the byte stream, so handle them specially
+		if(uchData == 0xF8 || uchData == 0xFA || uchData == 0xFB || uchData == 0xFC || uchData == 0xFE || uchData == 0xFF)
+		{
+			MIDIMessageHandler (&uchData, 1);
+			continue;
+		}
+		else if(m_nSysEx > 0)
 		{
 			m_SerialMessage[m_nSysEx++]=uchData;
 			if ((uchData & 0x80) == 0x80 || m_nSysEx >= MAX_MIDI_MESSAGE)
@@ -107,10 +113,6 @@ void CSerialMIDIDevice::Process (void)
 					MIDIMessageHandler (m_SerialMessage, m_nSysEx);
 				m_nSysEx = 0;
 			}
-			continue;
-		}
-		else if(uchData == 0xF8 || uchData == 0xFE)
-		{
 			continue;
 		}
 		else


### PR DESCRIPTION
Fixes #416

I'm not entirely sure this is the correct way to fix it. But it does seem to fix the problem I was seeing. I can now completely mash the keyboard and no notes will get stuck on.