### PR TITLE
Support for subdirectories in the SysEx voices directory

### DIFF
--- a/src/sysexfileloader.cpp
+++ b/src/sysexfileloader.cpp
@@ -97,14 +97,14 @@ void CSysExFileLoader::Load (bool bHeaderlessSysExVoices)
 	dirent *pEntry;
 	while ((pEntry = readdir (pDirectory)) != nullptr)
 	{
-		LoadBank(m_DirName.c_str (), pEntry->d_name);
+		LoadBank(m_DirName.c_str (), pEntry->d_name, bHeaderlessSysExVoices);
 	}
 	LOGDBG ("%u Banks loaded. Highest Bank loaded: #%u", m_nBanksLoaded, m_nNumHighestBank);
 
 	closedir (pDirectory);
 }
 
-void CSysExFileLoader::LoadBank (const char * sDirName, const char * sBankName)
+void CSysExFileLoader::LoadBank (const char * sDirName, const char * sBankName, bool bHeaderlessSysExVoices)
 {
 	unsigned nBank;
 	size_t nLen = strlen (sBankName);
@@ -126,7 +126,7 @@ void CSysExFileLoader::LoadBank (const char * sDirName, const char * sBankName)
 			dirent *pEntry;
 			while ((pEntry = readdir (pDirectory)) != nullptr)
 			{
-				LoadBank(Dirname.c_str (), pEntry->d_name);
+				LoadBank(Dirname.c_str (), pEntry->d_name, bHeaderlessSysExVoices);
 			}
 			closedir (pDirectory);
 		}
@@ -185,14 +185,18 @@ void CSysExFileLoader::LoadBank (const char * sDirName, const char * sBankName)
 			m_nBanksLoaded++;
 			bBankLoaded = true;
 		}
-	/*			else if (bHeaderlessSysExVoices)
+		else if (bHeaderlessSysExVoices)
 		{
 			// Config says to accept headerless SysEx Voice Banks
 			// so reset file pointer and try again.
 			fseek (pFile, 0, SEEK_SET);
 			if (fread (m_pVoiceBank[nBank]->Voice, VoiceSysExSize, 1, pFile) == 1)
 			{
-				LOGDBG ("Bank #%u successfully loaded (headerless)", nBank);
+				if (m_nBanksLoaded % 100 == 0)
+				{
+					LOGDBG ("Banks successfully loaded #%u", m_nBanksLoaded);
+				}
+				//LOGDBG ("Bank #%u successfully loaded (headerless)", nBank);
 
 				// Add in the missing header items.
 				// Naturally it isn't possible to validate these!
@@ -204,15 +208,16 @@ void CSysExFileLoader::LoadBank (const char * sDirName, const char * sBankName)
 				m_pVoiceBank[nBank]->Checksum    = 0x00;
 				m_pVoiceBank[nBank]->StatusEnd   = 0xF7;
 
-				m_BankFileName[nBank] = pEntry->d_name;
+				m_BankFileName[nBank] = sBankName;
 				if (nBank > m_nNumHighestBank)
 				{
 					// This is the bank ID of the highest loaded bank
 					m_nNumHighestBank = nBank;
 				}
 				bBankLoaded = true;
+				m_nBanksLoaded++;
 			}
-		}*/
+		}
 
 		if (!bBankLoaded)
 		{

--- a/src/sysexfileloader.h
+++ b/src/sysexfileloader.h
@@ -35,6 +35,7 @@ public:
 	static const size_t SizeSingleVoice = 156;
 	static const unsigned VoiceSysExHdrSize = 8; // Additional (optional) Header/Footer bytes for bank of 32 voices
 	static const unsigned VoiceSysExSize = 4096; // Bank of 32 voices as per DX7 MIDI Spec
+	static const unsigned MaxSubDirs = 3; // Number of nested subdirectories supported.
 
 	struct TVoiceBank
 	{
@@ -82,7 +83,7 @@ private:
 
 	static uint8_t s_DefaultVoice[SizeSingleVoice];
 	
-	void LoadBank (const char * sDirName, const char * sBankName, bool bHeaderlessSysExVoices);
+	void LoadBank (const char * sDirName, const char * sBankName, bool bHeaderlessSysExVoices, unsigned nSubDirCount);
 };
 
 #endif

--- a/src/sysexfileloader.h
+++ b/src/sysexfileloader.h
@@ -75,11 +75,14 @@ private:
 	std::string m_DirName;
 	
 	unsigned m_nNumHighestBank;
+	unsigned m_nBanksLoaded;
 
 	TVoiceBank *m_pVoiceBank[MaxVoiceBankID+1];
 	std::string m_BankFileName[MaxVoiceBankID+1];
 
 	static uint8_t s_DefaultVoice[SizeSingleVoice];
+	
+	void LoadBank (const char * sDirName, const char * sBankName);
 };
 
 #endif

--- a/src/sysexfileloader.h
+++ b/src/sysexfileloader.h
@@ -82,7 +82,7 @@ private:
 
 	static uint8_t s_DefaultVoice[SizeSingleVoice];
 	
-	void LoadBank (const char * sDirName, const char * sBankName);
+	void LoadBank (const char * sDirName, const char * sBankName, bool bHeaderlessSysExVoices);
 };
 
 #endif

--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -519,7 +519,7 @@ void CUIMenu::EditVoiceBankNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 	string TG ("TG");
 	TG += to_string (nTG+1);
 
-	string Value =   to_string (nValue+1) + "="
+	string Value =   to_string (nValue) + "="
 		       + pUIMenu->m_pMiniDexed->GetSysExFileLoader ()->GetBankName (nValue);
 
 	pUIMenu->m_pUI->DisplayWrite (TG.c_str (),

--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -519,7 +519,7 @@ void CUIMenu::EditVoiceBankNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 	string TG ("TG");
 	TG += to_string (nTG+1);
 
-	string Value =   to_string (nValue) + "="
+	string Value =   to_string (nValue+1) + "="
 		       + pUIMenu->m_pMiniDexed->GetSysExFileLoader ()->GetBankName (nValue);
 
 	pUIMenu->m_pUI->DisplayWrite (TG.c_str (),

--- a/submod.sh
+++ b/submod.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -ex
+git submodule update --init --recursive
+cd circle-stdlib/
+git checkout e318f89 # Needed to support Circle develop?
+cd -
+cd circle-stdlib/libs/circle
+git checkout ec09d7e # develop
+cd -
+cd circle-stdlib/libs/circle-newlib
+git checkout 48bf91d # needed for circle ec09d7e
+cd -
+           


### PR DESCRIPTION
Initial support for (nested) subdirectories in the sysex/voices folder.  Splitting up directories into less than 100 files per directory seems to really help with the performance issues discussed in https://github.com/probonopd/MiniDexed/discussions/456.

Kevin