### PR TITLE
Add hardware configuration for Serdaco MP32L device

### DIFF
--- a/hwconfig/serdaco_mp32l.override
+++ b/hwconfig/serdaco_mp32l.override
@@ -12,10 +12,10 @@ MIDIThru=umidi1,ttyS1
 SSD1306LCDI2CAddress=0x3c
 SSD1306LCDWidth=128
 SSD1306LCDHeight=32
-SSD1306LCDRotate=0
+SSD1306LCDRotate=1
 SSD1306LCDMirror=0
 
-LCDColumns=16
+LCDColumns=20
 LCDRows=2
 
 ButtonPinPrev=17

--- a/hwconfig/serdaco_mp32l.override
+++ b/hwconfig/serdaco_mp32l.override
@@ -1,0 +1,31 @@
+# Serdaco MP32L
+# https://www.serdashop.com/MP32L
+
+SoundDevice=i2s
+SampleRate=48000
+DACI2CAddress=0
+ChannelsSwapped=0
+
+MIDIBaudRate=31250
+MIDIThru=umidi1,ttyS1
+
+SSD1306LCDI2CAddress=0x3c
+SSD1306LCDWidth=128
+SSD1306LCDHeight=32
+SSD1306LCDRotate=0
+SSD1306LCDMirror=0
+
+LCDColumns=16
+LCDRows=2
+
+ButtonPinPrev=17
+ButtonActionPrev=click
+ButtonPinNext=27
+ButtonActionNext=click
+ButtonPinBack=22
+ButtonActionBack=click  
+ButtonPinSelect=23
+ButtonActionSelect=click
+ButtonPinHome=23
+ButtonActionHome=longpress 
+ButtonPinShortcut=0

--- a/hwconfig/serdaco_mp32l.override
+++ b/hwconfig/serdaco_mp32l.override
@@ -29,3 +29,5 @@ ButtonActionSelect=click
 ButtonPinHome=23
 ButtonActionHome=longpress 
 ButtonPinShortcut=0
+
+EncoderEnabled=0


### PR DESCRIPTION
https://github.com/probonopd/MiniDexed/discussions/785#discussioncomment-11765623

@BobanSpasic it would be great if you could test the configuration in this build. 

Need to replace the default `minidexed.ini` in the root of the microSD card with the appropriate one from inside the `hardware` folder.