### PR TITLE
fix op ordering and reenabling

### DIFF
--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -1177,6 +1177,8 @@ void CMiniDexed::SetVoiceParameter (uint8_t uchOffset, uint8_t uchValue, unsigne
 
 	if (nOP < 6)
 	{
+		nOP = 5 - nOP;		// OPs are in reverse order
+
 		if (uchOffset == DEXED_OP_ENABLE)
 		{
 			if (uchValue)
@@ -1191,9 +1193,7 @@ void CMiniDexed::SetVoiceParameter (uint8_t uchOffset, uint8_t uchValue, unsigne
 			m_pTG[nTG]->setOPAll (m_uchOPMask[nTG]);
 
 			return;
-		}
-
-		nOP = 5 - nOP;		// OPs are in reverse order
+		}		
 	}
 
 	uchOffset += nOP * 21;
@@ -1212,12 +1212,12 @@ uint8_t CMiniDexed::GetVoiceParameter (uint8_t uchOffset, unsigned nOP, unsigned
 
 	if (nOP < 6)
 	{
+		nOP = 5 - nOP;		// OPs are in reverse order
+
 		if (uchOffset == DEXED_OP_ENABLE)
 		{
 			return !!(m_uchOPMask[nTG] & (1 << nOP));
 		}
-
-		nOP = 5 - nOP;		// OPs are in reverse order
 	}
 
 	uchOffset += nOP * 21;

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -657,6 +657,7 @@ void CMiniDexed::ProgramChange (unsigned nProgram, unsigned nTG)
 
 	assert (m_pTG[nTG]);
 	m_pTG[nTG]->loadVoiceParameters (Buffer);
+	setOPMask(0b111111, nTG);
 
 	if (m_pConfig->GetMIDIAutoVoiceDumpOnPC())
 	{
@@ -1183,14 +1184,13 @@ void CMiniDexed::SetVoiceParameter (uint8_t uchOffset, uint8_t uchValue, unsigne
 		{
 			if (uchValue)
 			{
-				m_uchOPMask[nTG] |= 1 << nOP;
+				setOPMask(m_uchOPMask[nTG] | 1 << nOP, nTG);
 			}
 			else
 			{
-				m_uchOPMask[nTG] &= ~(1 << nOP);
+				setOPMask(m_uchOPMask[nTG] & ~(1 << nOP), nTG);
 			}
 
-			m_pTG[nTG]->setOPAll (m_uchOPMask[nTG]);
 
 			return;
 		}		
@@ -1791,6 +1791,8 @@ void CMiniDexed::loadVoiceParameters(const uint8_t* data, uint8_t nTG)
 
 	m_pTG[nTG]->loadVoiceParameters(&voice[6]);
 	m_pTG[nTG]->doRefreshVoice();
+	setOPMask(0b111111, nTG);
+
 	m_UI.ParameterChanged ();
 }
 
@@ -1845,6 +1847,12 @@ void CMiniDexed::getSysExVoiceDump(uint8_t* dest, uint8_t nTG)
 	}
 	dest[161] = checksum & 0x7f; // Checksum
 	dest[162] = 0xF7; // SysEx end
+}
+
+void CMiniDexed::setOPMask(uint8_t uchOPMask, uint8_t nTG)
+{
+	m_uchOPMask[nTG] = uchOPMask;
+	m_pTG[nTG]->setOPAll (m_uchOPMask[nTG]);
 }
 
 void CMiniDexed::setMasterVolume(float32_t vol)
@@ -2021,6 +2029,7 @@ void CMiniDexed::LoadPerformanceParameters(void)
 			{
 			uint8_t* tVoiceData = m_PerformanceConfig.GetVoiceDataFromTxt(nTG);
 			m_pTG[nTG]->loadVoiceParameters(tVoiceData); 
+			setOPMask(0b111111, nTG);
 			}
 			setMonoMode(m_PerformanceConfig.GetMonoMode(nTG) ? 1 : 0, nTG); 
 			SetReverbSend (m_PerformanceConfig.GetReverbSend (nTG), nTG);

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -122,6 +122,7 @@ public:
 	void loadVoiceParameters(const uint8_t* data, uint8_t nTG);
 	void setVoiceDataElement(uint8_t data, uint8_t number, uint8_t nTG);
 	void getSysExVoiceDump(uint8_t* dest, uint8_t nTG);
+	void setOPMask(uint8_t uchOPMask, uint8_t nTG);
 
 	void setModController (unsigned controller, unsigned parameter, uint8_t value, uint8_t nTG);
 	unsigned getModController (unsigned controller, unsigned parameter, uint8_t nTG);


### PR DESCRIPTION
The ops are in reverse order in the OPMask as well

If you change a voice, Dexed enables all operator.
Do the same in MiniDexed.