### PR TITLE
Issue470 fix - Performance file bounds checking and error handling

### DIFF
--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -1474,7 +1474,7 @@ bool CMiniDexed::DoSetNewPerformance (void)
 
 bool CMiniDexed::SavePerformanceNewFile ()
 {
-	m_bSavePerformanceNewFile = m_PerformanceConfig.GetInternalFolderOk();
+	m_bSavePerformanceNewFile = m_PerformanceConfig.GetInternalFolderOk() && m_PerformanceConfig.CheckFreePerformanceSlot();
 	return m_bSavePerformanceNewFile;
 }
 

--- a/src/performanceconfig.cpp
+++ b/src/performanceconfig.cpp
@@ -750,12 +750,27 @@ bool CPerformanceConfig::GetInternalFolderOk()
 	return nInternalFolderOk;
 }
 
+bool CPerformanceConfig::CheckFreePerformanceSlot(void)
+{
+	if (nLastPerformance < NUM_PERFORMANCES)
+	{
+		// There is a free slot...
+		return true;
+	}
+	else
+	{
+		return false;
+	}
+}
+
 bool CPerformanceConfig::CreateNewPerformanceFile(void)
 {
 	if (nLastPerformance >= NUM_PERFORMANCES) {
 		// No space left for new performances
+		LOGWARN ("No space left for new performance");
 		return false;
 	}
+
 	std::string sPerformanceName = NewPerformanceName;
 	NewPerformanceName=""; 
 	nActualPerformance=nLastPerformance;
@@ -836,7 +851,7 @@ bool CPerformanceConfig::ListPerformances()
 	Result = f_findfirst (&Directory, &FileInfo, "SD:/" PERFORMANCE_DIR, "*.ini");
 		for (unsigned i = 0; Result == FR_OK && FileInfo.fname[0]; i++)
 		{
-			if (nLastPerformance >=NUM_PERFORMANCES) {
+			if (nLastPerformance >= NUM_PERFORMANCES) {
 				LOGNOTE ("Skipping performance %s", FileInfo.fname);
 			} else {
 				if (!(FileInfo.fattrib & (AM_HID | AM_SYS)))  

--- a/src/performanceconfig.h
+++ b/src/performanceconfig.h
@@ -28,6 +28,7 @@
 #include <Properties/propertiesfatfsfile.h>
 #define NUM_VOICE_PARAM 156
 #define PERFORMANCE_DIR "performance" 
+#define NUM_PERFORMANCES 1024
 
 class CPerformanceConfig	// Performance configuration
 {
@@ -168,7 +169,7 @@ private:
 	unsigned nLastFileIndex;
 	unsigned nActualPerformance = 0;  
 	//unsigned nMenuSelectedPerformance = 0; 
-	std::string m_nPerformanceFileName[1024];
+	std::string m_nPerformanceFileName[NUM_PERFORMANCES];
 	FATFS *m_pFileSystem; 
 
 	bool nInternalFolderOk=false;

--- a/src/performanceconfig.h
+++ b/src/performanceconfig.h
@@ -28,7 +28,7 @@
 #include <Properties/propertiesfatfsfile.h>
 #define NUM_VOICE_PARAM 156
 #define PERFORMANCE_DIR "performance" 
-#define NUM_PERFORMANCES 1024
+#define NUM_PERFORMANCES 256
 
 class CPerformanceConfig	// Performance configuration
 {
@@ -132,6 +132,7 @@ public:
 	std::string GetNewPerformanceDefaultName(void);
 	void SetNewPerformanceName(std::string nName);
 	bool DeletePerformance(unsigned nID);
+	bool CheckFreePerformanceSlot(void);
 
 private:
 	CPropertiesFatFsFile m_Properties;


### PR DESCRIPTION
Introduces bounds checking for performances; reduces number of performances to 256; includes better error handling in the UI and on the display.

closes #470 