### PR TITLE
32 note polyphony on a PI 4

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -41,6 +41,8 @@ public:
 
 #if RASPPI == 1
 	static const unsigned MaxNotes = 8;		// polyphony
+#elif RASPPI == 4
+	static const unsigned MaxNotes = 32;
 #else
 	static const unsigned MaxNotes = 16;
 #endif

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -101,6 +101,8 @@ CMiniDexed::CMiniDexed (CConfig *pConfig, CInterruptSystem *pInterrupt,
 		m_pTG[i]->activate ();
 	}
 		
+	LOGNOTE ("Polyphony = %d", CConfig::MaxNotes);
+		
 	if (pConfig->GetUSBGadgetMode())
 	{
 		LOGNOTE ("USB In Gadget (Device) Mode");


### PR DESCRIPTION
This is just experimental at this stage for anyone wanting to experiment with 32-note polyphony on a Pi 4. It has been built and appears to configure 32-note polyphony correctly, but it hasn't really been tested in any significant way.

In particular the performance is currently unclear, so at present, use at your own risk.

Feedback on any experiences is welcome.

Kevin