### PR TITLE
MIDI CC 11 (Expression)

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -112,6 +112,7 @@ void CConfig::Load (void)
 	m_nMIDISystemCCVol = m_Properties.GetNumber ("MIDISystemCCVol", 0);
 	m_nMIDISystemCCPan = m_Properties.GetNumber ("MIDISystemCCPan", 0);
 	m_nMIDISystemCCDetune = m_Properties.GetNumber ("MIDISystemCCDetune", 0);
+	m_nMIDIGlobalExpression = m_Properties.GetNumber ("MIDIGlobalExpression", 0);
 
 	m_bLCDEnabled = m_Properties.GetNumber ("LCDEnabled", 0) != 0;
 	m_nLCDPinEnable = m_Properties.GetNumber ("LCDPinEnable", 4);
@@ -351,6 +352,11 @@ unsigned CConfig::GetMIDISystemCCPan (void) const
 unsigned CConfig::GetMIDISystemCCDetune (void) const
 {
 	return m_nMIDISystemCCDetune;
+}
+
+unsigned CConfig::GetMIDIGlobalExpression (void) const
+{
+	return m_nMIDIGlobalExpression;
 }
 
 bool CConfig::GetLCDEnabled (void) const

--- a/src/config.h
+++ b/src/config.h
@@ -131,6 +131,7 @@ public:
 	unsigned GetMIDISystemCCVol (void) const;
 	unsigned GetMIDISystemCCPan (void) const;
 	unsigned GetMIDISystemCCDetune (void) const;
+	unsigned GetMIDIGlobalExpression (void) const;
 
 	// HD44780 LCD
 	// GPIO pin numbers are chip numbers, not header positions
@@ -267,6 +268,7 @@ private:
 	unsigned m_nMIDISystemCCVol;
 	unsigned m_nMIDISystemCCPan;
 	unsigned m_nMIDISystemCCDetune;
+	unsigned m_nMIDIGlobalExpression;
 
 	bool m_bLCDEnabled;
 	unsigned m_nLCDPinEnable;

--- a/src/mididevice.cpp
+++ b/src/mididevice.cpp
@@ -37,14 +37,15 @@ LOGMODULE ("mididevice");
 #define MIDI_CHANNEL_AFTERTOUCH 0b1101   // right now Synth_Dexed just manage Channel Aftertouch not Polyphonic AT -> 0b1010
 #define MIDI_CONTROL_CHANGE	0b1011
 	#define MIDI_CC_BANK_SELECT_MSB		0
-	#define MIDI_CC_MODULATION			1
+	#define MIDI_CC_MODULATION		1
 	#define MIDI_CC_BREATH_CONTROLLER	2 
 	#define MIDI_CC_FOOT_PEDAL 		4
-	#define MIDI_CC_VOLUME				7
+	#define MIDI_CC_VOLUME			7
 	#define MIDI_CC_PAN_POSITION		10
+	#define MIDI_CC_EXPRESSION		11
 	#define MIDI_CC_BANK_SELECT_LSB		32
 	#define MIDI_CC_BANK_SUSTAIN		64
-	#define MIDI_CC_RESONANCE			71
+	#define MIDI_CC_RESONANCE		71
 	#define MIDI_CC_FREQUENCY_CUTOFF	74
 	#define MIDI_CC_REVERB_LEVEL		91
 	#define MIDI_CC_DETUNE_LEVEL		94
@@ -396,6 +397,10 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 		
 						case MIDI_CC_PAN_POSITION:
 							m_pSynthesizer->SetPan (pMessage[2], nTG);
+							break;
+		
+						case MIDI_CC_EXPRESSION:
+							m_pSynthesizer->SetExpression (pMessage[2], nTG);
 							break;
 		
 						case MIDI_CC_BANK_SELECT_MSB:

--- a/src/mididevice.h
+++ b/src/mididevice.h
@@ -75,6 +75,7 @@ private:
 	unsigned m_nMIDISystemCCPan;
 	unsigned m_nMIDISystemCCDetune;
 	u32	 m_MIDISystemCCBitmap[4]; // to allow for 128 bit entries
+	unsigned m_nMIDIGlobalExpression;
 
 	std::string m_DeviceName;
 

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -74,6 +74,7 @@ public:
 	void ProgramChange (unsigned nProgram, unsigned nTG);
 	void ProgramChangePerformance (unsigned nProgram);
 	void SetVolume (unsigned nVolume, unsigned nTG);
+	void SetExpression (unsigned nExpression, unsigned nTG);
 	void SetPan (unsigned nPan, unsigned nTG);			// 0 .. 127
 	void SetMasterTune (int nMasterTune, unsigned nTG);		// -99 .. 99
 	void SetCutoff (int nCutoff, unsigned nTG);			// 0 .. 99
@@ -261,6 +262,7 @@ private:
 	unsigned m_nVoiceBankIDMSBPerformance;
 	unsigned m_nProgram[CConfig::AllToneGenerators];
 	unsigned m_nVolume[CConfig::AllToneGenerators];
+	unsigned m_nExpression[CConfig::AllToneGenerators];
 	unsigned m_nPan[CConfig::AllToneGenerators];
 	int m_nMasterTune[CConfig::AllToneGenerators];
 	int m_nCutoff[CConfig::AllToneGenerators];


### PR DESCRIPTION
Initial implementation of MIDI CC 11 (Expression) implemented as a "live" performance parameter - i.e. MIDI only, not settable via the UI.

This wasn't originally supported in the DX7 or DX7II but is described as setting the percentage of the channel volume.  It is implemented so that the MIDI range 0..127 maps onto 0% to 100% of the channel volume.

The current setting is preserved through voice and performance changes.  There could be an option to reset it back to the default (max, 127) on voice or performance change if required.

Kevin