### PR TITLE
Skip empty voices while scrolling

### DIFF
--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -582,11 +582,10 @@ void CUIMenu::EditProgramNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 	}
 
 	string voiceName = pUIMenu->m_pMiniDexed->GetVoiceName (nTG); // Skip empty voices
-	if (voiceName == "INIT VOICE" 
-	    || voiceName == "init voice" 
-	    || voiceName == "          " 
-	    || voiceName == "----------" 
-	    || voiceName == "~~~~~~~~~~" ) 
+	if (voiceName == "EMPTY     "
+	    || voiceName == "          "
+	    || voiceName == "----------"
+	    || voiceName == "~~~~~~~~~~" )
 	{
 		if (Event == MenuEventStepUp) {
 			CUIMenu::EditProgramNumber (pUIMenu, MenuEventStepUp);

--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -582,7 +582,12 @@ void CUIMenu::EditProgramNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 	}
 
 	string voiceName = pUIMenu->m_pMiniDexed->GetVoiceName (nTG); // Skip empty voices
-	if (voiceName == "INIT VOICE") {
+	if (voiceName == "INIT VOICE" 
+	    || voiceName == "init voice" 
+	    || voiceName == "          " 
+	    || voiceName == "----------" 
+	    || voiceName == "~~~~~~~~~~" ) 
+	{
 		if (Event == MenuEventStepUp) {
 			CUIMenu::EditProgramNumber (pUIMenu, MenuEventStepUp);
 		}

--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -587,15 +587,25 @@ void CUIMenu::EditProgramNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 		return;
 	}
 
-	string TG ("TG");
-	TG += to_string (nTG+1);
+	string voiceName = pUIMenu->m_pMiniDexed->GetVoiceName (nTG); // Skip empty voices
+	if (voiceName == "INIT VOICE") {
+		if (Event == MenuEventStepUp) {
+			CUIMenu::EditProgramNumber (pUIMenu, MenuEventStepUp);
+		}
+		if (Event == MenuEventStepDown) {
+			CUIMenu::EditProgramNumber (pUIMenu, MenuEventStepDown);
+		}
+	} else {
+		string TG ("TG");
+		TG += to_string (nTG+1);
 
-	string Value = to_string (nValue+1) + "=" + pUIMenu->m_pMiniDexed->GetVoiceName (nTG);
+		string Value = to_string (nValue+1) + "=" + pUIMenu->m_pMiniDexed->GetVoiceName (nTG);
 
-	pUIMenu->m_pUI->DisplayWrite (TG.c_str (),
-				      pUIMenu->m_pParentMenu[pUIMenu->m_nCurrentMenuItem].Name,
-				      Value.c_str (),
-				      nValue > 0, nValue < (int) CSysExFileLoader::VoicesPerBank-1);
+		pUIMenu->m_pUI->DisplayWrite (TG.c_str (),
+					      pUIMenu->m_pParentMenu[pUIMenu->m_nCurrentMenuItem].Name,
+					      Value.c_str (),
+					      nValue > 0, nValue < (int) CSysExFileLoader::VoicesPerBank-1);
+	}
 }
 
 void CUIMenu::EditTGParameter (CUIMenu *pUIMenu, TMenuEvent Event)


### PR DESCRIPTION
There are banks which contain empty voices labeled as "INIT VOICES".
Those are just blank voices which can be skipped to make scrolling between lots of banks faster.