### PR TITLE
Add support for 8 channel I2S mono audio output on RPi 5

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -85,6 +85,7 @@ void CConfig::Load (void)
 	m_bMIDIAutoVoiceDumpOnPC = m_Properties.GetNumber ("MIDIAutoVoiceDumpOnPC", 0) != 0;
 	m_bHeaderlessSysExVoices = m_Properties.GetNumber ("HeaderlessSysExVoices", 0) != 0;
 	m_bExpandPCAcrossBanks = m_Properties.GetNumber ("ExpandPCAcrossBanks", 1) != 0;
+	m_bQuadDAC8Chan = m_Properties.GetNumber ("QuadDAC8Chan", 0) != 0;
 
 	m_bLCDEnabled = m_Properties.GetNumber ("LCDEnabled", 0) != 0;
 	m_nLCDPinEnable = m_Properties.GetNumber ("LCDPinEnable", 4);
@@ -241,6 +242,11 @@ bool CConfig::GetHeaderlessSysExVoices (void) const
 bool CConfig::GetExpandPCAcrossBanks (void) const
 {
 	return m_bExpandPCAcrossBanks;
+}
+
+bool CConfig::GetQuadDAC8Chan (void) const
+{
+	return m_bQuadDAC8Chan;
 }
 
 bool CConfig::GetLCDEnabled (void) const

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -41,15 +41,22 @@ void CConfig::Load (void)
 	m_SoundDevice = m_Properties.GetString ("SoundDevice", "pwm");
 
 	m_nSampleRate = m_Properties.GetNumber ("SampleRate", 48000);
+	m_bQuadDAC8Chan = m_Properties.GetNumber ("QuadDAC8Chan", 0) != 0;
+	if (m_SoundDevice == "hdmi") {
+		m_nChunkSize = m_Properties.GetNumber ("ChunkSize", 384*6);
+	}
+	else
+	{
 #ifdef ARM_ALLOW_MULTI_CORE
-	m_nChunkSize = m_Properties.GetNumber ("ChunkSize", m_SoundDevice == "hdmi" ? 384*6 : 256);
+		m_nChunkSize = m_Properties.GetNumber ("ChunkSize", m_bQuadDAC8Chan ? 1024 : 256);  // 128 per channel
 #else
-	m_nChunkSize = m_Properties.GetNumber ("ChunkSize", m_SoundDevice == "hdmi" ? 384*6 : 1024);
+		m_nChunkSize = m_Properties.GetNumber ("ChunkSize", 1024);
 #endif
+	}
 	m_nDACI2CAddress = m_Properties.GetNumber ("DACI2CAddress", 0);
 	m_bChannelsSwapped = m_Properties.GetNumber ("ChannelsSwapped", 0) != 0;
 
-		unsigned newEngineType = m_Properties.GetNumber ("EngineType", 1);
+	unsigned newEngineType = m_Properties.GetNumber ("EngineType", 1);
 	if (newEngineType == 2) {
   		m_EngineType = MKI;
 	} else if (newEngineType == 3) {
@@ -85,7 +92,6 @@ void CConfig::Load (void)
 	m_bMIDIAutoVoiceDumpOnPC = m_Properties.GetNumber ("MIDIAutoVoiceDumpOnPC", 0) != 0;
 	m_bHeaderlessSysExVoices = m_Properties.GetNumber ("HeaderlessSysExVoices", 0) != 0;
 	m_bExpandPCAcrossBanks = m_Properties.GetNumber ("ExpandPCAcrossBanks", 1) != 0;
-	m_bQuadDAC8Chan = m_Properties.GetNumber ("QuadDAC8Chan", 0) != 0;
 
 	m_bLCDEnabled = m_Properties.GetNumber ("LCDEnabled", 0) != 0;
 	m_nLCDPinEnable = m_Properties.GetNumber ("LCDPinEnable", 4);

--- a/src/config.h
+++ b/src/config.h
@@ -87,6 +87,7 @@ public:
 	bool GetMIDIAutoVoiceDumpOnPC (void) const; // false if not specified
 	bool GetHeaderlessSysExVoices (void) const; // false if not specified
 	bool GetExpandPCAcrossBanks (void) const; // true if not specified
+	bool GetQuadDAC8Chan (void) const; // false if not specified
 
 	// HD44780 LCD
 	// GPIO pin numbers are chip numbers, not header positions
@@ -208,6 +209,7 @@ private:
 	bool m_bMIDIAutoVoiceDumpOnPC;
 	bool m_bHeaderlessSysExVoices;
 	bool m_bExpandPCAcrossBanks;
+	bool m_bQuadDAC8Chan;
 
 	bool m_bLCDEnabled;
 	unsigned m_nLCDPinEnable;

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -279,7 +279,12 @@ bool CMiniDexed::Initialize (void)
 		Channels = 2;	// 16-bit Stereo
 	}
 #endif
-	if (!m_pSoundDevice->AllocateQueueFrames (m_pConfig->GetChunkSize () / Channels))
+	// Need 2 x ChunkSize / Channel queue frames as the audio driver uses
+	// two DMA channels each of ChunkSize and one single single frame
+	// contains a sample for each of all the channels.
+	//
+	// See discussion here: https://github.com/rsta2/circle/discussions/453
+	if (!m_pSoundDevice->AllocateQueueFrames (2 * m_pConfig->GetChunkSize () / Channels))
 	{
 		LOGERR ("Cannot allocate sound queue");
 

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -279,7 +279,7 @@ bool CMiniDexed::Initialize (void)
 		Channels = 2;	// 16-bit Stereo
 	}
 #endif
-	if (!m_pSoundDevice->AllocateQueueFrames (Channels * m_pConfig->GetChunkSize ()))
+	if (!m_pSoundDevice->AllocateQueueFrames (m_pConfig->GetChunkSize () / Channels))
 	{
 		LOGERR ("Cannot allocate sound queue");
 

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -298,6 +298,7 @@ private:
 	CPCKeyboard m_PCKeyboard;
 	CSerialMIDIDevice m_SerialMIDI;
 	bool m_bUseSerial;
+	bool m_bQuadDAC8Chan;
 
 	CSoundBaseDevice *m_pSoundDevice;
 	bool m_bChannelsSwapped;

--- a/submod.sh
+++ b/submod.sh
@@ -12,7 +12,7 @@ cd -
 #
 # Optional update submodules explicitly
 cd circle-stdlib/libs/circle
-git checkout 4155f43
+git checkout fff3764
 cd -
 cd circle-stdlib/libs/circle-newlib
 #git checkout develop


### PR DESCRIPTION
Support for 8 channel mono audio output - one per Tone Generator - on a Raspberry Pi 5 only.  This uses the four I2S lanes of the Raspberry Pi and can be configuring by adding
`QuadDAC8Chan=1`
to minidexed.ini.

It will be off by default.

Note: if enabled, then pan and effects are ignored and each TG will just have a direct output to one of the four stereo outputs as follows:
TG 0 = I2S module 1 L
TG 1 = I2S module 1 R
TG 2 = I2S module 2 L
...
TG 8 = I2S module 4 R

I2S modules will share LCK/BCK but the four DIN lines will need to be connected to GPIO 21, 23, 25, 27.

Requires the latest circle develop branch.

See discussions here: https://github.com/probonopd/MiniDexed/discussions/655 and https://github.com/rsta2/circle/discussions/453

This should support the HiFiBerry DAC8X board (untested) or four GY-PCM5102 modules (tested) as described here: https://diyelectromusic.wordpress.com/2024/05/27/rpi-5-quad-stereo-sound-with-pcm5102a/

As always, this needs testing with more normal configurations to make sure nothing has been broken with sound output across all Pi versions with I2S.

Post reply below if you test it and with what configuration :)

Kevin