### PR TITLE
Complete rewrite using cUrl to maximize compatibility

### DIFF
--- a/getsysex.sh
+++ b/getsysex.sh
@@ -1,43 +1,75 @@
-#!/bin/sh
+#!/bin/bash
 
 # Get voices from
 # https://yamahablackboxes.com/collection/yamaha-dx7-synthesizer/patches/
 
+CURL_OPTIONS="-L --connect-timeout 15 --max-time 120 --retry 3 --retry-delay 5 --show-error"
+ALLOW_INSECURE_SSL="true"
+
+# Add here the links you wish to download from, at the bottom of the list
+# First put the link to the SysEx file you wish to download, followed by a space and then the filename on Minidexed
+# Please note that files on Minidexed need to start with a number, in this case the next link should be 000028_something.syx
+LINKS=()
+LINKS+=("https://yamahablackboxes.com/patches/dx7/factory/rom1a.syx 000000_rom1a.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/factory/rom1b.syx 000001_rom1b.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/factory/rom2a.syx 000002_rom2a.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/factory/rom2b.syx 000003_rom2b.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/vrc/vrc101a.syx 000004_vrc101a.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/vrc/vrc101b.syx 000005_vrc101b.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/vrc/vrc102a.syx 000006_vrc102a.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/vrc/vrc102b.syx 000007_vrc102b.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/vrc/vrc103a.syx 000008_vrc103a.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/vrc/vrc103b.syx 000009_vrc103b.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/vrc/vrc104a.syx 000010_vrc104a.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/vrc/vrc104b.syx 000011_vrc104b.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/vrc/vrc105a.syx 000012_vrc105a.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/vrc/vrc105b.syx 000013_vrc105b.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/vrc/vrc106a.syx 000014_vrc106a.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/vrc/vrc106b.syx 000015_vrc106b.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/vrc/vrc107a.syx 000016_vrc107a.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/vrc/vrc107b.syx 000017_vrc107b.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/vrc/vrc108a.syx 000018_vrc108a.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/vrc/vrc108b.syx 000019_vrc108b.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/vrc/vrc109a.syx 000020_vrc109a.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/vrc/vrc109b.syx 000021_vrc109b.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/vrc/vrc110a.syx 000022_vrc110a.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/vrc/vrc110b.syx 000023_vrc110b.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/vrc/vrc111a.syx 000024_vrc111a.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/vrc/vrc111b.syx 000025_vrc111b.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/vrc/vrc112a.syx 000026_vrc112a.syx")
+LINKS+=("https://yamahablackboxes.com/patches/dx7/vrc/vrc112b.syx 000027_vrc112b.syx")
+# LINKS+=("https://linkToWebsite.com/something.syx 000028_something.syx")
+
 mkdir -p sysex/voice/
 
-DIR="https://yamahablackboxes.com/patches/dx7/factory"
+# Check internet connection, https and if website is up 
+curl ${CURL_OPTIONS} -s -I -X POST "https://yamahablackboxes.com" > /dev/null 2>&1
+case $? in
+    0)
+        ;;
+    60)
+        if [[ "${ALLOW_INSECURE_SSL}" == "true" ]]
+        then
+            CURL_OPTIONS+=" --insecure"
+        else
+            echo "Error establishing secure connection"
+        fi
+        ;;
+    *)
+        echo "No Internet connection or the website is down"
+        exit 1
+        ;;
+esac
 
-# wget -c "${DIR}"/rom1a.syx -O sysex/voice/000000_rom1a.syx
-# wget -c "${DIR}"/rom1b.syx -O sysex/voice/000001_rom1b.syx
-# wget -c "${DIR}"/rom2a.syx -O sysex/voice/000002_rom2a.syx
-# wget -c "${DIR}"/rom2b.syx -O sysex/voice/000003_rom2b.syx
-wget -c "${DIR}"/rom3a.syx -O sysex/voice/000000_rom3a.syx
-wget -c "${DIR}"/rom3b.syx -O sysex/voice/000001_rom3b.syx
-wget -c "${DIR}"/rom4a.syx -O sysex/voice/000002_rom4a.syx
-wget -c "${DIR}"/rom4b.syx -O sysex/voice/000003_rom4b.syx
-
-DIR="https://yamahablackboxes.com/patches/dx7/vrc"
-
-wget -c "${DIR}"/vrc101b.syx -O sysex/voice/000004_vrc101b.syx
-wget -c "${DIR}"/vrc102a.syx -O sysex/voice/000005_vrc102a.syx
-wget -c "${DIR}"/vrc102b.syx -O sysex/voice/000006_vrc102b.syx
-wget -c "${DIR}"/vrc103a.syx -O sysex/voice/000007_vrc103a.syx
-wget -c "${DIR}"/vrc103b.syx -O sysex/voice/000008_vrc103b.syx
-wget -c "${DIR}"/vrc104a.syx -O sysex/voice/000009_vrc104a.syx
-wget -c "${DIR}"/vrc104b.syx -O sysex/voice/000010_vrc104b.syx
-wget -c "${DIR}"/vrc105a.syx -O sysex/voice/000011_vrc105a.syx
-wget -c "${DIR}"/vrc105b.syx -O sysex/voice/000012_vrc105b.syx
-wget -c "${DIR}"/vrc106a.syx -O sysex/voice/000013_vrc106a.syx
-wget -c "${DIR}"/vrc106b.syx -O sysex/voice/000014_vrc106b.syx
-wget -c "${DIR}"/vrc107a.syx -O sysex/voice/000015_vrc107a.syx
-wget -c "${DIR}"/vrc107b.syx -O sysex/voice/000016_vrc107b.syx
-wget -c "${DIR}"/vrc108a.syx -O sysex/voice/000017_vrc108a.syx
-wget -c "${DIR}"/vrc108b.syx -O sysex/voice/000018_vrc108b.syx
-wget -c "${DIR}"/vrc109a.syx -O sysex/voice/000019_vrc109a.syx
-wget -c "${DIR}"/vrc109b.syx -O sysex/voice/000020_vrc109b.syx
-wget -c "${DIR}"/vrc110a.syx -O sysex/voice/000021_vrc110a.syx
-wget -c "${DIR}"/vrc110b.syx -O sysex/voice/000022_vrc110b.syx
-wget -c "${DIR}"/vrc111a.syx -O sysex/voice/000023_vrc111a.syx
-wget -c "${DIR}"/vrc111b.syx -O sysex/voice/000024_vrc111b.syx
-wget -c "${DIR}"/vrc112a.syx -O sysex/voice/000025_vrc112a.syx
-wget -c "${DIR}"/vrc112b.syx -O sysex/voice/000026_vrc112b.syx
+# Download all the files in the list
+for i in "${LINKS[@]}"; 
+do
+    LINK=`echo "${i}" | awk '{print $1}'`
+    FILE=`echo "${i}" | awk '{print $2}'`
+    echo "Downloading ${LINK} ..."
+    curl -o "sysex/voice/${FILE}" ${CURL_OPTIONS} "${LINK}" > /dev/null 2>&1
+    if (( $? > 0 ))
+    then
+        echo "Download failed"
+    fi
+done


### PR DESCRIPTION
I have completely rewritten the bash script with several improvements including:

- Using cUrl which has been included in most of the modern Unix distros (macOS included)
- Check for internet availability
- Check if the target website is online
- Make it easier to add links for people who want additional voices
- Extra voices downloaded by default, all standard cartridges available for the original DX7