### PR TITLE
Implement Bank Select Buttons and MIDI Buttons

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -164,11 +164,15 @@ void CConfig::Load (void)
 
 	m_nButtonPinPgmUp = m_Properties.GetNumber ("ButtonPinPgmUp", 0);
 	m_nButtonPinPgmDown = m_Properties.GetNumber ("ButtonPinPgmDown", 0);
+	m_nButtonPinBankUp = m_Properties.GetNumber ("ButtonPinBankUp", 0);
+	m_nButtonPinBankDown = m_Properties.GetNumber ("ButtonPinBankDown", 0);
 	m_nButtonPinTGUp = m_Properties.GetNumber ("ButtonPinTGUp", 0);
 	m_nButtonPinTGDown = m_Properties.GetNumber ("ButtonPinTGDown", 0);
 
 	m_ButtonActionPgmUp = m_Properties.GetString ("ButtonActionPgmUp", "");
 	m_ButtonActionPgmDown = m_Properties.GetString ("ButtonActionPgmDown", "");
+	m_ButtonActionBankUp = m_Properties.GetString ("ButtonActionBankUp", "");
+	m_ButtonActionBankDown = m_Properties.GetString ("ButtonActionBankDown", "");
 	m_ButtonActionTGUp = m_Properties.GetString ("ButtonActionTGUp", "");
 	m_ButtonActionTGDown = m_Properties.GetString ("ButtonActionTGDown", "");
 
@@ -182,6 +186,8 @@ void CConfig::Load (void)
 
 	m_nMIDIButtonPgmUp = m_Properties.GetNumber ("MIDIButtonPgmUp", 0);
 	m_nMIDIButtonPgmDown = m_Properties.GetNumber ("MIDIButtonPgmDown", 0);
+	m_nMIDIButtonBankUp = m_Properties.GetNumber ("MIDIButtonBankUp", 0);
+	m_nMIDIButtonBankDown = m_Properties.GetNumber ("MIDIButtonBankDown", 0);
 	m_nMIDIButtonTGUp = m_Properties.GetNumber ("MIDIButtonTGUp", 0);
 	m_nMIDIButtonTGDown = m_Properties.GetNumber ("MIDIButtonTGDown", 0);
 	
@@ -561,6 +567,16 @@ unsigned CConfig::GetButtonPinPgmDown (void) const
 	return m_nButtonPinPgmDown;
 }
 
+unsigned CConfig::GetButtonPinBankUp (void) const
+{
+	return m_nButtonPinBankUp;
+}
+
+unsigned CConfig::GetButtonPinBankDown (void) const
+{
+	return m_nButtonPinBankDown;
+}
+
 unsigned CConfig::GetButtonPinTGUp (void) const
 {
 	return m_nButtonPinTGUp;
@@ -579,6 +595,16 @@ const char *CConfig::GetButtonActionPgmUp (void) const
 const char *CConfig::GetButtonActionPgmDown (void) const
 {
 	return m_ButtonActionPgmDown.c_str();
+}
+
+const char *CConfig::GetButtonActionBankUp (void) const
+{
+	return m_ButtonActionBankUp.c_str();
+}
+
+const char *CConfig::GetButtonActionBankDown (void) const
+{
+	return m_ButtonActionBankDown.c_str();
 }
 
 const char *CConfig::GetButtonActionTGUp (void) const
@@ -634,6 +660,16 @@ unsigned CConfig::GetMIDIButtonPgmUp (void) const
 unsigned CConfig::GetMIDIButtonPgmDown (void) const
 {
 	return m_nMIDIButtonPgmDown;
+}
+
+unsigned CConfig::GetMIDIButtonBankUp (void) const
+{
+	return m_nMIDIButtonBankUp;
+}
+
+unsigned CConfig::GetMIDIButtonBankDown (void) const
+{
+	return m_nMIDIButtonBankDown;
 }
 
 unsigned CConfig::GetMIDIButtonTGUp (void) const

--- a/src/config.h
+++ b/src/config.h
@@ -194,12 +194,16 @@ public:
 	// GPIO pin numbers are chip numbers, not header positions
 	unsigned GetButtonPinPgmUp (void) const;
 	unsigned GetButtonPinPgmDown (void) const;
+	unsigned GetButtonPinBankUp (void) const;
+	unsigned GetButtonPinBankDown (void) const;
 	unsigned GetButtonPinTGUp (void) const;
 	unsigned GetButtonPinTGDown (void) const;
 
 	// Action type for buttons: "click", "doubleclick", "longpress", ""
 	const char *GetButtonActionPgmUp (void) const;
 	const char *GetButtonActionPgmDown (void) const;
+	const char *GetButtonActionBankUp (void) const;
+	const char *GetButtonActionBankDown (void) const;
 	const char *GetButtonActionTGUp (void) const;
 	const char *GetButtonActionTGDown (void) const;
 
@@ -215,6 +219,8 @@ public:
 	// MIDI Button Program and TG Selection
 	unsigned GetMIDIButtonPgmUp (void) const;
 	unsigned GetMIDIButtonPgmDown (void) const;
+	unsigned GetMIDIButtonBankUp (void) const;
+	unsigned GetMIDIButtonBankDown (void) const;
 	unsigned GetMIDIButtonTGUp (void) const;
 	unsigned GetMIDIButtonTGDown (void) const;
 	
@@ -303,6 +309,8 @@ private:
 	unsigned m_nButtonPinShortcut;
 	unsigned m_nButtonPinPgmUp;
 	unsigned m_nButtonPinPgmDown;
+	unsigned m_nButtonPinBankUp;
+	unsigned m_nButtonPinBankDown;
 	unsigned m_nButtonPinTGUp;
 	unsigned m_nButtonPinTGDown;
 
@@ -313,6 +321,8 @@ private:
 	std::string m_ButtonActionHome;
 	std::string m_ButtonActionPgmUp;
 	std::string m_ButtonActionPgmDown;
+	std::string m_ButtonActionBankUp;
+	std::string m_ButtonActionBankDown;
 	std::string m_ButtonActionTGUp;
 	std::string m_ButtonActionTGDown;
 	
@@ -328,6 +338,8 @@ private:
 	unsigned m_nMIDIButtonHome;
 	unsigned m_nMIDIButtonPgmUp;
 	unsigned m_nMIDIButtonPgmDown;
+	unsigned m_nMIDIButtonBankUp;
+	unsigned m_nMIDIButtonBankDown;
 	unsigned m_nMIDIButtonTGUp;
 	unsigned m_nMIDIButtonTGDown;
 

--- a/src/minidexed.ini
+++ b/src/minidexed.ini
@@ -95,12 +95,16 @@ ButtonActionHome=doubleclick
 ButtonPinShortcut=11
 # (Shortcut doesn't have an action)
 
-# GPIO Program/TG Selection
+# GPIO Program/Bank/TG Selection
 #  Any buttons set to 0 will be ignored
 ButtonPinPgmUp=0
 ButtonActionPgmUp=
 ButtonPinPgmDown=0
 ButtonActionPgmDown=
+ButtonPinBankUp=0
+ButtonActionBankUp=
+ButtonPinBankDown=0
+ButtonActionBankDown=
 ButtonPinTGUp=0
 ButtonActionTGUp=
 ButtonPinTGDown=0
@@ -125,6 +129,8 @@ MIDIButtonSelect=0
 MIDIButtonHome=0
 MIDIButtonPgmUp=0
 MIDIButtonPgmDown=0
+MIDIButtonBankUp=0
+MIDIButtonBankDown=0
 MIDIButtonTGUp=0
 MIDIButtonTGDown=0
 

--- a/src/uibuttons.cpp
+++ b/src/uibuttons.cpp
@@ -257,50 +257,8 @@ CUIButton::BtnTrigger CUIButton::triggerTypeFromString(const char* triggerString
 }
 
 
-CUIButtons::CUIButtons (
-			unsigned prevPin, const char *prevAction,
-			unsigned nextPin, const char *nextAction,
-			unsigned backPin, const char *backAction,
-			unsigned selectPin, const char *selectAction,
-			unsigned homePin, const char *homeAction,
-			unsigned pgmUpPin, const char *pgmUpAction,
-			unsigned pgmDownPin, const char *pgmDownAction,
-			unsigned TGUpPin, const char *TGUpAction,
-			unsigned TGDownPin, const char *TGDownAction,
-			unsigned doubleClickTimeout, unsigned longPressTimeout,
-			unsigned notesMidi, unsigned prevMidi, unsigned nextMidi, unsigned backMidi, unsigned selectMidi, unsigned homeMidi,
-			unsigned pgmUpMidi, unsigned pgmDownMidi, unsigned TGUpMidi, unsigned TGDownMidi
-)
-:	m_doubleClickTimeout(doubleClickTimeout),
-	m_longPressTimeout(longPressTimeout),
-	m_prevPin(prevPin),
-	m_prevAction(CUIButton::triggerTypeFromString(prevAction)),
-	m_nextPin(nextPin),
-	m_nextAction(CUIButton::triggerTypeFromString(nextAction)),
-	m_backPin(backPin),
-	m_backAction(CUIButton::triggerTypeFromString(backAction)),
-	m_selectPin(selectPin),
-	m_selectAction(CUIButton::triggerTypeFromString(selectAction)),
-	m_homePin(homePin),
-	m_homeAction(CUIButton::triggerTypeFromString(homeAction)),
-	m_pgmUpPin(pgmUpPin),
-	m_pgmUpAction(CUIButton::triggerTypeFromString(pgmUpAction)),
-	m_pgmDownPin(pgmDownPin),
-	m_pgmDownAction(CUIButton::triggerTypeFromString(pgmDownAction)),
-	m_TGUpPin(TGUpPin),
-	m_TGUpAction(CUIButton::triggerTypeFromString(TGUpAction)),
-	m_TGDownPin(TGDownPin),
-	m_TGDownAction(CUIButton::triggerTypeFromString(TGDownAction)),
-	m_notesMidi(notesMidi),
-	m_prevMidi(ccToMidiPin(prevMidi)),
-	m_nextMidi(ccToMidiPin(nextMidi)),
-	m_backMidi(ccToMidiPin(backMidi)),
-	m_selectMidi(ccToMidiPin(selectMidi)),
-	m_homeMidi(ccToMidiPin(homeMidi)),
-	m_pgmUpMidi(ccToMidiPin(pgmUpMidi)),
-	m_pgmDownMidi(ccToMidiPin(pgmDownMidi)),
-	m_TGUpMidi(ccToMidiPin(TGUpMidi)),
-	m_TGDownMidi(ccToMidiPin(TGDownMidi)),
+CUIButtons::CUIButtons (CConfig *pConfig)
+:	m_pConfig(pConfig),
 	m_eventHandler (0),
 	m_lastTick (0)
 {
@@ -312,6 +270,40 @@ CUIButtons::~CUIButtons (void)
 
 boolean CUIButtons::Initialize (void)
 {
+	assert (m_pConfig);
+
+	// Read the button configuration
+	m_doubleClickTimeout = m_pConfig->GetDoubleClickTimeout ();
+	m_longPressTimeout = m_pConfig->GetLongPressTimeout ();
+	m_prevPin = m_pConfig->GetButtonPinPrev ();
+	m_prevAction = CUIButton::triggerTypeFromString( m_pConfig->GetButtonActionPrev ());
+	m_nextPin = m_pConfig->GetButtonPinNext ();
+	m_nextAction = CUIButton::triggerTypeFromString( m_pConfig->GetButtonActionNext ());
+	m_backPin = m_pConfig->GetButtonPinBack ();
+	m_backAction = CUIButton::triggerTypeFromString( m_pConfig->GetButtonActionBack ());
+	m_selectPin = m_pConfig->GetButtonPinSelect ();
+	m_selectAction = CUIButton::triggerTypeFromString( m_pConfig->GetButtonActionSelect ());
+	m_homePin = m_pConfig->GetButtonPinHome ();
+	m_homeAction = CUIButton::triggerTypeFromString( m_pConfig->GetButtonActionHome ());
+	m_pgmUpPin = m_pConfig->GetButtonPinPgmUp ();
+	m_pgmUpAction = CUIButton::triggerTypeFromString( m_pConfig->GetButtonActionPgmUp ());
+	m_pgmDownPin = m_pConfig->GetButtonPinPgmDown ();
+	m_pgmDownAction = CUIButton::triggerTypeFromString( m_pConfig->GetButtonActionPgmDown ());
+	m_TGUpPin = m_pConfig->GetButtonPinTGUp ();
+	m_TGUpAction = CUIButton::triggerTypeFromString( m_pConfig->GetButtonActionTGUp ());
+	m_TGDownPin = m_pConfig->GetButtonPinTGDown ();
+	m_TGDownAction = CUIButton::triggerTypeFromString( m_pConfig->GetButtonActionTGDown ());
+	m_notesMidi = m_pConfig->GetMIDIButtonNotes ();
+	m_prevMidi = m_pConfig->GetMIDIButtonPrev ();
+	m_nextMidi = m_pConfig->GetMIDIButtonNext ();
+	m_backMidi = m_pConfig->GetMIDIButtonBack ();
+	m_selectMidi = m_pConfig->GetMIDIButtonSelect ();
+	m_homeMidi = m_pConfig->GetMIDIButtonHome ();
+	m_pgmUpMidi = m_pConfig->GetMIDIButtonPgmUp ();
+	m_pgmDownMidi = m_pConfig->GetMIDIButtonPgmDown ();
+	m_TGUpMidi = m_pConfig->GetMIDIButtonTGUp ();
+	m_TGDownMidi = m_pConfig->GetMIDIButtonTGDown ();
+	
 	// First sanity check and convert the timeouts:
 	// Internally values are in tenths of a millisecond, but config values
 	// are in milliseconds

--- a/src/uibuttons.cpp
+++ b/src/uibuttons.cpp
@@ -289,6 +289,10 @@ boolean CUIButtons::Initialize (void)
 	m_pgmUpAction = CUIButton::triggerTypeFromString( m_pConfig->GetButtonActionPgmUp ());
 	m_pgmDownPin = m_pConfig->GetButtonPinPgmDown ();
 	m_pgmDownAction = CUIButton::triggerTypeFromString( m_pConfig->GetButtonActionPgmDown ());
+	m_BankUpPin = m_pConfig->GetButtonPinBankUp ();
+	m_BankUpAction = CUIButton::triggerTypeFromString( m_pConfig->GetButtonActionBankUp ());
+	m_BankDownPin = m_pConfig->GetButtonPinBankDown ();
+	m_BankDownAction = CUIButton::triggerTypeFromString( m_pConfig->GetButtonActionBankDown ());
 	m_TGUpPin = m_pConfig->GetButtonPinTGUp ();
 	m_TGUpAction = CUIButton::triggerTypeFromString( m_pConfig->GetButtonActionTGUp ());
 	m_TGDownPin = m_pConfig->GetButtonPinTGDown ();
@@ -301,6 +305,8 @@ boolean CUIButtons::Initialize (void)
 	m_homeMidi = m_pConfig->GetMIDIButtonHome ();
 	m_pgmUpMidi = m_pConfig->GetMIDIButtonPgmUp ();
 	m_pgmDownMidi = m_pConfig->GetMIDIButtonPgmDown ();
+	m_BankUpMidi = m_pConfig->GetMIDIButtonBankUp ();
+	m_BankDownMidi = m_pConfig->GetMIDIButtonBankDown ();
 	m_TGUpMidi = m_pConfig->GetMIDIButtonTGUp ();
 	m_TGDownMidi = m_pConfig->GetMIDIButtonTGDown ();
 	
@@ -324,16 +330,16 @@ boolean CUIButtons::Initialize (void)
 	// longpress. We may not initialise all of the buttons.
 	// MIDI buttons only support a single click.
 	unsigned pins[MAX_BUTTONS] = {
-		m_prevPin, m_nextPin, m_backPin, m_selectPin, m_homePin, m_pgmUpPin,  m_pgmDownPin,  m_TGUpPin,  m_TGDownPin, 
-		m_prevMidi, m_nextMidi, m_backMidi, m_selectMidi, m_homeMidi, m_pgmUpMidi, m_pgmDownMidi, m_TGUpMidi, m_TGDownMidi
+		m_prevPin, m_nextPin, m_backPin, m_selectPin, m_homePin, m_pgmUpPin,  m_pgmDownPin,  m_BankUpPin,  m_BankDownPin, m_TGUpPin,  m_TGDownPin, 
+		m_prevMidi, m_nextMidi, m_backMidi, m_selectMidi, m_homeMidi, m_pgmUpMidi, m_pgmDownMidi, m_BankUpMidi, m_BankDownMidi, m_TGUpMidi, m_TGDownMidi
 	};
 	CUIButton::BtnTrigger triggers[MAX_BUTTONS] = {
 		// Normal buttons
 		m_prevAction, m_nextAction, m_backAction, m_selectAction, m_homeAction,
-		m_pgmUpAction, m_pgmDownAction, m_TGUpAction, m_TGDownAction, 
+		m_pgmUpAction, m_pgmDownAction, m_BankUpAction, m_BankDownAction, m_TGUpAction, m_TGDownAction, 
 		// MIDI Buttons only support a single click (at present)
 		CUIButton::BtnTriggerClick, CUIButton::BtnTriggerClick, CUIButton::BtnTriggerClick, CUIButton::BtnTriggerClick, CUIButton::BtnTriggerClick,
-		CUIButton::BtnTriggerClick, CUIButton::BtnTriggerClick, CUIButton::BtnTriggerClick, CUIButton::BtnTriggerClick
+		CUIButton::BtnTriggerClick, CUIButton::BtnTriggerClick, CUIButton::BtnTriggerClick, CUIButton::BtnTriggerClick, CUIButton::BtnTriggerClick, CUIButton::BtnTriggerClick
 	};
 	CUIButton::BtnEvent events[MAX_BUTTONS] = {
 		// Normal buttons
@@ -344,6 +350,8 @@ boolean CUIButtons::Initialize (void)
 		CUIButton::BtnEventHome,
 		CUIButton::BtnEventPgmUp,
 		CUIButton::BtnEventPgmDown,
+		CUIButton::BtnEventBankUp,
+		CUIButton::BtnEventBankDown,
 		CUIButton::BtnEventTGUp,
 		CUIButton::BtnEventTGDown,
 		// MIDI buttons
@@ -354,6 +362,8 @@ boolean CUIButtons::Initialize (void)
 		CUIButton::BtnEventHome,
 		CUIButton::BtnEventPgmUp,
 		CUIButton::BtnEventPgmDown,
+		CUIButton::BtnEventBankUp,
+		CUIButton::BtnEventBankDown,
 		CUIButton::BtnEventTGUp,
 		CUIButton::BtnEventTGDown
 	};

--- a/src/uibuttons.cpp
+++ b/src/uibuttons.cpp
@@ -297,18 +297,18 @@ boolean CUIButtons::Initialize (void)
 	m_TGUpAction = CUIButton::triggerTypeFromString( m_pConfig->GetButtonActionTGUp ());
 	m_TGDownPin = m_pConfig->GetButtonPinTGDown ();
 	m_TGDownAction = CUIButton::triggerTypeFromString( m_pConfig->GetButtonActionTGDown ());
-	m_notesMidi = m_pConfig->GetMIDIButtonNotes ();
-	m_prevMidi = m_pConfig->GetMIDIButtonPrev ();
-	m_nextMidi = m_pConfig->GetMIDIButtonNext ();
-	m_backMidi = m_pConfig->GetMIDIButtonBack ();
-	m_selectMidi = m_pConfig->GetMIDIButtonSelect ();
-	m_homeMidi = m_pConfig->GetMIDIButtonHome ();
-	m_pgmUpMidi = m_pConfig->GetMIDIButtonPgmUp ();
-	m_pgmDownMidi = m_pConfig->GetMIDIButtonPgmDown ();
-	m_BankUpMidi = m_pConfig->GetMIDIButtonBankUp ();
-	m_BankDownMidi = m_pConfig->GetMIDIButtonBankDown ();
-	m_TGUpMidi = m_pConfig->GetMIDIButtonTGUp ();
-	m_TGDownMidi = m_pConfig->GetMIDIButtonTGDown ();
+	m_notesMidi = ccToMidiPin( m_pConfig->GetMIDIButtonNotes ());
+	m_prevMidi = ccToMidiPin( m_pConfig->GetMIDIButtonPrev ());
+	m_nextMidi = ccToMidiPin( m_pConfig->GetMIDIButtonNext ());
+	m_backMidi = ccToMidiPin( m_pConfig->GetMIDIButtonBack ());
+	m_selectMidi = ccToMidiPin( m_pConfig->GetMIDIButtonSelect ());
+	m_homeMidi = ccToMidiPin( m_pConfig->GetMIDIButtonHome ());
+	m_pgmUpMidi = ccToMidiPin( m_pConfig->GetMIDIButtonPgmUp ());
+	m_pgmDownMidi = ccToMidiPin( m_pConfig->GetMIDIButtonPgmDown ());
+	m_BankUpMidi = ccToMidiPin( m_pConfig->GetMIDIButtonBankUp ());
+	m_BankDownMidi = ccToMidiPin( m_pConfig->GetMIDIButtonBankDown ());
+	m_TGUpMidi = ccToMidiPin( m_pConfig->GetMIDIButtonTGUp ());
+	m_TGDownMidi = ccToMidiPin( m_pConfig->GetMIDIButtonTGDown ());
 	
 	// First sanity check and convert the timeouts:
 	// Internally values are in tenths of a millisecond, but config values

--- a/src/uibuttons.h
+++ b/src/uibuttons.h
@@ -27,8 +27,8 @@
 
 #define BUTTONS_UPDATE_NUM_TICKS 100
 #define DEBOUNCE_TIME 20
-#define MAX_GPIO_BUTTONS 9  // 5 UI buttons, 4 Program/TG Select buttons
-#define MAX_MIDI_BUTTONS 9
+#define MAX_GPIO_BUTTONS 11  // 5 UI buttons, 6 Program/Bank/TG Select buttons
+#define MAX_MIDI_BUTTONS 11
 #define MAX_BUTTONS (MAX_GPIO_BUTTONS+MAX_MIDI_BUTTONS)
 
 class CUIButtons;
@@ -54,9 +54,11 @@ public:
 		BtnEventHome = 5,
 		BtnEventPgmUp = 6,
 		BtnEventPgmDown = 7,
-		BtnEventTGUp = 8,
-		BtnEventTGDown = 9,
-		BtnEventUnknown = 10
+		BtnEventBankUp = 8,
+		BtnEventBankDown = 9,
+		BtnEventTGUp = 10,
+		BtnEventTGDown = 11,
+		BtnEventUnknown = 12
 	};
 	
 	CUIButton (void);
@@ -152,6 +154,10 @@ private:
 	CUIButton::BtnTrigger m_pgmUpAction;
 	unsigned m_pgmDownPin;
 	CUIButton::BtnTrigger m_pgmDownAction;
+	unsigned m_BankUpPin;
+	CUIButton::BtnTrigger m_BankUpAction;
+	unsigned m_BankDownPin;
+	CUIButton::BtnTrigger m_BankDownAction;
 	unsigned m_TGUpPin;
 	CUIButton::BtnTrigger m_TGUpAction;
 	unsigned m_TGDownPin;
@@ -167,6 +173,8 @@ private:
 	
 	unsigned m_pgmUpMidi;
 	unsigned m_pgmDownMidi;
+	unsigned m_BankUpMidi;
+	unsigned m_BankDownMidi;
 	unsigned m_TGUpMidi;
 	unsigned m_TGDownMidi;
 

--- a/src/uibuttons.h
+++ b/src/uibuttons.h
@@ -111,20 +111,7 @@ public:
 	typedef void BtnEventHandler (CUIButton::BtnEvent Event, void *param);
 
 public:
-	CUIButtons (
-			unsigned prevPin, const char *prevAction,
-			unsigned nextPin, const char *nextAction,
-			unsigned backPin, const char *backAction,
-			unsigned selectPin, const char *selectAction,
-			unsigned homePin, const char *homeAction,
-			unsigned pgmUpPin, const char *pgmUpAction,
-			unsigned pgmDownPin, const char *pgmDownAction,
-			unsigned TGUpPin, const char *TGUpAction,
-			unsigned TGDownPin, const char *TGDownAction,
-			unsigned doubleClickTimeout, unsigned longPressTimeout,
-			unsigned notesMidi, unsigned prevMidi, unsigned nextMidi, unsigned backMidi, unsigned selectMidi, unsigned homeMidi,
-			unsigned pgmUpMidi, unsigned pgmDownMidi, unsigned TGUpMidi, unsigned TGDownMidi
-	);
+	CUIButtons (CConfig *pConfig);
 	~CUIButtons (void);
 	
 	boolean Initialize (void);
@@ -138,6 +125,8 @@ public:
 	void BtnMIDICmdHandler (unsigned nMidiCmd, unsigned nMidiData1, unsigned nMidiData2);
 	
 private:
+	CConfig *m_pConfig;
+
 	// Array of normal GPIO buttons and "MIDI buttons"
 	CUIButton m_buttons[MAX_BUTTONS];
 	

--- a/src/uimenu.h
+++ b/src/uimenu.h
@@ -48,6 +48,8 @@ public:
 		MenuEventPressAndStepUp,
 		MenuEventPgmUp,
 		MenuEventPgmDown,
+		MenuEventBankUp,
+		MenuEventBankDown,
 		MenuEventTGUp,
 		MenuEventTGDown,
 		MenuEventUnknown
@@ -119,6 +121,7 @@ private:
 	void OPShortcutHandler (TMenuEvent Event);
 
 	void PgmUpDownHandler (TMenuEvent Event);
+	void BankUpDownHandler (TMenuEvent Event);
 	void TGUpDownHandler (TMenuEvent Event);
 
 	static void TimerHandler (TKernelTimerHandle hTimer, void *pParam, void *pContext);

--- a/src/userinterface.cpp
+++ b/src/userinterface.cpp
@@ -162,37 +162,7 @@ bool CUserInterface::Initialize (void)
 		LOGDBG ("LCD initialized");
 	}
 
-	m_pUIButtons = new CUIButtons (	m_pConfig->GetButtonPinPrev (),
-									m_pConfig->GetButtonActionPrev (),
-									m_pConfig->GetButtonPinNext (),
-									m_pConfig->GetButtonActionNext (),
-									m_pConfig->GetButtonPinBack (),
-									m_pConfig->GetButtonActionBack (),
-									m_pConfig->GetButtonPinSelect (),
-									m_pConfig->GetButtonActionSelect (),
-									m_pConfig->GetButtonPinHome (),
-									m_pConfig->GetButtonActionHome (),
-									m_pConfig->GetButtonPinPgmUp (),
-									m_pConfig->GetButtonActionPgmUp (),
-									m_pConfig->GetButtonPinPgmDown (),
-									m_pConfig->GetButtonActionPgmDown (),
-									m_pConfig->GetButtonPinTGUp (),
-									m_pConfig->GetButtonActionTGUp (),
-									m_pConfig->GetButtonPinTGDown (),
-									m_pConfig->GetButtonActionTGDown (),
-									m_pConfig->GetDoubleClickTimeout (),
-									m_pConfig->GetLongPressTimeout (),
-									m_pConfig->GetMIDIButtonNotes (),
-									m_pConfig->GetMIDIButtonPrev (),
-									m_pConfig->GetMIDIButtonNext (),
-									m_pConfig->GetMIDIButtonBack (),
-									m_pConfig->GetMIDIButtonSelect (),
-									m_pConfig->GetMIDIButtonHome (),
-									m_pConfig->GetMIDIButtonPgmUp (),
-									m_pConfig->GetMIDIButtonPgmDown (),
-									m_pConfig->GetMIDIButtonTGUp (),
-									m_pConfig->GetMIDIButtonTGDown ()
-								  );
+	m_pUIButtons = new CUIButtons (	m_pConfig );
 	assert (m_pUIButtons);
 
 	if (!m_pUIButtons->Initialize ())

--- a/src/userinterface.cpp
+++ b/src/userinterface.cpp
@@ -367,6 +367,14 @@ void CUserInterface::UIButtonsEventHandler (CUIButton::BtnEvent Event)
 		m_Menu.EventHandler (CUIMenu::MenuEventPgmDown);
 		break;
 
+	case CUIButton::BtnEventBankUp:
+		m_Menu.EventHandler (CUIMenu::MenuEventBankUp);
+		break;
+
+	case CUIButton::BtnEventBankDown:
+		m_Menu.EventHandler (CUIMenu::MenuEventBankDown);
+		break;
+
 	case CUIButton::BtnEventTGUp:
 		m_Menu.EventHandler (CUIMenu::MenuEventTGUp);
 		break;


### PR DESCRIPTION
Closes https://github.com/probonopd/MiniDexed/issues/736

Implements buttons and MIDI buttons via the following additional config items in minidexed.ini

```
ButtonPinBankUp=
ButtonActionBankUp=
ButtonPinBankDown=
ButtonActionBankDown=
MIDIButtonBankUp=
MIDIButtonBankDown=
```

Needs testing for following cases:
* When above correspond to IO pins and `PerformanceSelectChannel=0` - i.e. selecting Voice Banks
* When above correspond to IO pins and `PerformanceSelectChannel!=0` - i.e. selecting Performance Banks
* When above are MIDI buttons and `PerformanceSelectChannel=0` - i.e. selecting Voice Banks over MIDI
* When above are MIDI buttons and `PerformanceSelectChannel!=0` - i.e. selecting Performance Banks over MIDI

Note: this does not depend on the setting of `PerformanceSelectToLoad` - if operating on performance banks then they are always automatically loaded and selected when using buttons or MIDI buttons for selecting.  Nothing else made sense to me as there is no "scroll then load" type action going on as would be the case via the UI itself.

Also, when a bank changes, the first voice/performance is automatically loaded.  This might cause a bit of a delay when moving through performances maybe as I think loading performances can be a little slow...?  Lets see how people get on...

So if anyone fancies giving it a go with the above configuration but also with your existing configs please do.

Kevin