### PR TITLE
Add synchronization for multicore

### DIFF
--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -436,6 +436,7 @@ void CMiniDexed::Run (unsigned nCore)
 			while (m_CoreStatus[nCore] != CoreStatusIdle)
 			{
 				// just wait
+				WaitForInterrupt ();
 			}
 		}
 
@@ -449,9 +450,11 @@ void CMiniDexed::Run (unsigned nCore)
 		while (1)
 		{
 			m_CoreStatus[nCore] = CoreStatusIdle;		// ready to be kicked
+			SendIPI (1, IPI_USER);
 			while (m_CoreStatus[nCore] == CoreStatusIdle)
 			{
 				// just wait
+				WaitForInterrupt ();
 			}
 
 			// now kicked from core 1
@@ -1230,6 +1233,7 @@ void CMiniDexed::ProcessSound (void)
 		{
 			assert (m_CoreStatus[nCore] == CoreStatusIdle);
 			m_CoreStatus[nCore] = CoreStatusBusy;
+			SendIPI (nCore, IPI_USER);
 		}
 
 		// process the TGs assigned to core 1
@@ -1245,6 +1249,7 @@ void CMiniDexed::ProcessSound (void)
 		{
 			while (m_CoreStatus[nCore] != CoreStatusIdle)
 			{
+				WaitForInterrupt ();
 				// just wait
 			}
 		}

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -30,6 +30,7 @@
 #include "serialmididevice.h"
 #include "perftimer.h"
 #include <fatfs/ff.h>
+#include <atomic>
 #include <stdint.h>
 #include <string>
 #include <circle/types.h>
@@ -309,8 +310,8 @@ private:
 
 #ifdef ARM_ALLOW_MULTI_CORE
 //	unsigned m_nActiveTGsLog2;
-	volatile TCoreStatus m_CoreStatus[CORES];
-	volatile unsigned m_nFramesToProcess;
+	std::atomic<TCoreStatus> m_CoreStatus[CORES];
+	std::atomic<unsigned> m_nFramesToProcess;
 	float32_t m_OutputLevel[CConfig::AllToneGenerators][CConfig::MaxChunkSize];
 #endif
 


### PR DESCRIPTION
There is currently no memory synchronization between the processor cores, which could cause problems in theory. I added memory barriers and atomic access to the cores' status.

I also suspend the cores when waiting. I thought this would make the PI a little cooler, but I haven't been able to measure it. Can someone measure it with a USB power meter?

Maybe not all of these changes are necessary. I'll get to know the barriers better.