### PR TITLE
Fix Device Master Volume Control handling

### DIFF
--- a/src/mididevice.cpp
+++ b/src/mididevice.cpp
@@ -136,8 +136,6 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 	// The packet contents are just normal MIDI data - see
 	// https://www.midi.org/specifications/item/table-1-summary-of-midi-message
 
-	// Additional byte-level MIDI dump for extra debugging
-/*
 	if (m_pConfig->GetMIDIDumpEnabled ())
 	{
 		switch (nLength)
@@ -146,40 +144,40 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 			if (   pMessage[0] != MIDI_TIMING_CLOCK
 			    && pMessage[0] != MIDI_ACTIVE_SENSING)
 			{
-				printf ("MIDI%u: %02X\n", nCable, (unsigned) pMessage[0]);
+				fprintf (stderr, "MIDI%u: %02X\n", nCable, (unsigned) pMessage[0]);
 			}
 			break;
 
 		case 2:
-			printf ("MIDI%u: %02X %02X\n", nCable,
+			fprintf (stderr, "MIDI%u: %02X %02X\n", nCable,
 				(unsigned) pMessage[0], (unsigned) pMessage[1]);
 			break;
 
 		case 3:
-			printf ("MIDI%u: %02X %02X %02X\n", nCable,
+			fprintf (stderr, "MIDI%u: %02X %02X %02X\n", nCable,
 				(unsigned) pMessage[0], (unsigned) pMessage[1],
 				(unsigned) pMessage[2]);
 			break;
+				
 		default:
 			switch(pMessage[0])
 			{
 				case MIDI_SYSTEM_EXCLUSIVE_BEGIN:
-					printf("MIDI%u: SysEx data length: [%d]:",nCable, uint16_t(nLength));
+					fprintf(stderr, "MIDI%u: SysEx data length: [%d]:",nCable, uint16_t(nLength));
 					for (uint16_t i = 0; i < nLength; i++)
 					{
 						if((i % 16) == 0)
-							printf("\n%04d:",i);
-						printf(" 0x%02x",pMessage[i]);
+							fprintf(stderr, "\n%04d:",i);
+						fprintf(stderr, " 0x%02x",pMessage[i]);
 					}
-					printf("\n");
+					fprintf(stderr, "\n");
 					break;
 				default:
-					printf("MIDI%u: Unhandled MIDI event type %0x02x\n",nCable,pMessage[0]);
+					fprintf(stderr, "MIDI%u: Unhandled MIDI event type %0x02x\n",nCable,pMessage[0]);
 			}
 			break;
 		}
 	}
-*/
 
 	// Only for debugging:
 /*


### PR DESCRIPTION
And also comment out low-level MIDI dump code that really should only be there if someone is messing around with the MIDI handler itself.
-- actually no, that is already commented out in the serial driver.  But this is very unresponsive due to line-buffer flushing, etc, so switched to fprintf to stderr instead.

This is a fix for Issue #773 and partly fixes #502 - at least the Master Volume Control part - the message is now explicitly checking all SysEx bytes and the message length to ensure it really is a MIDI SysEx realtime device control message for the Master Volume Control.

Kevin