### PR TITLE
Very early initial support for RPi 5 based on dev branch of circle.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,12 @@ jobs:
            wget -q https://developer.arm.com/-/media/Files/downloads/gnu-a/10.3-2021.07/binrel/gcc-arm-10.3-2021.07-x86_64-arm-none-eabi.tar.xz
            tar xf *-arm-none-eabi.tar.xz
            mkdir -p kernels
+    - name: Build for Raspberry Pi 5
+      run: |
+           set -ex
+           export PATH=$(readlink -f ./gcc-*aarch64-none*/bin/):$PATH
+           RPI=5 bash -ex build.sh
+           cp ./src/kernel*.img ./kernels/
     - name: Build for Raspberry Pi 4
       run: |
            set -ex

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Video about this project by [Floyd Steinberg](https://www.youtube.com/watch?v=Z3
 
 ## System Requirements
 
-- Raspberry Pi 1, 2, 3, 4, or 400 (Zero and Zero 2 can be used but need HDMI or a supported i2s DAC for audio out). On Raspberry Pi 1 and on Raspberry Pi Zero there will be severely limited functionality (only one tone generator instead of 8)
+- Raspberry Pi 1, 2, 3, 4, or 400. Raspberry Pi Zero and Zero 2 can be used but need HDMI or a supported i2s DAC for audio out. On Raspberry Pi 1 and on Raspberry Pi Zero there will be severely limited functionality (only one tone generator instead of 8)
+- Raspberry Pi 5 can be used but currently support is experimental; HDMI sound and USB Gadget mode are not available yet 
 - A [PCM5102A or PCM5122 based DAC](https://github.com/probonopd/MiniDexed/wiki/Hardware#i2s-dac), HDMI display or [audio extractor](https://github.com/probonopd/MiniDexed/wiki/Hardware#hdmi-to-audio) for good sound quality. If you don't have this, you can use the headphone jack on the Raspberry Pi but on anything but the Raspberry 4 the sound quality will be seriously limited
 - Optionally (but highly recommended), an [LCDC1602 Display](https://www.berrybase.de/en/sensors-modules/displays/alphanumeric-displays/alphanumerisches-lcd-16x2-gr-252-n/gelb) (with or without i2c "backpack" board) and a [KY-040 rotary encoder](https://www.berrybase.de/en/components/passive-components/potentiometer/rotary-encoder/drehregler/rotary-encoder-mit-breakoutboard-ohne-gewinde-und-mutter)
 

--- a/src/config.txt
+++ b/src/config.txt
@@ -10,7 +10,7 @@ gpu_mem=16
 disable_overscan=0
 
 #
-# Use 64-bit for RPi 3, 4, 400 and Zero 2, and 32-bit for all other models
+# Use 64-bit for RPi 3, 4, 400, 5 and Zero 2, and 32-bit for all other models
 #
 
 [pi3]
@@ -24,3 +24,7 @@ kernel=kernel8-rpi4.img
 # Zero 2 W
 [pi02]
 arm_64bit=1
+
+[pi5]
+arm_64bit=1
+kernel=kernel_2712.img

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -68,8 +68,12 @@ bool CKernel::Initialize (void)
 	
 	if (m_Config.GetUSBGadgetMode())
 	{
+#if RASPPI==5
+#warning No support for USB Gadget Mode on RPI 5 yet
+#else
 		// Run the USB stack in USB Gadget (device) mode
 		m_pUSB = new CUSBMiniDexedMIDIGadget (&mInterrupt);
+#endif
 	}
 	else
 	{

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -103,7 +103,11 @@ CMiniDexed::CMiniDexed (CConfig *pConfig, CInterruptSystem *pInterrupt,
 		
 	if (pConfig->GetUSBGadgetMode())
 	{
+#if RASPPI==5
+		LOGNOTE ("USB Gadget (Device) Mode NOT supported on RPI 5");
+#else
 		LOGNOTE ("USB In Gadget (Device) Mode");
+#endif
 	}
 	else
 	{
@@ -128,6 +132,9 @@ CMiniDexed::CMiniDexed (CConfig *pConfig, CInterruptSystem *pInterrupt,
 	}
 	else if (strcmp (pDeviceName, "hdmi") == 0)
 	{
+#if RASPPI==5
+		LOGNOTE ("HDMI mode NOT supported on RPI 5.");
+#else
 		LOGNOTE ("HDMI mode");
 
 		m_pSoundDevice = new CHDMISoundBaseDevice (pInterrupt, pConfig->GetSampleRate (),
@@ -136,6 +143,7 @@ CMiniDexed::CMiniDexed (CConfig *pConfig, CInterruptSystem *pInterrupt,
 		// The channels are swapped by default in the HDMI sound driver.
 		// TODO: Remove this line, when this has been fixed in the driver.
 		m_bChannelsSwapped = !m_bChannelsSwapped;
+#endif
 	}
 	else
 	{

--- a/src/serialmididevice.cpp
+++ b/src/serialmididevice.cpp
@@ -28,11 +28,15 @@
 
 LOGMODULE("serialmididevice");
 
+// There are several UART options - see circle/include/serial.h
+// 0 corresponds to GP14/GP15 on all RPi versions.
+#define SERIAL_MIDI_DEVICE 0
+
 CSerialMIDIDevice::CSerialMIDIDevice (CMiniDexed *pSynthesizer, CInterruptSystem *pInterrupt,
 				      CConfig *pConfig, CUserInterface *pUI)
 :	CMIDIDevice (pSynthesizer, pConfig, pUI),
 	m_pConfig (pConfig),
-	m_Serial (pInterrupt, TRUE),
+	m_Serial (pInterrupt, TRUE, SERIAL_MIDI_DEVICE),
 	m_nSerialState (0),
 	m_nSysEx (0),
 	m_SendBuffer (&m_Serial)

--- a/src/usbminidexedmidigadget.h
+++ b/src/usbminidexedmidigadget.h
@@ -22,6 +22,23 @@
 #ifndef _usbminidexedmidigadget_h
 #define _usbminidexedmidigadget_h
 
+#if RASPPI==5
+#include <circle/sysconfig.h>
+#include <assert.h>
+
+#warning No support for USB Gadget Mode on RPI 5 yet
+class CUSBMiniDexedMIDIGadget
+{
+public:
+	CUSBMiniDexedMIDIGadget (CInterruptSystem *pInterruptSystem)
+	{
+	}
+
+	~CUSBMiniDexedMIDIGadget (void)
+	{
+	}
+};
+#else
 #include <circle/usb/gadget/usbmidigadget.h>
 #include <circle/usb/gadget/usbmidigadgetendpoint.h>
 #include <circle/sysconfig.h>
@@ -82,5 +99,6 @@ protected:
 		return CUSBMIDIGadget::GetDescriptor(wValue, wIndex, pLength);
 	}
 };
+#endif
 
 #endif

--- a/submod.sh
+++ b/submod.sh
@@ -6,13 +6,13 @@ git submodule update --init --recursive
 #
 # Use fixed master branch of circle-stdlib then re-update
 cd circle-stdlib/
-git checkout 695ab4a
+git checkout 3bd135d
 git submodule update --init --recursive
 cd -
 #
 # Optional update submodules explicitly
 cd circle-stdlib/libs/circle
-git checkout fe09c4b
+git checkout 4b3e06f
 cd -
 cd circle-stdlib/libs/circle-newlib
 #git checkout develop


### PR DESCRIPTION
Initial support for RPI 5 based on develop branch of circle.

This is ***very experimental***.  Not to be merged at this time!

Known not to work:
* HDMI sound support (disabled in minidexed.cpp)
* USB Gadget support (disabled in kernel.cpp and usbminidexedmidigadget.h

I've seen it working with PCM5102 I2S sound, HD44780 (non I2C) display, HDMI console output, rotary encoder, USB keyboard.  It probably works with PWM sound output if you have the additional PWM filter hardware on GPIO pins 12/13...

Update: Looks like I2C SSD1306 is fine, so I'd guess I2C HD44780 ought to work too.
Update: Serial MIDI now working fine.

Everything else: I've no idea :)

Note: to get this running needs the latest boot files from Raspberry Pi (see the circle documentation), an updated config.txt (part of this commit) and the new kernel_2712.img file built when RPI=5.

I've not done anything with the automated build process, but if someone wants to fight with the build.yml file, feel free!  

Otherwise to build you'll need to ensure you are building the develop branches of circle-stdlib and circle itself (see the submod.sh file).

Apart from that, well, it seems to work :)

By the way, I don't think we say this enough... Rene is amazing for his circle environment that is doing all the heavy lifting here :)

Also, on that point, now we've upgraded to a more recent circle, we need to be testing the builds for RPi 1,2,3,4 too before accepting this change!

Kevin

![IMG_7785](https://github.com/probonopd/MiniDexed/assets/68612569/124bd390-a010-4cda-bcff-338585aaf315)
