### PR TITLE
add saturation for arm_float_to_q23 neon implementation

### DIFF
--- a/src/arm_float_to_q23.c
+++ b/src/arm_float_to_q23.c
@@ -22,6 +22,10 @@ void arm_float_to_q23(const float32_t * pSrc, q23_t * pDst, uint32_t blockSize)
 
         cvt = vcvtq_n_s32_f32(inV, 23);
 
+        /* saturate */
+        cvt = vminq_s32(cvt, vdupq_n_s32(0x007fffff));
+        cvt = vmaxq_s32(cvt, vdupq_n_s32(0xff800000));
+
         vst1q_s32(pDst, cvt);
         pDst += 4;
         pIn += 4;


### PR DESCRIPTION
altough vcvtq_n_s32_f32 does a saturation, but for 32 bits. We need saturation for 24 bits.