### PR TITLE
Try USBGadgetPin

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -46,8 +46,6 @@ void CConfig::Load (void)
 		m_bUSBGadgetMode = true;
 	}
 
-	m_bUSBGadgetMode = m_Properties.GetNumber ("USBGadget", 0) != 0;
-
 	m_SoundDevice = m_Properties.GetString ("SoundDevice", "pwm");
 
 	m_nSampleRate = m_Properties.GetNumber ("SampleRate", 48000);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -39,9 +39,8 @@ void CConfig::Load (void)
 	
 	m_bUSBGadgetMode = m_Properties.GetNumber ("USBGadget", 0) != 0;
 	unsigned usbGadgetPinNumber = m_Properties.GetNumber ("USBGadgetPin", 26); // Default to GPIO pin 26 if not specified
-	CGPIOPin usbGadgetPin(usbGadgetPinNumber);
-	usbGadgetPin.Input();
-	usbGadgetPin.PullUp();  // Enable the internal pull-up resistor
+	CGPIOPin usbGadgetPin(usbGadgetPinNumber, GPIOModeInputPullUp);
+	
 	if (usbGadgetPin.Read() == 0)  // If the pin is pulled down
 	{
 		m_bUSBGadgetMode = true;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -22,6 +22,7 @@
 //
 #include "config.h"
 #include "../Synth_Dexed/src/dexed.h"
+#include <circle/gpiopin.h>
 
 CConfig::CConfig (FATFS *pFileSystem)
 :	m_Properties ("minidexed.ini", pFileSystem)
@@ -36,6 +37,16 @@ void CConfig::Load (void)
 {
 	m_Properties.Load ();
 	
+	m_bUSBGadgetMode = m_Properties.GetNumber ("USBGadget", 0) != 0;
+	unsigned usbGadgetPinNumber = m_Properties.GetNumber ("USBGadgetPin", 26); // Default to GPIO pin 26 if not specified
+	CGPIOPin usbGadgetPin(usbGadgetPinNumber);
+	usbGadgetPin.Input();
+	usbGadgetPin.PullUp();  // Enable the internal pull-up resistor
+	if (usbGadgetPin.Read() == 0)  // If the pin is pulled down
+	{
+		m_bUSBGadgetMode = true;
+	}
+
 	m_bUSBGadgetMode = m_Properties.GetNumber ("USBGadget", 0) != 0;
 
 	m_SoundDevice = m_Properties.GetString ("SoundDevice", "pwm");


### PR DESCRIPTION
Allow for 

```
USBGadget=0  ; Default to 0 (not in gadget mode)
USBGadgetPin=26  ; Default GPIO pin 26
```

as per https://github.com/probonopd/MiniDexed/discussions/669:

If either `USBGadget` is set to `1` or `USBGadgetPin` is pulled down, then we enable gadget mode.