### PR TITLE
BREAKING CHANGE: Load default performances from performance/001_Default

### DIFF
--- a/src/performanceconfig.cpp
+++ b/src/performanceconfig.cpp
@@ -1290,12 +1290,6 @@ std::string CPerformanceConfig::AddPerformanceBankDirName(unsigned nBankID)
 	{
 		// Performance Banks directories in format "001_Bank Name"
 		std::string Index;
-		if (nBankID == 0)
-		{
-			// Legacy: Bank 1 is the default performance directory
-			return "";
-		}
-
 		if (nBankID < 9)
 		{
 			Index = "00" + std::to_string(nBankID+1);

--- a/src/performanceconfig.cpp
+++ b/src/performanceconfig.cpp
@@ -33,7 +33,6 @@ LOGMODULE ("Performance");
 #define PERFORMANCE_DIR "performance" 
 #define DEFAULT_PERFORMANCE_FILENAME "performance.ini"
 #define DEFAULT_PERFORMANCE_NAME "Default"
-#define DEFAULT_PERFORMANCE_BANK_NAME "Default"
 
 CPerformanceConfig::CPerformanceConfig (FATFS *pFileSystem)
 :	m_Properties (DEFAULT_PERFORMANCE_FILENAME, pFileSystem)
@@ -1168,10 +1167,6 @@ bool CPerformanceConfig::ListPerformanceBanks()
 	}
 
 	unsigned nNumBanks = 0;
-	
-	// Add in the default performance directory as the first bank
-	m_PerformanceBankName[0] = DEFAULT_PERFORMANCE_BANK_NAME;
-	nNumBanks = 1;
 	m_nLastPerformanceBank = 0;
 
 	// List directories with names in format 01_Perf Bank Name
@@ -1277,10 +1272,7 @@ std::string CPerformanceConfig::GetPerformanceBankName(unsigned nBankID)
 	{
 		return m_PerformanceBankName[nBankID];
 	}
-	else
-	{
-		return DEFAULT_PERFORMANCE_BANK_NAME;
-	}
+	return "";
 }
 
 std::string CPerformanceConfig::AddPerformanceBankDirName(unsigned nBankID)

--- a/updater.py
+++ b/updater.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python3  
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
+#  -*- coding: utf-8 -*-
 
 # Updater for MiniDexed
 


### PR DESCRIPTION

rather than performance/

Closes https://github.com/probonopd/MiniDexed/discussions/893, https://github.com/probonopd/MiniDexed/issues/894

Users need to create a `performance/001_Default/` directory and move `performance/*.ini` there.