### PR TITLE
Issue491 fix - Bank number auto-switching and bank number skipping issues in UI

### DIFF
--- a/src/sysexfileloader.cpp
+++ b/src/sysexfileloader.cpp
@@ -99,7 +99,7 @@ void CSysExFileLoader::Load (bool bHeaderlessSysExVoices)
 	{
 		LoadBank(m_DirName.c_str (), pEntry->d_name, bHeaderlessSysExVoices, 0);
 	}
-	LOGDBG ("%u Banks loaded. Highest Bank loaded: #%u", m_nBanksLoaded, m_nNumHighestBank);
+	LOGDBG ("%u Banks loaded. Highest Bank loaded: #%u", m_nBanksLoaded, m_nNumHighestBank+1);
 
 	closedir (pDirectory);
 }
@@ -189,10 +189,10 @@ void CSysExFileLoader::LoadBank (const char * sDirName, const char * sBankName, 
 			//LOGDBG ("Bank #%u successfully loaded", nBank);
 
 			m_BankFileName[nBankIdx] = sBankName;
-			if (nBank > m_nNumHighestBank)
+			if (nBankIdx > m_nNumHighestBank)
 			{
 				// This is the bank ID of the highest loaded bank
-				m_nNumHighestBank = nBank;
+				m_nNumHighestBank = nBankIdx;
 			}
 			m_nBanksLoaded++;
 			bBankLoaded = true;
@@ -221,10 +221,10 @@ void CSysExFileLoader::LoadBank (const char * sDirName, const char * sBankName, 
 				m_pVoiceBank[nBankIdx]->StatusEnd   = 0xF7;
 
 				m_BankFileName[nBankIdx] = sBankName;
-				if (nBank > m_nNumHighestBank)
+				if (nBankIdx > m_nNumHighestBank)
 				{
 					// This is the bank ID of the highest loaded bank
-					m_nNumHighestBank = nBank;
+					m_nNumHighestBank = nBankIdx;
 				}
 				bBankLoaded = true;
 				m_nBanksLoaded++;

--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -563,7 +563,6 @@ void CUIMenu::EditVoiceBankNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 void CUIMenu::EditProgramNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 {
 	unsigned nTG = pUIMenu->m_nMenuStackParameter[pUIMenu->m_nCurrentMenuDepth-1];
-	int nHighestBank = pUIMenu->m_pMiniDexed->GetSysExFileLoader ()->GetNumHighestBank();
 
 	int nValue = pUIMenu->m_pMiniDexed->GetTGParameter (CMiniDexed::TGParameterProgram, nTG);
 
@@ -578,11 +577,7 @@ void CUIMenu::EditProgramNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 			// Switch down a voice bank and set to the last voice
 			nValue = CSysExFileLoader::VoicesPerBank-1;
 			int nVB = pUIMenu->m_pMiniDexed->GetTGParameter(CMiniDexed::TGParameterVoiceBank, nTG);
-			if (--nVB < 0)
-			{
-				// Wrap around to last loaded bank
-				nVB = nHighestBank;
-			}
+			nVB = pUIMenu->m_pMiniDexed->GetSysExFileLoader ()->GetNextBankDown(nVB);
 			pUIMenu->m_pMiniDexed->SetTGParameter (CMiniDexed::TGParameterVoiceBank, nVB, nTG);
 		}
 		pUIMenu->m_pMiniDexed->SetTGParameter (CMiniDexed::TGParameterProgram, nValue, nTG);
@@ -594,11 +589,7 @@ void CUIMenu::EditProgramNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 			// Switch up a voice bank and reset to voice 0
 			nValue = 0;
 			int nVB = pUIMenu->m_pMiniDexed->GetTGParameter(CMiniDexed::TGParameterVoiceBank, nTG);
-			if (++nVB > (int) nHighestBank)
-			{
-				// Wrap around to first bank
-				nVB = 0;
-			}
+			nVB = pUIMenu->m_pMiniDexed->GetSysExFileLoader ()->GetNextBankUp(nVB);
 			pUIMenu->m_pMiniDexed->SetTGParameter (CMiniDexed::TGParameterVoiceBank, nVB, nTG);
 		}
 		pUIMenu->m_pMiniDexed->SetTGParameter (CMiniDexed::TGParameterProgram, nValue, nTG);


### PR DESCRIPTION
Fix for problems with bank number selection both on auto-changing when selecting voices and for when the UI has to skip banks, as detailed in https://github.com/probonopd/MiniDexed/issues/491