### PR TITLE
limit the number of processed frames to chunksize / 2

### DIFF
--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -1305,6 +1305,10 @@ void CMiniDexed::ProcessSound (void)
 	unsigned nFrames = m_nQueueSizeFrames - m_pSoundDevice->GetQueueFramesAvail ();
 	if (nFrames >= m_nQueueSizeFrames/2)
 	{
+		// only process the minimum number of frames (== chunksize / 2)
+		// as the tg_mixer cannot process more
+		nFrames = m_nQueueSizeFrames / 2;
+
 		if (m_bProfileEnabled)
 		{
 			m_GetChunkTimer.Start ();


### PR DESCRIPTION
The tg_mixer cannot process more franes,
So if it has to process more, uninitialized frames will be played, which causes strange sounds, e.g. at startup.

Closes #908