### PR TITLE
Initial implementation of system-level, i.e. all TG, MIDI control maps

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -108,6 +108,10 @@ void CConfig::Load (void)
 	m_bMIDIAutoVoiceDumpOnPC = m_Properties.GetNumber ("MIDIAutoVoiceDumpOnPC", 0) != 0;
 	m_bHeaderlessSysExVoices = m_Properties.GetNumber ("HeaderlessSysExVoices", 0) != 0;
 	m_bExpandPCAcrossBanks = m_Properties.GetNumber ("ExpandPCAcrossBanks", 1) != 0;
+	
+	m_nMIDISystemCCVol = m_Properties.GetNumber ("MIDISystemCCVol", 0);
+	m_nMIDISystemCCPan = m_Properties.GetNumber ("MIDISystemCCPan", 0);
+	m_nMIDISystemCCDetune = m_Properties.GetNumber ("MIDISystemCCDetune", 0);
 
 	m_bLCDEnabled = m_Properties.GetNumber ("LCDEnabled", 0) != 0;
 	m_nLCDPinEnable = m_Properties.GetNumber ("LCDPinEnable", 4);
@@ -283,6 +287,11 @@ unsigned CConfig::GetEngineType (void) const
 	return m_EngineType;
 }
 
+bool CConfig::GetQuadDAC8Chan (void) const
+{
+	return m_bQuadDAC8Chan;
+}
+
 unsigned CConfig::GetMIDIBaudRate (void) const
 {
 	return m_nMIDIBaudRate;
@@ -323,9 +332,19 @@ bool CConfig::GetExpandPCAcrossBanks (void) const
 	return m_bExpandPCAcrossBanks;
 }
 
-bool CConfig::GetQuadDAC8Chan (void) const
+unsigned CConfig::GetMIDISystemCCVol (void) const
 {
-	return m_bQuadDAC8Chan;
+	return m_nMIDISystemCCVol;
+}
+
+unsigned CConfig::GetMIDISystemCCPan (void) const
+{
+	return m_nMIDISystemCCPan;
+}
+
+unsigned CConfig::GetMIDISystemCCDetune (void) const
+{
+	return m_nMIDISystemCCDetune;
 }
 
 bool CConfig::GetLCDEnabled (void) const

--- a/src/config.h
+++ b/src/config.h
@@ -117,6 +117,7 @@ public:
 	unsigned GetDACI2CAddress (void) const;		// 0 for auto probing
 	bool GetChannelsSwapped (void) const;
 	unsigned GetEngineType (void) const;
+	bool GetQuadDAC8Chan (void) const; // false if not specified
 
 	// MIDI
 	unsigned GetMIDIBaudRate (void) const;
@@ -127,7 +128,9 @@ public:
 	bool GetMIDIAutoVoiceDumpOnPC (void) const; // false if not specified
 	bool GetHeaderlessSysExVoices (void) const; // false if not specified
 	bool GetExpandPCAcrossBanks (void) const; // true if not specified
-	bool GetQuadDAC8Chan (void) const; // false if not specified
+	unsigned GetMIDISystemCCVol (void) const;
+	unsigned GetMIDISystemCCPan (void) const;
+	unsigned GetMIDISystemCCDetune (void) const;
 
 	// HD44780 LCD
 	// GPIO pin numbers are chip numbers, not header positions
@@ -245,6 +248,7 @@ private:
 	unsigned m_nDACI2CAddress;
 	bool m_bChannelsSwapped;
 	unsigned m_EngineType;
+	bool m_bQuadDAC8Chan;
 
 	unsigned m_nMIDIBaudRate;
 	std::string m_MIDIThruIn;
@@ -254,7 +258,9 @@ private:
 	bool m_bMIDIAutoVoiceDumpOnPC;
 	bool m_bHeaderlessSysExVoices;
 	bool m_bExpandPCAcrossBanks;
-	bool m_bQuadDAC8Chan;
+	unsigned m_nMIDISystemCCVol;
+	unsigned m_nMIDISystemCCPan;
+	unsigned m_nMIDISystemCCDetune;
 
 	bool m_bLCDEnabled;
 	unsigned m_nLCDPinEnable;

--- a/src/mididevice.cpp
+++ b/src/mididevice.cpp
@@ -283,6 +283,7 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 
 		// Process MIDI for each active Tone Generator
 		bool bSystemCCHandled = false;
+		bool bSystemCCChecked = false;
 		for (unsigned nTG = 0; nTG < m_pConfig->GetToneGenerators() && !bSystemCCHandled; nTG++)
 		{
 			if (ucStatus == MIDI_SYSTEM_EXCLUSIVE_BEGIN)
@@ -423,8 +424,9 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 							// Also, if successfully handled, then no need to process other TGs,
 							// so it is possible to break out of the main TG loop too.
 							// Note: We handle this here so we get the TG MIDI channel checking.
-							if (!bSystemCCHandled) {
+							if (!bSystemCCChecked) {
 								bSystemCCHandled = HandleMIDISystemCC(pMessage[1], pMessage[2]);
+								bSystemCCChecked = true;
 							}
 							break;
 						}

--- a/src/mididevice.h
+++ b/src/mididevice.h
@@ -60,6 +60,10 @@ protected:
 	void MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsigned nCable = 0);
 	void AddDevice (const char *pDeviceName);
 	void HandleSystemExclusive(const uint8_t* pMessage, const size_t nLength, const unsigned nCable, const uint8_t nTG);
+
+private:
+	bool HandleMIDISystemCC(const u8 ucCC, const u8 ucCCval);
+
 private:
 	CMiniDexed *m_pSynthesizer;
 	CConfig *m_pConfig;
@@ -70,6 +74,7 @@ private:
 	unsigned m_nMIDISystemCCVol;
 	unsigned m_nMIDISystemCCPan;
 	unsigned m_nMIDISystemCCDetune;
+	u32	 m_MIDISystemCCBitmap[4]; // to allow for 128 bit entries
 
 	std::string m_DeviceName;
 

--- a/src/mididevice.h
+++ b/src/mididevice.h
@@ -66,6 +66,10 @@ private:
 	CUserInterface *m_pUI;
 
 	u8 m_ChannelMap[CConfig::AllToneGenerators];
+	
+	unsigned m_nMIDISystemCCVol;
+	unsigned m_nMIDISystemCCPan;
+	unsigned m_nMIDISystemCCDetune;
 
 	std::string m_DeviceName;
 


### PR DESCRIPTION
As per discussion here: https://github.com/probonopd/MiniDexed/discussions/702#discussioncomment-10409687

Defines the following "CC maps" for use in controlling each individual tone generator over the same MIDI channel:
0 = disabled
1 = CC 16-19, 80-83 - the General Purpose Controllers 1-8
2 = CC 20-27
3 = CC 52-59
4 = CC 102-109
5 = CC 110-117
6 = CC 3, 9, 14-15, 38-31
7 = CC 35, 41, 46-47, 60-63

Note: maps 2-7 utilise various sets of undefined in the MIDI spec MIDI CC numbers.

These can be configured in minidexed.ini for any of the following
MIDISystemCCVol=
MIDISystemCCPan=
MIDISystemCCDetune=

It has only had very, very basic testing but as a concept I think it could work.

This PR is to let people try out the concept and see if it has any merit.

Kevin