### PR TITLE
If running on a RPI 1 or single core Pi then default to the TG1 menu as the home menu

### DIFF
--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -338,6 +338,23 @@ CUIMenu::CUIMenu (CUserInterface *pUI, CMiniDexed *pMiniDexed)
 	m_nCurrentParameter (0),
 	m_nCurrentMenuDepth (0)
 {
+#ifndef ARM_ALLOW_MULTI_CORE
+	// If there is just one core, then there is only a single
+	// tone generator so start on the TG1 menu...
+	m_pParentMenu = s_MainMenu;
+	m_pCurrentMenu = s_TGMenu;
+	m_nCurrentMenuItem = 0;
+	m_nCurrentSelection = 0;
+	m_nCurrentParameter = 0;
+	m_nCurrentMenuDepth = 1;
+
+	// Place the "root" menu at the top of the stack
+	m_MenuStackParent[0] = s_MenuRoot;
+	m_MenuStackMenu[0] = s_MainMenu;
+	m_nMenuStackItem[0]	= 0;
+	m_nMenuStackSelection[0] = 0;
+	m_nMenuStackParameter[0] = 0;
+#endif
 }
 
 void CUIMenu::EventHandler (TMenuEvent Event)
@@ -360,13 +377,28 @@ void CUIMenu::EventHandler (TMenuEvent Event)
 		break;
 
 	case MenuEventHome:
+#ifdef ARM_ALLOW_MULTI_CORE
 		m_pParentMenu = s_MenuRoot;
 		m_pCurrentMenu = s_MainMenu;
 		m_nCurrentMenuItem = 0;
 		m_nCurrentSelection = 0;
 		m_nCurrentParameter = 0;
 		m_nCurrentMenuDepth = 0;
-
+#else
+		// "Home" is the TG0 menu if only one TG active
+		m_pParentMenu = s_MainMenu;
+		m_pCurrentMenu = s_TGMenu;
+		m_nCurrentMenuItem = 0;
+		m_nCurrentSelection = 0;
+		m_nCurrentParameter = 0;
+		m_nCurrentMenuDepth = 1;
+		// Place the "root" menu at the top of the stack
+		m_MenuStackParent[0] = s_MenuRoot;
+		m_MenuStackMenu[0] = s_MainMenu;
+		m_nMenuStackItem[0] = 0;
+		m_nMenuStackSelection[0] = 0;
+		m_nMenuStackParameter[0] = 0;
+#endif
 		EventHandler (MenuEventUpdate);
 		break;
 


### PR DESCRIPTION
When running on a single core RPi there is only one tone generator, so this change will get the menu system to default to the TG1 menu rather than always having to select TG1 before changing anything.

Note: the higher level menu hasn't gone away and can still be reached by selecting "back" - the highest level menu structure is still: TG1 - Effects - Performance.

But with this change the "home" menu is at the TG1 level, showing "Voice" which is a lot more convenient when only one TG is present.
