### PR TITLE
Potential fix for Issue #820

### DIFF
--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -1483,6 +1483,7 @@ bool CMiniDexed::DoSavePerformance (void)
 
 	if(m_bSaveAsDeault)
 	{
+		m_PerformanceConfig.SetNewPerformanceBank(0);
 		m_PerformanceConfig.SetNewPerformance(0);
 		
 	}


### PR DESCRIPTION
Potential fix for issue #820 where saving default performance always overwrites the first performance in the current bank, but should act on bank 0, performance 0.

Note: untested at this time by me.  If someone fancies trying it - please do!

Kevin