### PR TITLE
Do not refesh the display unnecessarily when updating a parameter

### DIFF
--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -2047,6 +2047,8 @@ void CMiniDexed::LoadPerformanceParameters(void)
 		SetParameter (ParameterReverbLowPass, m_PerformanceConfig.GetReverbLowPass ());
 		SetParameter (ParameterReverbDiffusion, m_PerformanceConfig.GetReverbDiffusion ());
 		SetParameter (ParameterReverbLevel, m_PerformanceConfig.GetReverbLevel ());
+
+		m_UI.DisplayChanged ();
 }
 
 std::string CMiniDexed::GetNewPerformanceDefaultName(void)	

--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -563,6 +563,7 @@ void CUIMenu::EditGlobalParameter (CUIMenu *pUIMenu, TMenuEvent Event)
 	switch (Event)
 	{
 	case MenuEventUpdate:
+	case MenuEventUpdateParameter:
 		break;
 
 	case MenuEventStepDown:
@@ -608,6 +609,7 @@ void CUIMenu::EditVoiceBankNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 	switch (Event)
 	{
 	case MenuEventUpdate:
+	case MenuEventUpdateParameter:
 		break;
 
 	case MenuEventStepDown:
@@ -652,6 +654,7 @@ void CUIMenu::EditProgramNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 	switch (Event)
 	{
 	case MenuEventUpdate:
+	case MenuEventUpdateParameter:
 		break;
 
 	case MenuEventStepDown:
@@ -741,6 +744,7 @@ void CUIMenu::EditTGParameter (CUIMenu *pUIMenu, TMenuEvent Event)
 	switch (Event)
 	{
 	case MenuEventUpdate:
+	case MenuEventUpdateParameter:
 		break;
 
 	case MenuEventStepDown:
@@ -794,6 +798,7 @@ void CUIMenu::EditTGParameter2 (CUIMenu *pUIMenu, TMenuEvent Event) // second me
 	switch (Event)
 	{
 	case MenuEventUpdate:
+	case MenuEventUpdateParameter:
 		break;
 
 	case MenuEventStepDown:
@@ -847,6 +852,7 @@ void CUIMenu::EditVoiceParameter (CUIMenu *pUIMenu, TMenuEvent Event)
 	switch (Event)
 	{
 	case MenuEventUpdate:
+	case MenuEventUpdateParameter:
 		break;
 
 	case MenuEventStepDown:
@@ -900,6 +906,7 @@ void CUIMenu::EditOPParameter (CUIMenu *pUIMenu, TMenuEvent Event)
 	switch (Event)
 	{
 	case MenuEventUpdate:
+	case MenuEventUpdateParameter:
 		break;
 
 	case MenuEventStepDown:

--- a/src/uimenu.h
+++ b/src/uimenu.h
@@ -39,6 +39,7 @@ public:
 	enum TMenuEvent
 	{
 		MenuEventUpdate,
+		MenuEventUpdateParameter,
 		MenuEventSelect,
 		MenuEventBack,
 		MenuEventHome,

--- a/src/userinterface.cpp
+++ b/src/userinterface.cpp
@@ -212,6 +212,11 @@ void CUserInterface::Process (void)
 
 void CUserInterface::ParameterChanged (void)
 {
+	m_Menu.EventHandler (CUIMenu::MenuEventUpdateParameter);
+}
+
+void CUserInterface::DisplayChanged (void)
+{
 	m_Menu.EventHandler (CUIMenu::MenuEventUpdate);
 }
 

--- a/src/userinterface.h
+++ b/src/userinterface.h
@@ -45,6 +45,7 @@ public:
 	void Process (void);
 
 	void ParameterChanged (void);
+	void DisplayChanged (void);
 
 	// Write to display in this format:
 	// +----------------+


### PR DESCRIPTION
When changing performance, display change is called too many times, and it takes too long. This solves the problem by not calling it every time a parameter is changed, but only once at the end.