### PR TITLE
Make performance directory switchable

### DIFF
--- a/src/mididevice.cpp
+++ b/src/mididevice.cpp
@@ -355,6 +355,25 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 						if( m_pConfig->GetMIDIRXProgramChange() && ( m_pSynthesizer->GetPerformanceSelectChannel() == Disabled) ) {
 							//printf("Program Change to %d (%d)\n", ucChannel, m_pSynthesizer->GetPerformanceSelectChannel());
 							m_pSynthesizer->ProgramChange (pMessage[1], nTG);
+
+							/* TODO: Depending on whether we get a MSB or LSB, we need to change the performance directory
+							   or do a program change. This is not yet implemented. Pseudo code:
+							
+							switch (pMessage[1])
+							{
+								case MIDI_CC_BANK_SELECT_MSB:
+									CString sDir;
+									sDir.Format ("performance/%d", pMessage[2]);
+									// Check if we find a performance directory that starts with that name; if yes, use it
+									m_pConfig->SetPerformanceDir (sDir.c_str ());
+									break;
+			
+								case MIDI_CC_BANK_SELECT_LSB:
+								    // Check if we find a performance file that starts with that name; if yes, use it
+									m_pSynthesizer->ProgramChange (pMessage[1], nTG);
+									break;
+							}
+							*/
 						}
 						break;
 		

--- a/src/mididevice.cpp
+++ b/src/mididevice.cpp
@@ -299,10 +299,14 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 							break;
 		
 						case MIDI_CC_BANK_SELECT_MSB:
+							// TODO: Check whether we want to change the performance directory and act accordingly
+							// (in "Performance Select Channel" mode)
 							m_pSynthesizer->BankSelectMSB (pMessage[2], nTG);
 							break;
 		
 						case MIDI_CC_BANK_SELECT_LSB:
+							// TODO: Check whether we want to change the performance directory and act accordingly
+							// (in "Performance Select Channel" mode)
 							m_pSynthesizer->BankSelectLSB (pMessage[2], nTG);
 							break;
 		
@@ -355,25 +359,6 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 						if( m_pConfig->GetMIDIRXProgramChange() && ( m_pSynthesizer->GetPerformanceSelectChannel() == Disabled) ) {
 							//printf("Program Change to %d (%d)\n", ucChannel, m_pSynthesizer->GetPerformanceSelectChannel());
 							m_pSynthesizer->ProgramChange (pMessage[1], nTG);
-
-							/* TODO: Depending on whether we get a MSB or LSB, we need to change the performance directory
-							   or do a program change. This is not yet implemented. Pseudo code:
-							
-							switch (pMessage[1])
-							{
-								case MIDI_CC_BANK_SELECT_MSB:
-									CString sDir;
-									sDir.Format ("performance/%d", pMessage[2]);
-									// Check if we find a performance directory that starts with that name; if yes, use it
-									m_pConfig->SetPerformanceDir (sDir.c_str ());
-									break;
-			
-								case MIDI_CC_BANK_SELECT_LSB:
-								    // Check if we find a performance file that starts with that name; if yes, use it
-									m_pSynthesizer->ProgramChange (pMessage[1], nTG);
-									break;
-							}
-							*/
 						}
 						break;
 		

--- a/src/performanceconfig.cpp
+++ b/src/performanceconfig.cpp
@@ -25,6 +25,7 @@
 #include "mididevice.h"
 #include <cstring> 
 #include <algorithm>
+#include "minidexed.h"
 
 LOGMODULE ("Performance");
 
@@ -796,7 +797,7 @@ bool CPerformanceConfig::CreateNewPerformanceFile(void)
 	m_nPerformanceFileName[nLastPerformance]= nFileName;
 	
 	nPath = "SD:/" ;
-	nPath += PERFORMANCE_DIR;
+	nPath += GetPerformanceDir();
 	nPath += "/";
 	nFileName = nPath + nFileName;
 	
@@ -832,8 +833,11 @@ bool CPerformanceConfig::ListPerformances()
     DIR Directory;
 	FILINFO FileInfo;
 	FRESULT Result;
-	//Check if internal "performance" directory exists
-	Result = f_opendir (&Directory, "SD:/" PERFORMANCE_DIR);
+	// Check if internal "performance" directory exists
+	std::string Path = "SD:/" ;
+	Path += GetPerformanceDir();
+	Result = f_opendir (&Directory, Path.c_str());
+	
 	if (Result == FR_OK)
 	{
 		nInternalFolderOk=true;		
@@ -841,14 +845,14 @@ bool CPerformanceConfig::ListPerformances()
 	}
 	else
 	{
-		// attenpt to create the folder
-		Result = f_mkdir("SD:/" PERFORMANCE_DIR);
+		// attempt to create the folder
+		Result = f_mkdir(Path.c_str());
 		nInternalFolderOk = (Result == FR_OK);
 	}
 	
 	if (nInternalFolderOk)
 	{
-	Result = f_findfirst (&Directory, &FileInfo, "SD:/" PERFORMANCE_DIR, "*.ini");
+	Result = f_findfirst (&Directory, &FileInfo, Path.c_str(), "*.ini");
 		for (unsigned i = 0; Result == FR_OK && FileInfo.fname[0]; i++)
 		{
 			if (nLastPerformance >= NUM_PERFORMANCES) {
@@ -892,7 +896,7 @@ void CPerformanceConfig::SetNewPerformance (unsigned nID)
 		std::string FileN = "";
 		if (nID != 0) // in order to assure retrocompatibility
 		{
-			FileN += PERFORMANCE_DIR;
+			FileN += GetPerformanceDir();
 			FileN += "/";
 		}
 		FileN += m_nPerformanceFileName[nID];
@@ -928,8 +932,7 @@ bool CPerformanceConfig::DeletePerformance(unsigned nID)
 	DIR Directory;
 	FILINFO FileInfo;
 	std::string FileN = "SD:/";
-	FileN += PERFORMANCE_DIR;
-
+	FileN += GetPerformanceDir();
 	
 	FRESULT Result = f_findfirst (&Directory, &FileInfo, FileN.c_str(), m_nPerformanceFileName[nID].c_str());
 	if (Result == FR_OK && FileInfo.fname[0])
@@ -950,4 +953,17 @@ bool CPerformanceConfig::DeletePerformance(unsigned nID)
 		}
 	}
 	return bOK;
+}
+
+const char *CPerformanceConfig::GetPerformanceDir (void) const
+{
+	return m_PerformanceDir.c_str();
+}
+
+void CPerformanceConfig::SetPerformanceDir (const char *pDir)
+{
+	m_PerformanceDir = pDir;
+
+	// TODO: Load performance files from new directory
+
 }

--- a/src/performanceconfig.h
+++ b/src/performanceconfig.h
@@ -27,7 +27,6 @@
 #include <fatfs/ff.h>
 #include <Properties/propertiesfatfsfile.h>
 #define NUM_VOICE_PARAM 156
-#define PERFORMANCE_DIR "performance" 
 #define NUM_PERFORMANCES 256
 
 class CPerformanceConfig	// Performance configuration
@@ -39,6 +38,9 @@ public:
 	bool Load (void);
 
 	bool Save (void);
+
+	const char *GetPerformanceDir (void) const;
+	void SetPerformanceDir (const char *pDir);
 
 	// TG#
 	unsigned GetBankNumber (unsigned nTG) const;		// 0 .. 127
@@ -176,6 +178,8 @@ private:
 	bool nInternalFolderOk=false;
 	bool nExternalFolderOk=false; // for future USB implementation
 	std::string NewPerformanceName="";
+
+	std::string m_PerformanceDir = "performance";
 	
 	bool m_bCompressorEnable;
 	bool m_bReverbEnable;


### PR DESCRIPTION
With [so many performances](https://github.com/probonopd/MiniDexed/discussions/560) to choose from, we need a way to switch between multiple directories (folders) of performances.

Intended behavior:
* We can have `performance/000000_factory/`, `performance/000001_somefolder/,  `performance/000002_someotherfolder/` instead of a hardcoded `performance/` directory
* By sending the MIDI Bank Change messages on the MIDI channel configured for selecting performances (rather than voices), the directory can be switched
* It can also be switched in the UI

TODO:
- [ ] The changes in `performanceconfig.*` need to be reviewed; in `CPerformanceConfig::SetPerformanceDir` the performances from the new performance directory need to be loaded
- [ ] The changes in `src/mididevice.cpp` are pseudo-code and need to be implemented properly
- [ ] The Performances menu entry should get a new submenu to change the performance directory without using MIDI bank change messages

**This PR is currently not functional because the TODOs need to be implemented. Any help appreciated. Volunteers?**