### PR TITLE
do not wait network to be available

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
            cd -
            mkdir -p ./sdcard/hardware/
            cp -r ./hwconfig/minidexed_* ./sdcard/minidexed.ini ./sdcard/hardware/
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: ${{ env.artifactName }} # Exported above
         path: ./sdcard/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   Build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -203,7 +203,7 @@ void CConfig::Load (void)
 	// Network
 	m_bNetworkEnabled  = m_Properties.GetNumber ("NetworkEnabled", 0) != 0;
 	m_bNetworkDHCP  = m_Properties.GetNumber ("NetworkDHCP", 0) != 0;
-	m_NetworkType = m_Properties.GetString ("NetworkType", "wifi");
+	m_NetworkType = m_Properties.GetString ("NetworkType", "wlan");
 	m_NetworkHostname = m_Properties.GetString ("NetworkHostname", "MiniDexed");
 	m_INetworkIPAddress = m_Properties.GetIPAddress("NetworkIPAddress") != 0;
 	m_INetworkSubnetMask = m_Properties.GetIPAddress("NetworkSubnetMask") != 0;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -208,6 +208,7 @@ void CConfig::Load (void)
 	m_INetworkIPAddress = m_Properties.GetIPAddress("NetworkIPAddress") != 0;
 	m_INetworkSubnetMask = m_Properties.GetIPAddress("NetworkSubnetMask") != 0;
 	m_INetworkDefaultGateway = m_Properties.GetIPAddress("NetworkDefaultGateway") != 0;
+	m_bSyslogEnabled  = m_Properties.GetNumber ("SyslogEnabled", 0) != 0;
 	m_INetworkDNSServer = m_Properties.GetIPAddress("NetworkDNSServer") != 0;
 
 	const u8 *pSyslogServerIP = m_Properties.GetIPAddress ("NetworkSyslogServerIPAddress");
@@ -772,6 +773,11 @@ CIPAddress CConfig::GetNetworkDefaultGateway (void) const
 CIPAddress CConfig::GetNetworkDNSServer (void) const
 {
 	return m_INetworkDNSServer;
+}
+
+bool CConfig::GetSyslogEnabled (void) const
+{
+	return m_bSyslogEnabled;
 }
 
 CIPAddress CConfig::GetNetworkSyslogServerIPAddress (void) const

--- a/src/config.h
+++ b/src/config.h
@@ -248,6 +248,7 @@ public:
 	CIPAddress GetNetworkSubnetMask (void) const;
 	CIPAddress GetNetworkDefaultGateway (void) const;
 	CIPAddress GetNetworkDNSServer (void) const;
+	bool GetSyslogEnabled (void) const;
 	CIPAddress GetNetworkSyslogServerIPAddress (void) const;
 
 private:
@@ -373,6 +374,7 @@ private:
 	CIPAddress m_INetworkSubnetMask;
 	CIPAddress m_INetworkDefaultGateway;
 	CIPAddress m_INetworkDNSServer;
+	bool m_bSyslogEnabled;
 	CIPAddress m_INetworkSyslogServerIPAddress;
 };
 

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -2299,7 +2299,7 @@ bool CMiniDexed::InitNetwork()
 
 	TNetDeviceType NetDeviceType = NetDeviceTypeUnknown;
 
-	if (m_pConfig->GetNetworkEnabled () && (strcmp(m_pConfig->GetNetworkType(), "wifi") == 0))
+	if (m_pConfig->GetNetworkEnabled () && (strcmp(m_pConfig->GetNetworkType(), "wlan") == 0))
 	{
 		LOGNOTE("Initializing WLAN");
 		NetDeviceType = NetDeviceTypeWLAN;
@@ -2343,7 +2343,7 @@ bool CMiniDexed::InitNetwork()
 				if (!m_WPASupplicant.Initialize()) {
 					// It seems no way to catch if config is missing unless circle provides it
 					// or we catch the faults in config file ourselves
-					LOGERR("Failed to initialize WPASupplicant, maybe wifi config is missing?"); 
+					LOGERR("Failed to initialize WPASupplicant, maybe wlan config is missing?"); 
 				}
 			}
 		}

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -2346,7 +2346,7 @@ bool CMiniDexed::InitNetwork()
 				m_pNet = nullptr;
 			}
 			// WPASupplicant needs to be started after netdevice available
-			if (NetDeviceType == NetDeviceTypeWLAN)	
+			if (NetDeviceType == NetDeviceTypeWLAN)
 			{
 				if (!m_WPASupplicant.Initialize()) 
 				{
@@ -2355,6 +2355,7 @@ bool CMiniDexed::InitNetwork()
 					LOGERR("Failed to initialize WPASupplicant, maybe wlan config is missing?"); 
 				}
 			}
+			m_pNetDevice = CNetDevice::GetNetDevice(NetDeviceType);
 		}
 		return m_pNet != nullptr;
 	}

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -2258,7 +2258,7 @@ void CMiniDexed::UpdateNetwork()
 				LOGNOTE ("Sending log messages to syslog server %s:%u",
 					(const char *) IPString, (unsigned) usServerPort);
 
-				new CSysLogDaemon (m_pNet, ServerIP, usServerPort);
+				m_pSysLogDaemon = std::make_unique<CSysLogDaemon>(m_pNet, ServerIP, usServerPort);
 			}
 		}
 		m_bNetworkReady = true;

--- a/src/minidexed.ini
+++ b/src/minidexed.ini
@@ -151,8 +151,8 @@ ProfileEnabled=0
 # Network
 NetworkEnabled=0
 NetworkDHCP=1
-# NetworkType ( wifi ; ethernet )
-NetworkType=wifi
+# NetworkType ( wlan ; ethernet )
+NetworkType=wlan
 NetworkHostname=MiniDexed
 NetworkIPAddress=0
 NetworkSubnetMask=0


### PR DESCRIPTION
The checks for Syslog IPAddress (IsNull, IsSet) did not work for me so added a boolean to config.  Network tasks carry on in the background so raspberry always in a usable state.  This needs to be tested in noisy wlan environment with disconnections/reassociation etc. Sound seems not be affected while wireless chip doing its thing.