### PR TITLE
Always show both arrows in the bank selector menu

### DIFF
--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -1773,9 +1773,7 @@ void CUIMenu::EditPerformanceBankNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 	}
 
 	pUIMenu->m_pUI->DisplayWrite (pUIMenu->m_pParentMenu[pUIMenu->m_nCurrentMenuItem].Name, nPSelected.c_str(),
-							Value.c_str (),
-							nValue > 0,
-							nValue < pUIMenu->m_pMiniDexed->GetLastPerformanceBank()-1);
+							Value.c_str (), true, true);
 }
 
 void CUIMenu::InputTxt (CUIMenu *pUIMenu, TMenuEvent Event)


### PR DESCRIPTION
It wraps around.