### PR TITLE
Support for ST7789 based (SPI) displays

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -102,6 +102,15 @@ void CConfig::Load (void)
 	m_bSSD1306LCDRotate = m_Properties.GetNumber ("SSD1306LCDRotate", 0) != 0;
 	m_bSSD1306LCDMirror = m_Properties.GetNumber ("SSD1306LCDMirror", 0) != 0;
 
+	m_nSPIBus = m_Properties.GetNumber ("SPIBus", SPI_INACTIVE);  // Disabled by default
+	m_bST7789Enabled = m_Properties.GetNumber ("ST7789Enabled", 0) != 0;
+	m_nST7789Data = m_Properties.GetNumber ("ST7789Data", 0);
+	m_nST7789Select = m_Properties.GetNumber ("ST7789Select", 0);
+	m_nST7789Reset = m_Properties.GetNumber ("ST7789Reset", 0);  // optional
+	m_nST7789Backlight = m_Properties.GetNumber ("ST7789Backlight", 0);  // optional
+	m_nST7789Width = m_Properties.GetNumber ("ST7789Width", 240);
+	m_nST7789Height = m_Properties.GetNumber ("ST7789Height", 240);
+
 	m_nLCDColumns = m_Properties.GetNumber ("LCDColumns", 16);
 	m_nLCDRows = m_Properties.GetNumber ("LCDRows", 2);
 
@@ -297,6 +306,46 @@ bool CConfig::GetSSD1306LCDRotate (void) const
 bool CConfig::GetSSD1306LCDMirror (void) const
 {
 	return m_bSSD1306LCDMirror;
+}
+
+unsigned CConfig::GetSPIBus (void) const
+{
+	return m_nSPIBus;
+}
+
+bool CConfig::GetST7789Enabled (void) const
+{
+	return m_bST7789Enabled;
+}
+
+unsigned CConfig::GetST7789Data (void) const
+{
+	return m_nST7789Data;
+}
+
+unsigned CConfig::GetST7789Select (void) const
+{
+	return m_nST7789Select;
+}
+
+unsigned CConfig::GetST7789Reset (void) const
+{
+	return m_nST7789Reset;
+}
+
+unsigned CConfig::GetST7789Backlight (void) const
+{
+	return m_nST7789Backlight;
+}
+
+unsigned CConfig::GetST7789Width (void) const
+{
+	return m_nST7789Width;
+}
+
+unsigned CConfig::GetST7789Height (void) const
+{
+	return m_nST7789Height;
 }
 
 unsigned CConfig::GetLCDColumns (void) const

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -103,6 +103,9 @@ void CConfig::Load (void)
 	m_bSSD1306LCDMirror = m_Properties.GetNumber ("SSD1306LCDMirror", 0) != 0;
 
 	m_nSPIBus = m_Properties.GetNumber ("SPIBus", SPI_INACTIVE);  // Disabled by default
+	m_nSPIMode = m_Properties.GetNumber ("SPIMode", SPI_DEF_MODE);
+	m_nSPIClockKHz = m_Properties.GetNumber ("SPIClockKHz", SPI_DEF_CLOCK);
+
 	m_bST7789Enabled = m_Properties.GetNumber ("ST7789Enabled", 0) != 0;
 	m_nST7789Data = m_Properties.GetNumber ("ST7789Data", 0);
 	m_nST7789Select = m_Properties.GetNumber ("ST7789Select", 0);
@@ -312,6 +315,16 @@ bool CConfig::GetSSD1306LCDMirror (void) const
 unsigned CConfig::GetSPIBus (void) const
 {
 	return m_nSPIBus;
+}
+
+unsigned CConfig::GetSPIMode (void) const
+{
+	return m_nSPIMode;
+}
+
+unsigned CConfig::GetSPIClockKHz (void) const
+{
+	return m_nSPIClockKHz;
 }
 
 bool CConfig::GetST7789Enabled (void) const

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -114,6 +114,7 @@ void CConfig::Load (void)
 	m_nST7789Width = m_Properties.GetNumber ("ST7789Width", 240);
 	m_nST7789Height = m_Properties.GetNumber ("ST7789Height", 240);
 	m_nST7789Rotation = m_Properties.GetNumber ("ST7789Rotation", 0);
+	m_bST7789SmallFont = m_Properties.GetNumber ("ST7789SmallFont", 0) != 0;
 
 	m_nLCDColumns = m_Properties.GetNumber ("LCDColumns", 16);
 	m_nLCDRows = m_Properties.GetNumber ("LCDRows", 2);
@@ -367,6 +368,10 @@ unsigned CConfig::GetST7789Rotation (void) const
 	return m_nST7789Rotation;
 }
 
+bool CConfig::GetST7789SmallFont (void) const
+{
+	return m_bST7789SmallFont;
+}
 unsigned CConfig::GetLCDColumns (void) const
 {
 	return m_nLCDColumns;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -110,6 +110,7 @@ void CConfig::Load (void)
 	m_nST7789Backlight = m_Properties.GetNumber ("ST7789Backlight", 0);  // optional
 	m_nST7789Width = m_Properties.GetNumber ("ST7789Width", 240);
 	m_nST7789Height = m_Properties.GetNumber ("ST7789Height", 240);
+	m_nST7789Rotation = m_Properties.GetNumber ("ST7789Rotation", 0);
 
 	m_nLCDColumns = m_Properties.GetNumber ("LCDColumns", 16);
 	m_nLCDRows = m_Properties.GetNumber ("LCDRows", 2);
@@ -346,6 +347,11 @@ unsigned CConfig::GetST7789Width (void) const
 unsigned CConfig::GetST7789Height (void) const
 {
 	return m_nST7789Height;
+}
+
+unsigned CConfig::GetST7789Rotation (void) const
+{
+	return m_nST7789Rotation;
 }
 
 unsigned CConfig::GetLCDColumns (void) const

--- a/src/config.h
+++ b/src/config.h
@@ -30,8 +30,8 @@
 
 #define SPI_INACTIVE	255
 #define SPI_CLOCK_SPEED	15000000	// Hz
-#define SPI_CPOL		1			// Taken from circle sample application
-#define SPI_CPHA		0
+#define SPI_CPOL		0			// Taken from circle sample application
+#define SPI_CPHA		0			// Apparently Mode 0 (0,0) is common...?
 
 
 class CConfig		// Configuration for MiniDexed
@@ -118,6 +118,7 @@ public:
 	unsigned GetST7789Backlight (void) const;
 	unsigned GetST7789Width (void) const;
 	unsigned GetST7789Height (void) const;
+	unsigned GetST7789Rotation (void) const;
 
 	unsigned GetLCDColumns (void) const;
 	unsigned GetLCDRows (void) const;
@@ -229,6 +230,7 @@ private:
 	unsigned m_nST7789Backlight;
 	unsigned m_nST7789Width;
 	unsigned m_nST7789Height;
+	unsigned m_nST7789Rotation;
 
 	unsigned m_nLCDColumns;
 	unsigned m_nLCDRows;

--- a/src/config.h
+++ b/src/config.h
@@ -113,7 +113,7 @@ public:
 	unsigned GetSPIClockKHz (void) const;
 
 	// ST7789 LCD
-	bool GetST7789Enabled (void) const;
+	bool     GetST7789Enabled (void) const;
 	unsigned GetST7789Data (void) const;
 	unsigned GetST7789Select (void) const;
 	unsigned GetST7789Reset (void) const;
@@ -121,6 +121,7 @@ public:
 	unsigned GetST7789Width (void) const;
 	unsigned GetST7789Height (void) const;
 	unsigned GetST7789Rotation (void) const;
+	bool     GetST7789SmallFont (void) const;
 
 	unsigned GetLCDColumns (void) const;
 	unsigned GetLCDRows (void) const;
@@ -236,6 +237,7 @@ private:
 	unsigned m_nST7789Width;
 	unsigned m_nST7789Height;
 	unsigned m_nST7789Rotation;
+	unsigned m_bST7789SmallFont;
 
 	unsigned m_nLCDColumns;
 	unsigned m_nLCDRows;

--- a/src/config.h
+++ b/src/config.h
@@ -30,8 +30,8 @@
 
 #define SPI_INACTIVE	255
 #define SPI_CLOCK_SPEED	15000000	// Hz
-#define SPI_CPOL		0			// Taken from circle sample application
-#define SPI_CPHA		0			// Apparently Mode 0 (0,0) is common...?
+#define SPI_CPOL	0		// Taken from circle sample application
+#define SPI_CPHA	0		// Apparently Mode 0 (0,0) is common...?
 
 
 class CConfig		// Configuration for MiniDexed

--- a/src/config.h
+++ b/src/config.h
@@ -29,10 +29,8 @@
 #include <string>
 
 #define SPI_INACTIVE	255
-#define SPI_CLOCK_SPEED	15000000	// Hz
-#define SPI_CPOL	0		// Taken from circle sample application
-#define SPI_CPHA	0		// Apparently Mode 0 (0,0) is common...?
-
+#define SPI_DEF_CLOCK	15000	// kHz
+#define SPI_DEF_MODE	0		// Default mode (0,1,2,3)
 
 class CConfig		// Configuration for MiniDexed
 {
@@ -109,8 +107,12 @@ public:
 	bool     GetSSD1306LCDRotate (void) const;
 	bool     GetSSD1306LCDMirror (void) const;
 
-	// ST7789 LCD
+	// SPI support
 	unsigned GetSPIBus (void) const;
+	unsigned GetSPIMode (void) const;
+	unsigned GetSPIClockKHz (void) const;
+
+	// ST7789 LCD
 	bool GetST7789Enabled (void) const;
 	unsigned GetST7789Data (void) const;
 	unsigned GetST7789Select (void) const;
@@ -223,6 +225,9 @@ private:
 	bool     m_bSSD1306LCDMirror;
 
 	unsigned m_nSPIBus;
+	unsigned m_nSPIMode;
+	unsigned m_nSPIClockKHz;
+
 	bool     m_bST7789Enabled;
 	unsigned m_nST7789Data;
 	unsigned m_nST7789Select;

--- a/src/config.h
+++ b/src/config.h
@@ -28,6 +28,12 @@
 #include <circle/sysconfig.h>
 #include <string>
 
+#define SPI_INACTIVE	255
+#define SPI_CLOCK_SPEED	15000000	// Hz
+#define SPI_CPOL		1			// Taken from circle sample application
+#define SPI_CPHA		0
+
+
 class CConfig		// Configuration for MiniDexed
 {
 public:
@@ -102,6 +108,16 @@ public:
 	unsigned GetSSD1306LCDHeight (void) const;
 	bool     GetSSD1306LCDRotate (void) const;
 	bool     GetSSD1306LCDMirror (void) const;
+
+	// ST7789 LCD
+	unsigned GetSPIBus (void) const;
+	bool GetST7789Enabled (void) const;
+	unsigned GetST7789Data (void) const;
+	unsigned GetST7789Select (void) const;
+	unsigned GetST7789Reset (void) const;
+	unsigned GetST7789Backlight (void) const;
+	unsigned GetST7789Width (void) const;
+	unsigned GetST7789Height (void) const;
 
 	unsigned GetLCDColumns (void) const;
 	unsigned GetLCDRows (void) const;
@@ -204,7 +220,16 @@ private:
 	unsigned m_nSSD1306LCDHeight;
 	bool     m_bSSD1306LCDRotate;
 	bool     m_bSSD1306LCDMirror;
-	
+
+	unsigned m_nSPIBus;
+	bool     m_bST7789Enabled;
+	unsigned m_nST7789Data;
+	unsigned m_nST7789Select;
+	unsigned m_nST7789Reset;
+	unsigned m_nST7789Backlight;
+	unsigned m_nST7789Width;
+	unsigned m_nST7789Height;
+
 	unsigned m_nLCDColumns;
 	unsigned m_nLCDRows;
 	

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -68,6 +68,8 @@ bool CKernel::Initialize (void)
 	m_Config.Load ();
 	
 	unsigned nSPIMaster = m_Config.GetSPIBus();
+	unsigned nSPIMode = m_Config.GetSPIMode();
+	unsigned long nSPIClock = 1000 * m_Config.GetSPIClockKHz();
 #if RASPPI<4
 	// By default older RPI versions use SPI 0.
 	// It is possible to build circle to support SPI 1 for
@@ -81,7 +83,9 @@ bool CKernel::Initialize (void)
 	if (nSPIMaster == 0 || nSPIMaster == 3 || nSPIMaster == 4 || nSPIMaster == 5 || nSPIMaster == 6)
 #endif
 	{
-		m_pSPIMaster = new CSPIMaster (SPI_CLOCK_SPEED, SPI_CPOL, SPI_CPHA, nSPIMaster);
+		unsigned nCPHA = (nSPIMode & 1) ? 1 : 0;
+		unsigned nCPOL = (nSPIMode & 2) ? 1 : 0;
+		m_pSPIMaster = new CSPIMaster (nSPIClock, nCPOL, nCPHA, nSPIMaster);
 		if (!m_pSPIMaster->Initialize())
 		{
 			delete (m_pSPIMaster);

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -24,6 +24,7 @@
 #include <circle/cputhrottle.h>
 #include <circle/gpiomanager.h>
 #include <circle/i2cmaster.h>
+#include <circle/spimaster.h>
 #include <circle/usb/usbcontroller.h>
 #include "config.h"
 #include "minidexed.h"
@@ -54,6 +55,7 @@ private:
 	CCPUThrottle	m_CPUThrottle;
 	CGPIOManager	m_GPIOManager;
 	CI2CMaster	m_I2CMaster;
+	CSPIMaster	*m_pSPIMaster;
 	CMiniDexed	*m_pDexed;
 	CUSBController *m_pUSB;
 

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -31,13 +31,13 @@
 LOGMODULE ("minidexed");
 
 CMiniDexed::CMiniDexed (CConfig *pConfig, CInterruptSystem *pInterrupt,
-			CGPIOManager *pGPIOManager, CI2CMaster *pI2CMaster, FATFS *pFileSystem)
+			CGPIOManager *pGPIOManager, CI2CMaster *pI2CMaster, CSPIMaster *pSPIMaster, FATFS *pFileSystem)
 :
 #ifdef ARM_ALLOW_MULTI_CORE
 	CMultiCoreSupport (CMemorySystem::Get ()),
 #endif
 	m_pConfig (pConfig),
-	m_UI (this, pGPIOManager, pI2CMaster, pConfig),
+	m_UI (this, pGPIOManager, pI2CMaster, pSPIMaster, pConfig),
 	m_PerformanceConfig (pFileSystem),
 	m_PCKeyboard (this, pConfig, &m_UI),
 	m_SerialMIDI (this, pInterrupt, pConfig, &m_UI),

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -36,6 +36,7 @@
 #include <circle/interrupt.h>
 #include <circle/gpiomanager.h>
 #include <circle/i2cmaster.h>
+#include <circle/spimaster.h>
 #include <circle/multicore.h>
 #include <circle/sound/soundbasedevice.h>
 #include <circle/spinlock.h>
@@ -51,7 +52,7 @@ class CMiniDexed
 {
 public:
 	CMiniDexed (CConfig *pConfig, CInterruptSystem *pInterrupt,
-		    CGPIOManager *pGPIOManager, CI2CMaster *pI2CMaster, FATFS *pFileSystem);
+		    CGPIOManager *pGPIOManager, CI2CMaster *pI2CMaster, CSPIMaster *pSPIMaster, FATFS *pFileSystem);
 
 	bool Initialize (void);
 

--- a/src/minidexed.ini
+++ b/src/minidexed.ini
@@ -56,10 +56,14 @@ SSD1306LCDRotate=0
 SSD1306LCDMirror=0
 
 # ST7789 LCD
-# SPIBus=0 for any RPi (GPIO 10,11,8,7)
+# SPIBus=0 for any RPi (GPIO 10,11,8,7).
+#     Note: Leave blank (default) if no SPI device required.
 # Select=0|1 for CE0 or CE1
 # Data = GPIO pin number
 # Optional: Reset, Backlight = GPIO pin numbers
+# Rotation=0,90,180,270
+#
+# For a 240 wide display set LCDColumns=15 with LCDRows=2
 SPIBus=
 ST7789Enabled=0
 ST7789Data=
@@ -68,6 +72,7 @@ ST7789Reset=
 ST7789Backlight=
 ST7789Width=240
 ST7789Height=240
+ST7789Rotation=0
 
 # Default is 16x2 display (e.g. HD44780)
 LCDColumns=16

--- a/src/minidexed.ini
+++ b/src/minidexed.ini
@@ -62,6 +62,7 @@ SSD1306LCDMirror=0
 # Data = GPIO pin number
 # Optional: Reset, Backlight = GPIO pin numbers
 # Rotation=0,90,180,270
+# SmallFont=0 (default), 1
 #
 # For a 240 wide display set LCDColumns=15 with LCDRows=2
 SPIBus=
@@ -73,6 +74,7 @@ ST7789Backlight=
 ST7789Width=240
 ST7789Height=240
 ST7789Rotation=0
+ST7789SmallFont=0
 
 # Default is 16x2 display (e.g. HD44780)
 LCDColumns=16

--- a/src/minidexed.ini
+++ b/src/minidexed.ini
@@ -55,6 +55,20 @@ SSD1306LCDHeight=32
 SSD1306LCDRotate=0
 SSD1306LCDMirror=0
 
+# ST7789 LCD
+# SPIBus=0 for any RPi (GPIO 10,11,8,7)
+# Select=0|1 for CE0 or CE1
+# Data = GPIO pin number
+# Optional: Reset, Backlight = GPIO pin numbers
+SPIBus=
+ST7789Enabled=0
+ST7789Data=
+ST7789Select=
+ST7789Reset=
+ST7789Backlight=
+ST7789Width=240
+ST7789Height=240
+
 # Default is 16x2 display (e.g. HD44780)
 LCDColumns=16
 LCDRows=2

--- a/src/userinterface.cpp
+++ b/src/userinterface.cpp
@@ -79,8 +79,6 @@ bool CUserInterface::Initialize (void)
 				return false;
 			}
 
-			LOGDBG ("ST7789 Params: dc=%d, cs=%d", m_pConfig->GetST7789Data(), m_pConfig->GetST7789Select());
-
 			m_pST7789Display = new CST7789Display (m_pSPIMaster,
 													m_pConfig->GetST7789Data(),
 													m_pConfig->GetST7789Reset(),
@@ -89,9 +87,9 @@ bool CUserInterface::Initialize (void)
 													m_pConfig->GetST7789Height(),
 													SPI_CPOL, SPI_CPHA, SPI_CLOCK_SPEED,
 													m_pConfig->GetST7789Select());
-			LOGDBG ("ST7789 Display OK");
 			if (m_pST7789Display->Initialize())
 			{
+				m_pST7789Display->SetRotation (m_pConfig->GetST7789Rotation());
 				m_pST7789 = new CST7789Device (m_pSPIMaster, m_pST7789Display, m_pConfig->GetLCDColumns (), m_pConfig->GetLCDRows ());
 				if (m_pST7789->Initialize())
 				{
@@ -268,7 +266,7 @@ void CUserInterface::DisplayWrite (const char *pMenu, const char *pParam, const 
 	CString Value (" ");
 	if (bArrowDown)
 	{
-		Value = "\x7F";			// arrow left character
+		Value = "<";			// arrow left character
 	}
 
 	Value.Append (pValue);
@@ -283,7 +281,7 @@ void CUserInterface::DisplayWrite (const char *pMenu, const char *pParam, const 
 			}
 		}
 
-		Value.Append ("\x7E");		// arrow right character
+		Value.Append (">");		// arrow right character
 	}
 
 	Msg.Append (Value);

--- a/src/userinterface.cpp
+++ b/src/userinterface.cpp
@@ -79,13 +79,18 @@ bool CUserInterface::Initialize (void)
 				return false;
 			}
 
+			unsigned long nSPIClock = 1000 * m_pConfig->GetSPIClockKHz();
+			unsigned nSPIMode = m_pConfig->GetSPIMode();
+			unsigned nCPHA = (nSPIMode & 1) ? 1 : 0;
+			unsigned nCPOL = (nSPIMode & 2) ? 1 : 0;
+			LOGDBG("SPI: CPOL=%u; CPHA=%u; CLK=%u",nCPOL,nCPHA,nSPIClock);
 			m_pST7789Display = new CST7789Display (m_pSPIMaster,
 							m_pConfig->GetST7789Data(),
 							m_pConfig->GetST7789Reset(),
 							m_pConfig->GetST7789Backlight(),
 							m_pConfig->GetST7789Width(),
 							m_pConfig->GetST7789Height(),
-							SPI_CPOL, SPI_CPHA, SPI_CLOCK_SPEED,
+							nCPOL, nCPHA, nSPIClock,
 							m_pConfig->GetST7789Select());
 			if (m_pST7789Display->Initialize())
 			{

--- a/src/userinterface.cpp
+++ b/src/userinterface.cpp
@@ -80,13 +80,13 @@ bool CUserInterface::Initialize (void)
 			}
 
 			m_pST7789Display = new CST7789Display (m_pSPIMaster,
-													m_pConfig->GetST7789Data(),
-													m_pConfig->GetST7789Reset(),
-													m_pConfig->GetST7789Backlight(),
-													m_pConfig->GetST7789Width(),
-													m_pConfig->GetST7789Height(),
-													SPI_CPOL, SPI_CPHA, SPI_CLOCK_SPEED,
-													m_pConfig->GetST7789Select());
+							m_pConfig->GetST7789Data(),
+							m_pConfig->GetST7789Reset(),
+							m_pConfig->GetST7789Backlight(),
+							m_pConfig->GetST7789Width(),
+							m_pConfig->GetST7789Height(),
+							SPI_CPOL, SPI_CPHA, SPI_CLOCK_SPEED,
+							m_pConfig->GetST7789Select());
 			if (m_pST7789Display->Initialize())
 			{
 				m_pST7789Display->SetRotation (m_pConfig->GetST7789Rotation());

--- a/src/userinterface.cpp
+++ b/src/userinterface.cpp
@@ -95,7 +95,8 @@ bool CUserInterface::Initialize (void)
 			if (m_pST7789Display->Initialize())
 			{
 				m_pST7789Display->SetRotation (m_pConfig->GetST7789Rotation());
-				m_pST7789 = new CST7789Device (m_pSPIMaster, m_pST7789Display, m_pConfig->GetLCDColumns (), m_pConfig->GetLCDRows ());
+				bool bLargeFont = !(m_pConfig->GetST7789SmallFont());
+				m_pST7789 = new CST7789Device (m_pSPIMaster, m_pST7789Display, m_pConfig->GetLCDColumns (), m_pConfig->GetLCDRows (), bLargeFont, bLargeFont);
 				if (m_pST7789->Initialize())
 				{
 					LOGDBG ("LCD: ST7789");

--- a/src/userinterface.h
+++ b/src/userinterface.h
@@ -26,16 +26,18 @@
 #include <sensor/ky040.h>
 #include <display/hd44780device.h>
 #include <display/ssd1306device.h>
+#include <display/st7789device.h>
 #include <circle/gpiomanager.h>
 #include <circle/writebuffer.h>
 #include <circle/i2cmaster.h>
+#include <circle/spimaster.h>
 
 class CMiniDexed;
 
 class CUserInterface
 {
 public:
-	CUserInterface (CMiniDexed *pMiniDexed, CGPIOManager *pGPIOManager, CI2CMaster *pI2CMaster, CConfig *pConfig);
+	CUserInterface (CMiniDexed *pMiniDexed, CGPIOManager *pGPIOManager, CI2CMaster *pI2CMaster, CSPIMaster *pSPIMaster, CConfig *pConfig);
 	~CUserInterface (void);
 
 	bool Initialize (void);
@@ -68,11 +70,14 @@ private:
 	CMiniDexed *m_pMiniDexed;
 	CGPIOManager *m_pGPIOManager;
 	CI2CMaster *m_pI2CMaster;
+	CSPIMaster *m_pSPIMaster;
 	CConfig *m_pConfig;
 
 	CCharDevice    *m_pLCD;
 	CHD44780Device *m_pHD44780;
 	CSSD1306Device *m_pSSD1306;
+	CST7789Display *m_pST7789Display;
+	CST7789Device  *m_pST7789;
 	CWriteBufferDevice *m_pLCDBuffered;
 	
 	CUIButtons *m_pUIButtons;

--- a/submod.sh
+++ b/submod.sh
@@ -12,7 +12,7 @@ cd -
 #
 # Optional update submodules explicitly
 cd circle-stdlib/libs/circle
-git checkout f8c9026
+git checkout 4155f43
 cd -
 cd circle-stdlib/libs/circle-newlib
 #git checkout develop

--- a/submod.sh
+++ b/submod.sh
@@ -12,7 +12,7 @@ cd -
 #
 # Optional update submodules explicitly
 cd circle-stdlib/libs/circle
-git checkout 4b3e06f
+git checkout f8c9026
 cd -
 cd circle-stdlib/libs/circle-newlib
 #git checkout develop


### PR DESCRIPTION
Initial support for ST7789 SPI displays. Note that a typical small 240x240 display will only provide 15x2 characters.

New Minidexed.ini default settings in this build:
```
SPIBus=
ST7789Enabled=0
ST7789Data=
ST7789Select=
ST7789Reset=
ST7789Backlight=
ST7789Width=240
ST7789Height=240
ST7789Rotation=0
```
Note: default is for ST7789 and SPI support to be disabled.

I've successfully use it with my Pimoroni Pirate Audio (screen, buttons and audio output) with the following settings:
```
SoundDevice=i2s
LCDEnabled=1

SPIBus=0
ST7789Enabled=1
ST7789Data=9
ST7789Select=1
ST7789Reset=
ST7789Backlight=13
ST7789Width=240
ST7789Height=240
ST7789Rotation=90

LCDColumns=15
LCDRows=2

ButtonPinPrev=5
ButtonActionPrev=click
ButtonPinNext=6
ButtonActionNext=click
ButtonPinBack=16
ButtonActionBack=click
ButtonPinSelect=24
ButtonActionSelect=click
ButtonPinHome=16
ButtonActionHome=doubleclick
ButtonPinShortcut=0

EncoderEnabled=0
```

Kevin

![IMG_7789](https://github.com/probonopd/MiniDexed/assets/68612569/3b24b06b-630a-4345-9d6d-61ad4e02b012)

