### PR TITLE
Initial attempt at caching performances to improve performance load times

### DIFF
--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -1913,55 +1913,57 @@ bool CMiniDexed::DoSavePerformanceNewFile (void)
 void CMiniDexed::LoadPerformanceParameters(void)
 {
 	for (unsigned nTG = 0; nTG < CConfig::AllToneGenerators; nTG++)
+	{
+
+		BankSelect (m_PerformanceConfig.GetBankNumber (nTG), nTG);
+		ProgramChange (m_PerformanceConfig.GetVoiceNumber (nTG), nTG);
+		SetMIDIChannel (m_PerformanceConfig.GetMIDIChannel (nTG), nTG);
+		SetVolume (m_PerformanceConfig.GetVolume (nTG), nTG);
+		SetPan (m_PerformanceConfig.GetPan (nTG), nTG);
+		SetMasterTune (m_PerformanceConfig.GetDetune (nTG), nTG);
+		SetCutoff (m_PerformanceConfig.GetCutoff (nTG), nTG);
+		SetResonance (m_PerformanceConfig.GetResonance (nTG), nTG);
+		setPitchbendRange (m_PerformanceConfig.GetPitchBendRange (nTG), nTG);
+		setPitchbendStep (m_PerformanceConfig.GetPitchBendStep (nTG), nTG);
+		setPortamentoMode (m_PerformanceConfig.GetPortamentoMode (nTG), nTG);
+		setPortamentoGlissando (m_PerformanceConfig.GetPortamentoGlissando  (nTG), nTG);
+		setPortamentoTime (m_PerformanceConfig.GetPortamentoTime (nTG), nTG);
+
+		m_nNoteLimitLow[nTG] = m_PerformanceConfig.GetNoteLimitLow (nTG);
+		m_nNoteLimitHigh[nTG] = m_PerformanceConfig.GetNoteLimitHigh (nTG);
+		m_nNoteShift[nTG] = m_PerformanceConfig.GetNoteShift (nTG);
+
+		if(m_PerformanceConfig.VoiceDataFilled(nTG)) 
 		{
-			
-			BankSelect (m_PerformanceConfig.GetBankNumber (nTG), nTG);
-			ProgramChange (m_PerformanceConfig.GetVoiceNumber (nTG), nTG);
-			SetMIDIChannel (m_PerformanceConfig.GetMIDIChannel (nTG), nTG);
-			SetVolume (m_PerformanceConfig.GetVolume (nTG), nTG);
-			SetPan (m_PerformanceConfig.GetPan (nTG), nTG);
-			SetMasterTune (m_PerformanceConfig.GetDetune (nTG), nTG);
-			SetCutoff (m_PerformanceConfig.GetCutoff (nTG), nTG);
-			SetResonance (m_PerformanceConfig.GetResonance (nTG), nTG);
-			setPitchbendRange (m_PerformanceConfig.GetPitchBendRange (nTG), nTG);
-			setPitchbendStep (m_PerformanceConfig.GetPitchBendStep (nTG), nTG);
-			setPortamentoMode (m_PerformanceConfig.GetPortamentoMode (nTG), nTG);
-			setPortamentoGlissando (m_PerformanceConfig.GetPortamentoGlissando  (nTG), nTG);
-			setPortamentoTime (m_PerformanceConfig.GetPortamentoTime (nTG), nTG);
-
-			m_nNoteLimitLow[nTG] = m_PerformanceConfig.GetNoteLimitLow (nTG);
-			m_nNoteLimitHigh[nTG] = m_PerformanceConfig.GetNoteLimitHigh (nTG);
-			m_nNoteShift[nTG] = m_PerformanceConfig.GetNoteShift (nTG);
-			
-			if(m_PerformanceConfig.VoiceDataFilled(nTG)) 
-			{
-			uint8_t* tVoiceData = m_PerformanceConfig.GetVoiceDataFromTxt(nTG);
-			m_pTG[nTG]->loadVoiceParameters(tVoiceData); 
-			}
-			setMonoMode(m_PerformanceConfig.GetMonoMode(nTG) ? 1 : 0, nTG); 
-			SetReverbSend (m_PerformanceConfig.GetReverbSend (nTG), nTG);
-					
-			setModWheelRange (m_PerformanceConfig.GetModulationWheelRange (nTG),  nTG);
-			setModWheelTarget (m_PerformanceConfig.GetModulationWheelTarget (nTG),  nTG);
-			setFootControllerRange (m_PerformanceConfig.GetFootControlRange (nTG),  nTG);
-			setFootControllerTarget (m_PerformanceConfig.GetFootControlTarget (nTG),  nTG);
-			setBreathControllerRange (m_PerformanceConfig.GetBreathControlRange (nTG),  nTG);
-			setBreathControllerTarget (m_PerformanceConfig.GetBreathControlTarget (nTG),  nTG);
-			setAftertouchRange (m_PerformanceConfig.GetAftertouchRange (nTG),  nTG);
-			setAftertouchTarget (m_PerformanceConfig.GetAftertouchTarget (nTG),  nTG);
-			
-		
+		uint8_t* tVoiceData = m_PerformanceConfig.GetVoiceDataFromTxt(nTG);
+		m_pTG[nTG]->loadVoiceParameters(tVoiceData); 
 		}
+		setMonoMode(m_PerformanceConfig.GetMonoMode(nTG) ? 1 : 0, nTG); 
+		SetReverbSend (m_PerformanceConfig.GetReverbSend (nTG), nTG);
 
-		// Effects
-		SetParameter (ParameterCompressorEnable, m_PerformanceConfig.GetCompressorEnable () ? 1 : 0);
-		SetParameter (ParameterReverbEnable, m_PerformanceConfig.GetReverbEnable () ? 1 : 0);
-		SetParameter (ParameterReverbSize, m_PerformanceConfig.GetReverbSize ());
-		SetParameter (ParameterReverbHighDamp, m_PerformanceConfig.GetReverbHighDamp ());
-		SetParameter (ParameterReverbLowDamp, m_PerformanceConfig.GetReverbLowDamp ());
-		SetParameter (ParameterReverbLowPass, m_PerformanceConfig.GetReverbLowPass ());
-		SetParameter (ParameterReverbDiffusion, m_PerformanceConfig.GetReverbDiffusion ());
-		SetParameter (ParameterReverbLevel, m_PerformanceConfig.GetReverbLevel ());
+		setModWheelRange (m_PerformanceConfig.GetModulationWheelRange (nTG),  nTG);
+		setModWheelTarget (m_PerformanceConfig.GetModulationWheelTarget (nTG),  nTG);
+		setFootControllerRange (m_PerformanceConfig.GetFootControlRange (nTG),  nTG);
+		setFootControllerTarget (m_PerformanceConfig.GetFootControlTarget (nTG),  nTG);
+		setBreathControllerRange (m_PerformanceConfig.GetBreathControlRange (nTG),  nTG);
+		setBreathControllerTarget (m_PerformanceConfig.GetBreathControlTarget (nTG),  nTG);
+		setAftertouchRange (m_PerformanceConfig.GetAftertouchRange (nTG),  nTG);
+		setAftertouchTarget (m_PerformanceConfig.GetAftertouchTarget (nTG),  nTG);
+
+
+	}
+
+	// Effects
+	SetParameter (ParameterCompressorEnable, m_PerformanceConfig.GetCompressorEnable () ? 1 : 0);
+	SetParameter (ParameterReverbEnable, m_PerformanceConfig.GetReverbEnable () ? 1 : 0);
+	SetParameter (ParameterReverbSize, m_PerformanceConfig.GetReverbSize ());
+	SetParameter (ParameterReverbHighDamp, m_PerformanceConfig.GetReverbHighDamp ());
+	SetParameter (ParameterReverbLowDamp, m_PerformanceConfig.GetReverbLowDamp ());
+	SetParameter (ParameterReverbLowPass, m_PerformanceConfig.GetReverbLowPass ());
+	SetParameter (ParameterReverbDiffusion, m_PerformanceConfig.GetReverbDiffusion ());
+	SetParameter (ParameterReverbLevel, m_PerformanceConfig.GetReverbLevel ());
+	
+	m_UI.DisplayChanged();
 }
 
 std::string CMiniDexed::GetNewPerformanceDefaultName(void)	

--- a/src/performanceconfig.cpp
+++ b/src/performanceconfig.cpp
@@ -36,7 +36,6 @@ LOGMODULE ("Performance");
 #define DEFAULT_PERFORMANCE_BANK_NAME "Default"
 
 CPerformanceConfig::CPerformanceConfig (FATFS *pFileSystem)
-:	m_Properties (DEFAULT_PERFORMANCE_FILENAME, pFileSystem)
 {
 	m_pFileSystem = pFileSystem; 
 }
@@ -74,6 +73,10 @@ bool CPerformanceConfig::Init (unsigned nToneGenerators)
 		m_bPerformanceDirectoryExists = false;
 	}
 	
+	for (unsigned i=0; i<NUM_PERFORMANCES; i++) {
+		m_pPerfBank[i] = nullptr;
+	}
+	
 	// List banks if present
 	ListPerformanceBanks();
 
@@ -100,10 +103,24 @@ bool CPerformanceConfig::Init (unsigned nToneGenerators)
 
 bool CPerformanceConfig::Load (void)
 {
-	if (!m_Properties.Load ())
+	assert (m_nActualPerformance < NUM_PERFORMANCES);
+	if (m_pPerfBank[m_nActualPerformance] != nullptr)
+	{
+		// Already loaded - nothing more to do
+		return true;
+	}
+
+	std::string FileN = GetPerformanceFullFilePath(m_nActualPerformance);
+	CPropertiesFatFsFile Properties (FileN.c_str(), m_pFileSystem);
+
+	if (!Properties.Load ())
 	{
 		return false;
 	}
+	
+	m_pPerfBank[m_nActualPerformance] = new TPerf;
+	assert(m_pPerfBank[m_nActualPerformance]);
+	TPerf *pPB = m_pPerfBank[m_nActualPerformance];
 
 	bool bResult = false;
 
@@ -112,135 +129,141 @@ bool CPerformanceConfig::Load (void)
 		CString PropertyName;
 
 		PropertyName.Format ("BankNumber%u", nTG+1);
-		m_nBankNumber[nTG] = m_Properties.GetNumber (PropertyName, 0);
+		pPB->nBankNumber[nTG] = Properties.GetNumber (PropertyName, 0);
 
 		PropertyName.Format ("VoiceNumber%u", nTG+1);
-		m_nVoiceNumber[nTG] = m_Properties.GetNumber (PropertyName, 1);
-		if (m_nVoiceNumber[nTG] > 0)
+		pPB->nVoiceNumber[nTG] = Properties.GetNumber (PropertyName, 1);
+		if (pPB->nVoiceNumber[nTG] > 0)
 		{
-			m_nVoiceNumber[nTG]--;
+			pPB->nVoiceNumber[nTG]--;
 		}
 
 		PropertyName.Format ("MIDIChannel%u", nTG+1);
-		unsigned nMIDIChannel = m_Properties.GetNumber (PropertyName, 0);
+		unsigned nMIDIChannel = Properties.GetNumber (PropertyName, 0);
 		if (nMIDIChannel == 0)
 		{
-			m_nMIDIChannel[nTG] = CMIDIDevice::Disabled;
+			pPB->nMIDIChannel[nTG] = CMIDIDevice::Disabled;
 		}
 		else if (nMIDIChannel <= CMIDIDevice::Channels)
 		{
-			m_nMIDIChannel[nTG] = nMIDIChannel-1;
+			pPB->nMIDIChannel[nTG] = nMIDIChannel-1;
 			bResult = true;
 		}
 		else
 		{
-			m_nMIDIChannel[nTG] = CMIDIDevice::OmniMode;
+			pPB->nMIDIChannel[nTG] = CMIDIDevice::OmniMode;
 			bResult = true;
 		}
 
 		PropertyName.Format ("Volume%u", nTG+1);
-		m_nVolume[nTG] = m_Properties.GetNumber (PropertyName, 100);
+		pPB->nVolume[nTG] = Properties.GetNumber (PropertyName, 100);
 
 		PropertyName.Format ("Pan%u", nTG+1);
-		m_nPan[nTG] = m_Properties.GetNumber (PropertyName, 64);
+		pPB->nPan[nTG] = Properties.GetNumber (PropertyName, 64);
 
 		PropertyName.Format ("Detune%u", nTG+1);
-		m_nDetune[nTG] = m_Properties.GetSignedNumber (PropertyName, 0);
+		pPB->nDetune[nTG] = Properties.GetSignedNumber (PropertyName, 0);
 
 		PropertyName.Format ("Cutoff%u", nTG+1);
-		m_nCutoff[nTG] = m_Properties.GetNumber (PropertyName, 99);
+		pPB->nCutoff[nTG] = Properties.GetNumber (PropertyName, 99);
 
 		PropertyName.Format ("Resonance%u", nTG+1);
-		m_nResonance[nTG] = m_Properties.GetNumber (PropertyName, 0);
+		pPB->nResonance[nTG] = Properties.GetNumber (PropertyName, 0);
 
 		PropertyName.Format ("NoteLimitLow%u", nTG+1);
-		m_nNoteLimitLow[nTG] = m_Properties.GetNumber (PropertyName, 0);
+		pPB->nNoteLimitLow[nTG] = Properties.GetNumber (PropertyName, 0);
 
 		PropertyName.Format ("NoteLimitHigh%u", nTG+1);
-		m_nNoteLimitHigh[nTG] = m_Properties.GetNumber (PropertyName, 127);
+		pPB->nNoteLimitHigh[nTG] = Properties.GetNumber (PropertyName, 127);
 
 		PropertyName.Format ("NoteShift%u", nTG+1);
-		m_nNoteShift[nTG] = m_Properties.GetSignedNumber (PropertyName, 0);
+		pPB->nNoteShift[nTG] = Properties.GetSignedNumber (PropertyName, 0);
 
 		PropertyName.Format ("ReverbSend%u", nTG+1);
-		m_nReverbSend[nTG] = m_Properties.GetNumber (PropertyName, 50);
+		pPB->nReverbSend[nTG] = Properties.GetNumber (PropertyName, 50);
 		
 		PropertyName.Format ("PitchBendRange%u", nTG+1);
-		m_nPitchBendRange[nTG] = m_Properties.GetNumber (PropertyName, 2);
+		pPB->nPitchBendRange[nTG] = Properties.GetNumber (PropertyName, 2);
 
 		PropertyName.Format ("PitchBendStep%u", nTG+1);
-		m_nPitchBendStep[nTG] = m_Properties.GetNumber (PropertyName, 0);
+		pPB->nPitchBendStep[nTG] = Properties.GetNumber (PropertyName, 0);
 
 		PropertyName.Format ("PortamentoMode%u", nTG+1);
-		m_nPortamentoMode[nTG] = m_Properties.GetNumber (PropertyName, 0);
+		pPB->nPortamentoMode[nTG] = Properties.GetNumber (PropertyName, 0);
 
 		PropertyName.Format ("PortamentoGlissando%u", nTG+1);
-		m_nPortamentoGlissando[nTG] = m_Properties.GetNumber (PropertyName, 0);
+		pPB->nPortamentoGlissando[nTG] = Properties.GetNumber (PropertyName, 0);
 
 		PropertyName.Format ("PortamentoTime%u", nTG+1);
-		m_nPortamentoTime[nTG] = m_Properties.GetNumber (PropertyName, 0);
+		pPB->nPortamentoTime[nTG] = Properties.GetNumber (PropertyName, 0);
 		
 		PropertyName.Format ("VoiceData%u", nTG+1); 
-		m_nVoiceDataTxt[nTG] = m_Properties.GetString (PropertyName, "");
+		pPB->nVoiceDataTxt[nTG] = Properties.GetString (PropertyName, "");
 		
 		PropertyName.Format ("MonoMode%u", nTG+1);
-		m_bMonoMode[nTG] = m_Properties.GetNumber (PropertyName, 0) != 0;
+		pPB->bMonoMode[nTG] = Properties.GetNumber (PropertyName, 0) != 0;
 				
 		PropertyName.Format ("ModulationWheelRange%u", nTG+1);
-		m_nModulationWheelRange[nTG] = m_Properties.GetNumber (PropertyName, 99); 
+		pPB->nModulationWheelRange[nTG] = Properties.GetNumber (PropertyName, 99); 
 		
 		PropertyName.Format ("ModulationWheelTarget%u", nTG+1);
-		m_nModulationWheelTarget[nTG] = m_Properties.GetNumber (PropertyName, 1);
+		pPB->nModulationWheelTarget[nTG] = Properties.GetNumber (PropertyName, 1);
 		
 		PropertyName.Format ("FootControlRange%u", nTG+1);
-		m_nFootControlRange[nTG] = m_Properties.GetNumber (PropertyName, 99); 
+		pPB->nFootControlRange[nTG] = Properties.GetNumber (PropertyName, 99); 
 		
 		PropertyName.Format ("FootControlTarget%u", nTG+1);
-		m_nFootControlTarget[nTG] = m_Properties.GetNumber (PropertyName, 0);
+		pPB->nFootControlTarget[nTG] = Properties.GetNumber (PropertyName, 0);
 		
 		PropertyName.Format ("BreathControlRange%u", nTG+1);
-		m_nBreathControlRange[nTG] = m_Properties.GetNumber (PropertyName, 99); 
+		pPB->nBreathControlRange[nTG] = Properties.GetNumber (PropertyName, 99); 
 		
 		PropertyName.Format ("BreathControlTarget%u", nTG+1);
-		m_nBreathControlTarget[nTG] = m_Properties.GetNumber (PropertyName, 0);
+		pPB->nBreathControlTarget[nTG] = Properties.GetNumber (PropertyName, 0);
 		
 		PropertyName.Format ("AftertouchRange%u", nTG+1);
-		m_nAftertouchRange[nTG] = m_Properties.GetNumber (PropertyName, 99); 
+		pPB->nAftertouchRange[nTG] = Properties.GetNumber (PropertyName, 99); 
 		
 		PropertyName.Format ("AftertouchTarget%u", nTG+1);
-		m_nAftertouchTarget[nTG] = m_Properties.GetNumber (PropertyName, 0);
+		pPB->nAftertouchTarget[nTG] = Properties.GetNumber (PropertyName, 0);
 		
 		}
 
-	m_bCompressorEnable = m_Properties.GetNumber ("CompressorEnable", 1) != 0;
+	pPB->bCompressorEnable = Properties.GetNumber ("CompressorEnable", 1) != 0;
 
-	m_bReverbEnable = m_Properties.GetNumber ("ReverbEnable", 1) != 0;
-	m_nReverbSize = m_Properties.GetNumber ("ReverbSize", 70);
-	m_nReverbHighDamp = m_Properties.GetNumber ("ReverbHighDamp", 50);
-	m_nReverbLowDamp = m_Properties.GetNumber ("ReverbLowDamp", 50);
-	m_nReverbLowPass = m_Properties.GetNumber ("ReverbLowPass", 30);
-	m_nReverbDiffusion = m_Properties.GetNumber ("ReverbDiffusion", 65);
-	m_nReverbLevel = m_Properties.GetNumber ("ReverbLevel", 99);
+	pPB->bReverbEnable = Properties.GetNumber ("ReverbEnable", 1) != 0;
+	pPB->nReverbSize = Properties.GetNumber ("ReverbSize", 70);
+	pPB->nReverbHighDamp = Properties.GetNumber ("ReverbHighDamp", 50);
+	pPB->nReverbLowDamp = Properties.GetNumber ("ReverbLowDamp", 50);
+	pPB->nReverbLowPass = Properties.GetNumber ("ReverbLowPass", 30);
+	pPB->nReverbDiffusion = Properties.GetNumber ("ReverbDiffusion", 65);
+	pPB->nReverbLevel = Properties.GetNumber ("ReverbLevel", 99);
 
 	return bResult;
 }
 
 bool CPerformanceConfig::Save (void)
 {
-	m_Properties.RemoveAll ();
+	std::string FileN = GetPerformanceFullFilePath(m_nActualPerformance);
+	CPropertiesFatFsFile Properties (FileN.c_str(), m_pFileSystem);
+
+	TPerf *pPB = m_pPerfBank[m_nActualPerformance];
+	assert (pPB);
+
+	Properties.RemoveAll ();
 
 	for (unsigned nTG = 0; nTG < m_nToneGenerators; nTG++)
 	{
 		CString PropertyName;
 
 		PropertyName.Format ("BankNumber%u", nTG+1);
-		m_Properties.SetNumber (PropertyName, m_nBankNumber[nTG]);
+		Properties.SetNumber (PropertyName, pPB->nBankNumber[nTG]);
 
 		PropertyName.Format ("VoiceNumber%u", nTG+1);
-		m_Properties.SetNumber (PropertyName, m_nVoiceNumber[nTG]+1);
+		Properties.SetNumber (PropertyName, pPB->nVoiceNumber[nTG]+1);
 
 		PropertyName.Format ("MIDIChannel%u", nTG+1);
-		unsigned nMIDIChannel = m_nMIDIChannel[nTG];
+		unsigned nMIDIChannel = pPB->nMIDIChannel[nTG];
 		if (nMIDIChannel < CMIDIDevice::Channels)
 		{
 			nMIDIChannel++;
@@ -253,503 +276,572 @@ bool CPerformanceConfig::Save (void)
 		{
 			nMIDIChannel = 0;
 		}
-		m_Properties.SetNumber (PropertyName, nMIDIChannel);
+		Properties.SetNumber (PropertyName, nMIDIChannel);
 
 		PropertyName.Format ("Volume%u", nTG+1);
-		m_Properties.SetNumber (PropertyName, m_nVolume[nTG]);
+		Properties.SetNumber (PropertyName, pPB->nVolume[nTG]);
 
 		PropertyName.Format ("Pan%u", nTG+1);
-		m_Properties.SetNumber (PropertyName, m_nPan[nTG]);
+		Properties.SetNumber (PropertyName, pPB->nPan[nTG]);
 
 		PropertyName.Format ("Detune%u", nTG+1);
-		m_Properties.SetSignedNumber (PropertyName, m_nDetune[nTG]);
+		Properties.SetSignedNumber (PropertyName, pPB->nDetune[nTG]);
 
 		PropertyName.Format ("Cutoff%u", nTG+1);
-		m_Properties.SetNumber (PropertyName, m_nCutoff[nTG]);
+		Properties.SetNumber (PropertyName, pPB->nCutoff[nTG]);
 
 		PropertyName.Format ("Resonance%u", nTG+1);
-		m_Properties.SetNumber (PropertyName, m_nResonance[nTG]);
+		Properties.SetNumber (PropertyName, pPB->nResonance[nTG]);
 
 		PropertyName.Format ("NoteLimitLow%u", nTG+1);
-		m_Properties.SetNumber (PropertyName, m_nNoteLimitLow[nTG]);
+		Properties.SetNumber (PropertyName, pPB->nNoteLimitLow[nTG]);
 
 		PropertyName.Format ("NoteLimitHigh%u", nTG+1);
-		m_Properties.SetNumber (PropertyName, m_nNoteLimitHigh[nTG]);
+		Properties.SetNumber (PropertyName, pPB->nNoteLimitHigh[nTG]);
 
 		PropertyName.Format ("NoteShift%u", nTG+1);
-		m_Properties.SetSignedNumber (PropertyName, m_nNoteShift[nTG]);
+		Properties.SetSignedNumber (PropertyName, pPB->nNoteShift[nTG]);
 
 		PropertyName.Format ("ReverbSend%u", nTG+1);
-		m_Properties.SetNumber (PropertyName, m_nReverbSend[nTG]);
+		Properties.SetNumber (PropertyName, pPB->nReverbSend[nTG]);
 		
 		PropertyName.Format ("PitchBendRange%u", nTG+1);
-		m_Properties.SetNumber (PropertyName, m_nPitchBendRange[nTG]);
+		Properties.SetNumber (PropertyName, pPB->nPitchBendRange[nTG]);
 
 		PropertyName.Format ("PitchBendStep%u", nTG+1);
-		m_Properties.SetNumber (PropertyName, m_nPitchBendStep[nTG]);
+		Properties.SetNumber (PropertyName, pPB->nPitchBendStep[nTG]);
 
 		PropertyName.Format ("PortamentoMode%u", nTG+1);
-		m_Properties.SetNumber (PropertyName, m_nPortamentoMode[nTG]);
+		Properties.SetNumber (PropertyName, pPB->nPortamentoMode[nTG]);
 
 		PropertyName.Format ("PortamentoGlissando%u", nTG+1);
-		m_Properties.SetNumber (PropertyName, m_nPortamentoGlissando[nTG]);
+		Properties.SetNumber (PropertyName, pPB->nPortamentoGlissando[nTG]);
 
 		PropertyName.Format ("PortamentoTime%u", nTG+1);
-		m_Properties.SetNumber (PropertyName, m_nPortamentoTime[nTG]);
+		Properties.SetNumber (PropertyName, pPB->nPortamentoTime[nTG]);
 		
 		PropertyName.Format ("VoiceData%u", nTG+1);
-		char *cstr = &m_nVoiceDataTxt[nTG][0];
-		m_Properties.SetString (PropertyName, cstr);
+		char *cstr = &pPB->nVoiceDataTxt[nTG][0];
+		Properties.SetString (PropertyName, cstr);
 		
 		PropertyName.Format ("MonoMode%u", nTG+1);
-		m_Properties.SetNumber (PropertyName, m_bMonoMode[nTG] ? 1 : 0);
+		Properties.SetNumber (PropertyName, pPB->bMonoMode[nTG] ? 1 : 0);
 				
 		PropertyName.Format ("ModulationWheelRange%u", nTG+1);
-		m_Properties.SetNumber (PropertyName, m_nModulationWheelRange[nTG]);
+		Properties.SetNumber (PropertyName, pPB->nModulationWheelRange[nTG]);
 	
 		PropertyName.Format ("ModulationWheelTarget%u", nTG+1);
-		m_Properties.SetNumber (PropertyName, m_nModulationWheelTarget[nTG]);	
+		Properties.SetNumber (PropertyName, pPB->nModulationWheelTarget[nTG]);	
 			
 		PropertyName.Format ("FootControlRange%u", nTG+1);
-		m_Properties.SetNumber (PropertyName, m_nFootControlRange[nTG]);	
+		Properties.SetNumber (PropertyName, pPB->nFootControlRange[nTG]);	
 		
 		PropertyName.Format ("FootControlTarget%u", nTG+1);
-		m_Properties.SetNumber (PropertyName, m_nFootControlTarget[nTG]);	
+		Properties.SetNumber (PropertyName, pPB->nFootControlTarget[nTG]);	
 		
 		PropertyName.Format ("BreathControlRange%u", nTG+1);
-		m_Properties.SetNumber (PropertyName, m_nBreathControlRange[nTG]);	
+		Properties.SetNumber (PropertyName, pPB->nBreathControlRange[nTG]);	
 		
 		PropertyName.Format ("BreathControlTarget%u", nTG+1);
-		m_Properties.SetNumber (PropertyName, m_nBreathControlTarget[nTG]);	
+		Properties.SetNumber (PropertyName, pPB->nBreathControlTarget[nTG]);	
 		
 		PropertyName.Format ("AftertouchRange%u", nTG+1);
-		m_Properties.SetNumber (PropertyName, m_nAftertouchRange[nTG]);	
+		Properties.SetNumber (PropertyName, pPB->nAftertouchRange[nTG]);	
 		
 		PropertyName.Format ("AftertouchTarget%u", nTG+1);
-		m_Properties.SetNumber (PropertyName, m_nAftertouchTarget[nTG]);			
+		Properties.SetNumber (PropertyName, pPB->nAftertouchTarget[nTG]);			
 
 		}
 
-	m_Properties.SetNumber ("CompressorEnable", m_bCompressorEnable ? 1 : 0);
+	Properties.SetNumber ("CompressorEnable", pPB->bCompressorEnable ? 1 : 0);
 
-	m_Properties.SetNumber ("ReverbEnable", m_bReverbEnable ? 1 : 0);
-	m_Properties.SetNumber ("ReverbSize", m_nReverbSize);
-	m_Properties.SetNumber ("ReverbHighDamp", m_nReverbHighDamp);
-	m_Properties.SetNumber ("ReverbLowDamp", m_nReverbLowDamp);
-	m_Properties.SetNumber ("ReverbLowPass", m_nReverbLowPass);
-	m_Properties.SetNumber ("ReverbDiffusion", m_nReverbDiffusion);
-	m_Properties.SetNumber ("ReverbLevel", m_nReverbLevel);
+	Properties.SetNumber ("ReverbEnable", pPB->bReverbEnable ? 1 : 0);
+	Properties.SetNumber ("ReverbSize", pPB->nReverbSize);
+	Properties.SetNumber ("ReverbHighDamp", pPB->nReverbHighDamp);
+	Properties.SetNumber ("ReverbLowDamp", pPB->nReverbLowDamp);
+	Properties.SetNumber ("ReverbLowPass", pPB->nReverbLowPass);
+	Properties.SetNumber ("ReverbDiffusion", pPB->nReverbDiffusion);
+	Properties.SetNumber ("ReverbLevel", pPB->nReverbLevel);
 
-	return m_Properties.Save ();
+	return Properties.Save ();
 }
 
 unsigned CPerformanceConfig::GetBankNumber (unsigned nTG) const
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	return m_nBankNumber[nTG];
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nBankNumber[nTG];
 }
 
 unsigned CPerformanceConfig::GetVoiceNumber (unsigned nTG) const
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	return m_nVoiceNumber[nTG];
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nVoiceNumber[nTG];
 }
 
 unsigned CPerformanceConfig::GetMIDIChannel (unsigned nTG) const
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	return m_nMIDIChannel[nTG];
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nMIDIChannel[nTG];
 }
 
 unsigned CPerformanceConfig::GetVolume (unsigned nTG) const
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	return m_nVolume[nTG];
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nVolume[nTG];
 }
 
 unsigned CPerformanceConfig::GetPan (unsigned nTG) const
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	return m_nPan[nTG];
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nPan[nTG];
 }
 
 int CPerformanceConfig::GetDetune (unsigned nTG) const
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	return m_nDetune[nTG];
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nDetune[nTG];
 }
 
 unsigned CPerformanceConfig::GetCutoff (unsigned nTG) const
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	return m_nCutoff[nTG];
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nCutoff[nTG];
 }
 
 unsigned CPerformanceConfig::GetResonance (unsigned nTG) const
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	return m_nResonance[nTG];
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nResonance[nTG];
 }
 
 unsigned CPerformanceConfig::GetNoteLimitLow (unsigned nTG) const
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	return m_nNoteLimitLow[nTG];
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nNoteLimitLow[nTG];
 }
 
 unsigned CPerformanceConfig::GetNoteLimitHigh (unsigned nTG) const
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	return m_nNoteLimitHigh[nTG];
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nNoteLimitHigh[nTG];
 }
 
 int CPerformanceConfig::GetNoteShift (unsigned nTG) const
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	return m_nNoteShift[nTG];
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nNoteShift[nTG];
 }
 
 unsigned CPerformanceConfig::GetReverbSend (unsigned nTG) const
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	return m_nReverbSend[nTG];
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nReverbSend[nTG];
 }
 
 void CPerformanceConfig::SetBankNumber (unsigned nValue, unsigned nTG)
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_nBankNumber[nTG] = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nBankNumber[nTG] = nValue;
 }
 
 void CPerformanceConfig::SetVoiceNumber (unsigned nValue, unsigned nTG)
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_nVoiceNumber[nTG] = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nVoiceNumber[nTG] = nValue;
 }
 
 void CPerformanceConfig::SetMIDIChannel (unsigned nValue, unsigned nTG)
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_nMIDIChannel[nTG] = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nMIDIChannel[nTG] = nValue;
 }
 
 void CPerformanceConfig::SetVolume (unsigned nValue, unsigned nTG)
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_nVolume[nTG] = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nVolume[nTG] = nValue;
 }
 
 void CPerformanceConfig::SetPan (unsigned nValue, unsigned nTG)
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_nPan[nTG] = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nPan[nTG] = nValue;
 }
 
 void CPerformanceConfig::SetDetune (int nValue, unsigned nTG)
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_nDetune[nTG] = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nDetune[nTG] = nValue;
 }
 
 void CPerformanceConfig::SetCutoff (unsigned nValue, unsigned nTG)
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_nCutoff[nTG] = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nCutoff[nTG] = nValue;
 }
 
 void CPerformanceConfig::SetResonance (unsigned nValue, unsigned nTG)
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_nResonance[nTG] = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nResonance[nTG] = nValue;
 }
 
 void CPerformanceConfig::SetNoteLimitLow (unsigned nValue, unsigned nTG)
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_nNoteLimitLow[nTG] = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nNoteLimitLow[nTG] = nValue;
 }
 
 void CPerformanceConfig::SetNoteLimitHigh (unsigned nValue, unsigned nTG)
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_nNoteLimitHigh[nTG] = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nNoteLimitHigh[nTG] = nValue;
 }
 
 void CPerformanceConfig::SetNoteShift (int nValue, unsigned nTG)
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_nNoteShift[nTG] = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nNoteShift[nTG] = nValue;
 }
 
 void CPerformanceConfig::SetReverbSend (unsigned nValue, unsigned nTG)
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_nReverbSend[nTG] = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nReverbSend[nTG] = nValue;
 }
 
 bool CPerformanceConfig::GetCompressorEnable (void) const
 {
-	return m_bCompressorEnable;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->bCompressorEnable;
 }
 
 bool CPerformanceConfig::GetReverbEnable (void) const
 {
-	return m_bReverbEnable;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->bReverbEnable;
 }
 
 unsigned CPerformanceConfig::GetReverbSize (void) const
 {
-	return m_nReverbSize;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nReverbSize;
 }
 
 unsigned CPerformanceConfig::GetReverbHighDamp (void) const
 {
-	return m_nReverbHighDamp;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nReverbHighDamp;
 }
 
 unsigned CPerformanceConfig::GetReverbLowDamp (void) const
 {
-	return m_nReverbLowDamp;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nReverbLowDamp;
 }
 
 unsigned CPerformanceConfig::GetReverbLowPass (void) const
 {
-	return m_nReverbLowPass;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nReverbLowPass;
 }
 
 unsigned CPerformanceConfig::GetReverbDiffusion (void) const
 {
-	return m_nReverbDiffusion;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nReverbDiffusion;
 }
 
 unsigned CPerformanceConfig::GetReverbLevel (void) const
 {
-	return m_nReverbLevel;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nReverbLevel;
 }
 
 void CPerformanceConfig::SetCompressorEnable (bool bValue)
 {
-	m_bCompressorEnable = bValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->bCompressorEnable = bValue;
 }
 
 void CPerformanceConfig::SetReverbEnable (bool bValue)
 {
-	m_bReverbEnable = bValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->bReverbEnable = bValue;
 }
 
 void CPerformanceConfig::SetReverbSize (unsigned nValue)
 {
-	m_nReverbSize = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nReverbSize = nValue;
 }
 
 void CPerformanceConfig::SetReverbHighDamp (unsigned nValue)
 {
-	m_nReverbHighDamp = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nReverbHighDamp = nValue;
 }
 
 void CPerformanceConfig::SetReverbLowDamp (unsigned nValue)
 {
-	m_nReverbLowDamp = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nReverbLowDamp = nValue;
 }
 
 void CPerformanceConfig::SetReverbLowPass (unsigned nValue)
 {
-	m_nReverbLowPass = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nReverbLowPass = nValue;
 }
 
 void CPerformanceConfig::SetReverbDiffusion (unsigned nValue)
 {
-	m_nReverbDiffusion = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nReverbDiffusion = nValue;
 }
 
 void CPerformanceConfig::SetReverbLevel (unsigned nValue)
 {
-	m_nReverbLevel = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nReverbLevel = nValue;
 }
 // Pitch bender and portamento:
 void CPerformanceConfig::SetPitchBendRange (unsigned nValue, unsigned nTG)
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_nPitchBendRange[nTG] = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nPitchBendRange[nTG] = nValue;
 }
 
 unsigned CPerformanceConfig::GetPitchBendRange (unsigned nTG) const
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	return m_nPitchBendRange[nTG];
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nPitchBendRange[nTG];
 }
 
 
 void CPerformanceConfig::SetPitchBendStep (unsigned nValue, unsigned nTG)
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_nPitchBendStep[nTG] = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nPitchBendStep[nTG] = nValue;
 }
 
 unsigned CPerformanceConfig::GetPitchBendStep (unsigned nTG) const
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	return m_nPitchBendStep[nTG];
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nPitchBendStep[nTG];
 }
 
 
 void CPerformanceConfig::SetPortamentoMode (unsigned nValue, unsigned nTG)
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_nPortamentoMode[nTG] = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nPortamentoMode[nTG] = nValue;
 }
 
 unsigned CPerformanceConfig::GetPortamentoMode (unsigned nTG) const
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	return m_nPortamentoMode[nTG];
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nPortamentoMode[nTG];
 }
 
 
 void CPerformanceConfig::SetPortamentoGlissando (unsigned nValue, unsigned nTG)
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_nPortamentoGlissando[nTG] = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nPortamentoGlissando[nTG] = nValue;
 }
 
 unsigned CPerformanceConfig::GetPortamentoGlissando (unsigned nTG) const
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	return m_nPortamentoGlissando[nTG];
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nPortamentoGlissando[nTG];
 }
 
 
 void CPerformanceConfig::SetPortamentoTime (unsigned nValue, unsigned nTG)
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_nPortamentoTime[nTG] = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nPortamentoTime[nTG] = nValue;
 }
 
 unsigned CPerformanceConfig::GetPortamentoTime (unsigned nTG) const
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	return m_nPortamentoTime[nTG];
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nPortamentoTime[nTG];
 }
 
 void CPerformanceConfig::SetMonoMode (bool bValue, unsigned nTG)
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_bMonoMode[nTG] = bValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->bMonoMode[nTG] = bValue;
 }
 
 bool CPerformanceConfig::GetMonoMode (unsigned nTG) const
 {
-	return m_bMonoMode[nTG];
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->bMonoMode[nTG];
 }
 
 void CPerformanceConfig::SetModulationWheelRange (unsigned nValue, unsigned nTG)
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_nModulationWheelRange[nTG] = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nModulationWheelRange[nTG] = nValue;
 }
 
 unsigned CPerformanceConfig::GetModulationWheelRange (unsigned nTG) const
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	return m_nModulationWheelRange[nTG];
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nModulationWheelRange[nTG];
 }
 
 void CPerformanceConfig::SetModulationWheelTarget (unsigned nValue, unsigned nTG)
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_nModulationWheelTarget[nTG] = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nModulationWheelTarget[nTG] = nValue;
 }
 
 unsigned CPerformanceConfig::GetModulationWheelTarget (unsigned nTG) const
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	return m_nModulationWheelTarget[nTG];
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nModulationWheelTarget[nTG];
 }
 
 void CPerformanceConfig::SetFootControlRange (unsigned nValue, unsigned nTG)
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_nFootControlRange[nTG] = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nFootControlRange[nTG] = nValue;
 }
 
 unsigned CPerformanceConfig::GetFootControlRange (unsigned nTG) const
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	return m_nFootControlRange[nTG];
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nFootControlRange[nTG];
 }
 
 void CPerformanceConfig::SetFootControlTarget (unsigned nValue, unsigned nTG)
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_nFootControlTarget[nTG] = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nFootControlTarget[nTG] = nValue;
 }
 
 unsigned CPerformanceConfig::GetFootControlTarget (unsigned nTG) const
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	return m_nFootControlTarget[nTG];
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nFootControlTarget[nTG];
 }
 
 void CPerformanceConfig::SetBreathControlRange (unsigned nValue, unsigned nTG)
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_nBreathControlRange[nTG] = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nBreathControlRange[nTG] = nValue;
 }
 
 unsigned CPerformanceConfig::GetBreathControlRange (unsigned nTG) const
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	return m_nBreathControlRange[nTG];
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nBreathControlRange[nTG];
 }
 
 void CPerformanceConfig::SetBreathControlTarget (unsigned nValue, unsigned nTG)
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_nBreathControlTarget[nTG] = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nBreathControlTarget[nTG] = nValue;
 }
 
 unsigned CPerformanceConfig::GetBreathControlTarget (unsigned nTG) const
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	return m_nBreathControlTarget[nTG];
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nBreathControlTarget[nTG];
 }
 
 void CPerformanceConfig::SetAftertouchRange (unsigned nValue, unsigned nTG)
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_nAftertouchRange[nTG] = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nAftertouchRange[nTG] = nValue;
 }
 
 unsigned CPerformanceConfig::GetAftertouchRange (unsigned nTG) const
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	return m_nAftertouchRange[nTG];
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nAftertouchRange[nTG];
 }
 
 void CPerformanceConfig::SetAftertouchTarget (unsigned nValue, unsigned nTG)
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_nAftertouchTarget[nTG] = nValue;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nAftertouchTarget[nTG] = nValue;
 }
 
 unsigned CPerformanceConfig::GetAftertouchTarget (unsigned nTG) const
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	return m_nAftertouchTarget[nTG];
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return m_pPerfBank[m_nActualPerformance]->nAftertouchTarget[nTG];
 }
 
 void CPerformanceConfig::SetVoiceDataToTxt (const uint8_t *pData, unsigned nTG)  
 {
 	assert (nTG < CConfig::AllToneGenerators);
-	m_nVoiceDataTxt[nTG] = "";
+	assert (m_pPerfBank[m_nActualPerformance]);
+	m_pPerfBank[m_nActualPerformance]->nVoiceDataTxt[nTG] = "";
 	char nDtoH[]="0123456789ABCDEF";
 	for (int i = 0; i < NUM_VOICE_PARAM; i++)
 	{
-	m_nVoiceDataTxt[nTG]  += nDtoH[(pData[i] & 0xF0)/16];
-	m_nVoiceDataTxt[nTG]  += nDtoH[pData[i] & 0x0F]  ;
+	m_pPerfBank[m_nActualPerformance]->nVoiceDataTxt[nTG]  += nDtoH[(pData[i] & 0xF0)/16];
+	m_pPerfBank[m_nActualPerformance]->nVoiceDataTxt[nTG]  += nDtoH[pData[i] & 0x0F]  ;
 	if ( i < (NUM_VOICE_PARAM-1)  ) 
     	{
-     	 m_nVoiceDataTxt[nTG] += " ";
+     	 m_pPerfBank[m_nActualPerformance]->nVoiceDataTxt[nTG] += " ";
     	}
 	}
 }
@@ -757,12 +849,13 @@ void CPerformanceConfig::SetVoiceDataToTxt (const uint8_t *pData, unsigned nTG)
 uint8_t *CPerformanceConfig::GetVoiceDataFromTxt (unsigned nTG) 
 {
 	assert (nTG < CConfig::AllToneGenerators);
+	assert (m_pPerfBank[m_nActualPerformance]);
 	static uint8_t pData[NUM_VOICE_PARAM];
 	std::string nHtoD="0123456789ABCDEF";
 	 
  	for (int i=0; i<NUM_VOICE_PARAM * 3; i=i+3)
 	{
-  	pData[i/3] = ((nHtoD.find(toupper(m_nVoiceDataTxt[nTG][i]),0) * 16 + nHtoD.find(toupper(m_nVoiceDataTxt[nTG][i+1]),0))) & 0xFF ;
+  	pData[i/3] = ((nHtoD.find(toupper(m_pPerfBank[m_nActualPerformance]->nVoiceDataTxt[nTG][i]),0) * 16 + nHtoD.find(toupper(m_pPerfBank[m_nActualPerformance]->nVoiceDataTxt[nTG][i+1]),0))) & 0xFF ;
 	} 
   
 	return pData;
@@ -770,7 +863,8 @@ uint8_t *CPerformanceConfig::GetVoiceDataFromTxt (unsigned nTG)
 
 bool CPerformanceConfig::VoiceDataFilled(unsigned nTG) 
 {
-	return (strcmp(m_nVoiceDataTxt[nTG].c_str(),"") != 0) ;
+	assert (m_pPerfBank[m_nActualPerformance]);
+	return (strcmp(m_pPerfBank[m_nActualPerformance]->nVoiceDataTxt[nTG].c_str(),"") != 0) ;
 }
 
 std::string CPerformanceConfig::GetPerformanceFileName(unsigned nID)
@@ -966,7 +1060,10 @@ bool CPerformanceConfig::CreateNewPerformanceFile(void)
 	
 	m_nLastPerformance = nNewPerformance;
 	m_nActualPerformance = nNewPerformance;
-	new (&m_Properties) CPropertiesFatFsFile(nFileName.c_str(), m_pFileSystem);
+	
+	// This has no actual data associated with it until the caller
+	// Sets the parameters and then saves them.
+	m_pPerfBank[m_nActualPerformance] = new TPerf;	
 	
 	return true;
 }
@@ -977,6 +1074,7 @@ bool CPerformanceConfig::ListPerformances()
 	for (unsigned i=0; i<NUM_PERFORMANCES; i++)
 	{
 		m_PerformanceFileName[i].clear();
+		m_pPerfBank[i] = nullptr;
 	}
 	m_nLastPerformance=0;
 	if (m_nPerformanceBank == 0)
@@ -1067,8 +1165,6 @@ void CPerformanceConfig::SetNewPerformance (unsigned nID)
 	assert (nID < NUM_PERFORMANCES);
 	m_nActualPerformance=nID;
 	std::string FileN = GetPerformanceFullFilePath(nID);
-
-	new (&m_Properties) CPropertiesFatFsFile(FileN.c_str(), m_pFileSystem);
 #ifdef VERBOSE_DEBUG
 	LOGNOTE("Selecting Performance: %d (%s)", nID+1, FileN.c_str());
 #endif
@@ -1115,6 +1211,9 @@ bool CPerformanceConfig::DeletePerformance(unsigned nID)
 	std::string FileN = "SD:/";
 	FileN += PERFORMANCE_DIR;
 	FileN += AddPerformanceBankDirName(m_nPerformanceBank);
+
+	// Remove from cache
+	m_pPerfBank[nID] = nullptr;
 	
 	FRESULT Result = f_findfirst (&Directory, &FileInfo, FileN.c_str(), GetPerformanceFileName(nID).c_str());
 	if (Result == FR_OK && FileInfo.fname[0])

--- a/src/performanceconfig.h
+++ b/src/performanceconfig.h
@@ -149,39 +149,48 @@ public:
 	std::string GetPerformanceBankName(unsigned nBankID);
 	bool IsValidPerformanceBank(unsigned nBankID);
 
-private:
-	CPropertiesFatFsFile m_Properties;
+private:	
+	struct TPerf {
+		unsigned nBankNumber[CConfig::AllToneGenerators];
+		unsigned nVoiceNumber[CConfig::AllToneGenerators];
+		unsigned nMIDIChannel[CConfig::AllToneGenerators];
+		unsigned nVolume[CConfig::AllToneGenerators];
+		unsigned nPan[CConfig::AllToneGenerators];
+		int nDetune[CConfig::AllToneGenerators];
+		unsigned nCutoff[CConfig::AllToneGenerators];
+		unsigned nResonance[CConfig::AllToneGenerators];
+		unsigned nNoteLimitLow[CConfig::AllToneGenerators];
+		unsigned nNoteLimitHigh[CConfig::AllToneGenerators];
+		int nNoteShift[CConfig::AllToneGenerators];
+		int nReverbSend[CConfig::AllToneGenerators];
+		unsigned nPitchBendRange[CConfig::AllToneGenerators];
+		unsigned nPitchBendStep[CConfig::AllToneGenerators];
+		unsigned nPortamentoMode[CConfig::AllToneGenerators];
+		unsigned nPortamentoGlissando[CConfig::AllToneGenerators];
+		unsigned nPortamentoTime[CConfig::AllToneGenerators];
+		std::string nVoiceDataTxt[CConfig::AllToneGenerators]; 
+		bool bMonoMode[CConfig::AllToneGenerators]; 
+
+		unsigned nModulationWheelRange[CConfig::AllToneGenerators];
+		unsigned nModulationWheelTarget[CConfig::AllToneGenerators];
+		unsigned nFootControlRange[CConfig::AllToneGenerators];	
+		unsigned nFootControlTarget[CConfig::AllToneGenerators];	
+		unsigned nBreathControlRange[CConfig::AllToneGenerators];	
+		unsigned nBreathControlTarget[CConfig::AllToneGenerators];	
+		unsigned nAftertouchRange[CConfig::AllToneGenerators];	
+		unsigned nAftertouchTarget[CConfig::AllToneGenerators];	
+
+		bool bCompressorEnable;
+		bool bReverbEnable;
+		unsigned nReverbSize;
+		unsigned nReverbHighDamp;
+		unsigned nReverbLowDamp;
+		unsigned nReverbLowPass;
+		unsigned nReverbDiffusion;
+		unsigned nReverbLevel;
+	};
 	
 	unsigned m_nToneGenerators;
-
-	unsigned m_nBankNumber[CConfig::AllToneGenerators];
-	unsigned m_nVoiceNumber[CConfig::AllToneGenerators];
-	unsigned m_nMIDIChannel[CConfig::AllToneGenerators];
-	unsigned m_nVolume[CConfig::AllToneGenerators];
-	unsigned m_nPan[CConfig::AllToneGenerators];
-	int m_nDetune[CConfig::AllToneGenerators];
-	unsigned m_nCutoff[CConfig::AllToneGenerators];
-	unsigned m_nResonance[CConfig::AllToneGenerators];
-	unsigned m_nNoteLimitLow[CConfig::AllToneGenerators];
-	unsigned m_nNoteLimitHigh[CConfig::AllToneGenerators];
-	int m_nNoteShift[CConfig::AllToneGenerators];
-	int m_nReverbSend[CConfig::AllToneGenerators];
-	unsigned m_nPitchBendRange[CConfig::AllToneGenerators];
-	unsigned m_nPitchBendStep[CConfig::AllToneGenerators];
-	unsigned m_nPortamentoMode[CConfig::AllToneGenerators];
-	unsigned m_nPortamentoGlissando[CConfig::AllToneGenerators];
-	unsigned m_nPortamentoTime[CConfig::AllToneGenerators];
-	std::string m_nVoiceDataTxt[CConfig::AllToneGenerators]; 
-	bool m_bMonoMode[CConfig::AllToneGenerators]; 
-
-	unsigned m_nModulationWheelRange[CConfig::AllToneGenerators];
-	unsigned m_nModulationWheelTarget[CConfig::AllToneGenerators];
-	unsigned m_nFootControlRange[CConfig::AllToneGenerators];	
-	unsigned m_nFootControlTarget[CConfig::AllToneGenerators];	
-	unsigned m_nBreathControlRange[CConfig::AllToneGenerators];	
-	unsigned m_nBreathControlTarget[CConfig::AllToneGenerators];	
-	unsigned m_nAftertouchRange[CConfig::AllToneGenerators];	
-	unsigned m_nAftertouchTarget[CConfig::AllToneGenerators];	
 
 	unsigned m_nLastPerformance;  
 	unsigned m_nActualPerformance = 0;  
@@ -195,15 +204,8 @@ private:
 	FATFS *m_pFileSystem; 
 
 	std::string NewPerformanceName="";
-	
-	bool m_bCompressorEnable;
-	bool m_bReverbEnable;
-	unsigned m_nReverbSize;
-	unsigned m_nReverbHighDamp;
-	unsigned m_nReverbLowDamp;
-	unsigned m_nReverbLowPass;
-	unsigned m_nReverbDiffusion;
-	unsigned m_nReverbLevel;
+
+	TPerf *m_pPerfBank[NUM_PERFORMANCES];
 };
 
 #endif

--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -563,6 +563,7 @@ void CUIMenu::EditGlobalParameter (CUIMenu *pUIMenu, TMenuEvent Event)
 	switch (Event)
 	{
 	case MenuEventUpdate:
+	case MenuEventUpdateParameter:
 		break;
 
 	case MenuEventStepDown:
@@ -608,6 +609,7 @@ void CUIMenu::EditVoiceBankNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 	switch (Event)
 	{
 	case MenuEventUpdate:
+	case MenuEventUpdateParameter:
 		break;
 
 	case MenuEventStepDown:
@@ -652,6 +654,7 @@ void CUIMenu::EditProgramNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 	switch (Event)
 	{
 	case MenuEventUpdate:
+	case MenuEventUpdateParameter:
 		break;
 
 	case MenuEventStepDown:
@@ -726,6 +729,7 @@ void CUIMenu::EditTGParameter (CUIMenu *pUIMenu, TMenuEvent Event)
 	switch (Event)
 	{
 	case MenuEventUpdate:
+	case MenuEventUpdateParameter:
 		break;
 
 	case MenuEventStepDown:
@@ -779,6 +783,7 @@ void CUIMenu::EditTGParameter2 (CUIMenu *pUIMenu, TMenuEvent Event) // second me
 	switch (Event)
 	{
 	case MenuEventUpdate:
+	case MenuEventUpdateParameter:
 		break;
 
 	case MenuEventStepDown:
@@ -832,6 +837,7 @@ void CUIMenu::EditVoiceParameter (CUIMenu *pUIMenu, TMenuEvent Event)
 	switch (Event)
 	{
 	case MenuEventUpdate:
+	case MenuEventUpdateParameter:
 		break;
 
 	case MenuEventStepDown:
@@ -885,6 +891,7 @@ void CUIMenu::EditOPParameter (CUIMenu *pUIMenu, TMenuEvent Event)
 	switch (Event)
 	{
 	case MenuEventUpdate:
+	case MenuEventUpdateParameter:
 		break;
 
 	case MenuEventStepDown:

--- a/src/uimenu.h
+++ b/src/uimenu.h
@@ -39,6 +39,7 @@ public:
 	enum TMenuEvent
 	{
 		MenuEventUpdate,
+		MenuEventUpdateParameter,
 		MenuEventSelect,
 		MenuEventBack,
 		MenuEventHome,

--- a/src/userinterface.cpp
+++ b/src/userinterface.cpp
@@ -212,6 +212,11 @@ void CUserInterface::Process (void)
 
 void CUserInterface::ParameterChanged (void)
 {
+	m_Menu.EventHandler (CUIMenu::MenuEventUpdateParameter);
+}
+
+void CUserInterface::DisplayChanged (void)
+{
 	m_Menu.EventHandler (CUIMenu::MenuEventUpdate);
 }
 

--- a/src/userinterface.h
+++ b/src/userinterface.h
@@ -45,6 +45,7 @@ public:
 	void Process (void);
 
 	void ParameterChanged (void);
+	void DisplayChanged (void);
 
 	// Write to display in this format:
 	// +----------------+


### PR DESCRIPTION
Looking at the performance issues when loading performances.

This change adds a "caching layer" between minidexed.cpp and the circle properties files, so that if a file has already been loaded then it doesn't need to be grabbed off the SD card a second time.

This has the following properties:
* First time a performance is selected it will need to get it from the card which will be slower.
* All subsequent times the performance is loaded it is loaded from memory.
* When the banks are changed the cache is cleared so all performances will once again have to be obtained from the card.
* I believe save as new, overwrite and delete all work, but it needs some serious ttesting.
* I think this makes `PerformanceSelectToLoad=0` much more feasible to use now, meaning selecting performances can be a lot more similar to selecting voices.
* When first loading performances it is still possible for the menu to lag compared to the selected performance due to loading from the card.
* It should be possible to include a start-up mode to preload all performances in a bank - tbd.  But it isn't clear what to do on bank changes - should it load all performances in that bank too?  That will be slow I'd imagine.
* If using PCCH and MIDI and your programmer sends BANKSEL+PC each time, then the cache will be invalidated on every BANKSEL.  But if your programmer only sends Program Change, the cache will work as expected.

I don't know how much memory this takes up, so it might not work on smaller PIs... I need to have a look at that.  I'm running on a PI 3A+ fine as far as I know so far.

Please give it a go and let me know any issues :)

If this works, then I hope it essentially fixes #694 and similar issues (tbc).

Kevin