### PR TITLE
MIDI messages for MiniDexed Performance parameters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,10 +87,10 @@ jobs:
           mkdir -p ./sdcard/hardware/
           cp -r ./hwconfig/minidexed_* ./sdcard/minidexed.ini ./sdcard/hardware/
           # WLAN firmware
-          mkdir -p sdcard/firmware
-          cp circle-stdlib/libs/circle/addon/wlan/sample/hello_wlan/wpa_supplicant.conf sdcard/
-          cd sdcard/firmware
-          make -f ../../circle-stdlib/libs/circle/addon/wlan/firmware/Makefile
+          # mkdir -p sdcard/firmware
+          # cp circle-stdlib/libs/circle/addon/wlan/sample/hello_wlan/wpa_supplicant.conf sdcard/
+          # cd sdcard/firmware
+          # make -f ../../circle-stdlib/libs/circle/addon/wlan/firmware/Makefile
           cd -
 
       - name: Upload 64-bit artifacts

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,7 +11,8 @@ OBJS = main.o kernel.o minidexed.o config.o userinterface.o uimenu.o \
        sysexfileloader.o performanceconfig.o perftimer.o \
        effect_compressor.o effect_platervbstereo.o uibuttons.o midipin.o \
        arm_float_to_q23.o \
-       net/ftpdaemon.o net/ftpworker.o net/applemidi.o net/udpmidi.o net/mdnspublisher.o udpmididevice.o
+       net/ftpdaemon.o net/ftpworker.o net/applemidi.o net/udpmidi.o net/mdnspublisher.o udpmididevice.o \
+       performance_sysex.o
 
 OPTIMIZE = -O3
 

--- a/src/mididevice.cpp
+++ b/src/mididevice.cpp
@@ -816,9 +816,15 @@ void CMIDIDevice::HandleSystemExclusive(const uint8_t* pMessage, const size_t nL
       LOGERR("Unknown SysEx message.");
       break;
     case 100:
-      // load sysex-data into voice memory
+      // Load sysex-data into voice memory
       LOGDBG("One Voice bulk upload");
       m_pSynthesizer->loadVoiceParameters(pMessage,nTG);
+      // Also update performance config so the new voice is not lost
+      if (m_pSynthesizer && m_pSynthesizer->GetPerformanceConfig()) {
+        uint8_t unpackedVoice[156];
+        m_pSynthesizer->GetCurrentVoiceData(unpackedVoice, nTG);
+        m_pSynthesizer->GetPerformanceConfig()->SetVoiceDataToTxt(unpackedVoice, nTG);
+      }
       break;
     case 200:
       LOGDBG("Bank bulk upload.");

--- a/src/mididevice.cpp
+++ b/src/mididevice.cpp
@@ -239,8 +239,8 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 	// Handle MiniDexed performance SysEx messages
 	if (pMessage[0] == MIDI_SYSTEM_EXCLUSIVE_BEGIN && pMessage[1] == 0x7D ) {
 		LOGNOTE("MiniDexed SysEx handler entered, nLength=%u", nLength);
-		// Use performance_sysex.h to handle the SysEx message
-		handle_performance_sysex(pMessage, this, m_pSynthesizer->GetPerformanceConfig(), nCable);
+		// Update: Pass m_pSynthesizer to handle_performance_sysex for synth/GUI update
+		handle_performance_sysex(pMessage, this, m_pSynthesizer, nCable);
         return;
     } else  {
         LOGNOTE("MiniDexed SysEx handler NOT entered, nLength=%u", nLength);

--- a/src/mididevice.cpp
+++ b/src/mididevice.cpp
@@ -819,13 +819,11 @@ void CMIDIDevice::HandleSystemExclusive(const uint8_t* pMessage, const size_t nL
       // Load sysex-data into voice memory
       LOGDBG("One Voice bulk upload");
       m_pSynthesizer->loadVoiceParameters(pMessage,nTG);
-      // Defer performance config update to main loop
+      // Defer performance config update to main loop because it would be too slow to do it here
       if (m_pSynthesizer && m_pSynthesizer->GetPerformanceConfig()) {
-        uint8_t unpackedVoice[156];
-        m_pSynthesizer->GetCurrentVoiceData(unpackedVoice, nTG);
         CMiniDexed* pMiniDexed = static_cast<CMiniDexed*>(m_pSynthesizer);
         if (pMiniDexed) {
-          pMiniDexed->SetPendingVoicePerformanceUpdate(unpackedVoice, nTG);
+          pMiniDexed->SetPendingVoicePerformanceUpdate(nTG);
         }
       }
       break;

--- a/src/mididevice.cpp
+++ b/src/mididevice.cpp
@@ -238,12 +238,8 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 
 	// Handle MiniDexed performance SysEx messages
 	if (pMessage[0] == MIDI_SYSTEM_EXCLUSIVE_BEGIN && pMessage[1] == 0x7D ) {
-		LOGNOTE("MiniDexed SysEx handler entered, nLength=%u", nLength);
-		// Update: Pass m_pSynthesizer to handle_performance_sysex for synth/GUI update
 		handle_performance_sysex(pMessage, this, m_pSynthesizer, nCable);
         return;
-    } else  {
-        LOGNOTE("MiniDexed SysEx handler NOT entered, nLength=%u", nLength);
     }
 
 	// Master Volume is set using a MIDI SysEx message as follows:

--- a/src/mididevice.cpp
+++ b/src/mididevice.cpp
@@ -819,11 +819,14 @@ void CMIDIDevice::HandleSystemExclusive(const uint8_t* pMessage, const size_t nL
       // Load sysex-data into voice memory
       LOGDBG("One Voice bulk upload");
       m_pSynthesizer->loadVoiceParameters(pMessage,nTG);
-      // Also update performance config so the new voice is not lost
+      // Defer performance config update to main loop
       if (m_pSynthesizer && m_pSynthesizer->GetPerformanceConfig()) {
         uint8_t unpackedVoice[156];
         m_pSynthesizer->GetCurrentVoiceData(unpackedVoice, nTG);
-        m_pSynthesizer->GetPerformanceConfig()->SetVoiceDataToTxt(unpackedVoice, nTG);
+        CMiniDexed* pMiniDexed = static_cast<CMiniDexed*>(m_pSynthesizer);
+        if (pMiniDexed) {
+          pMiniDexed->SetPendingVoicePerformanceUpdate(unpackedVoice, nTG);
+        }
       }
       break;
     case 200:

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -2498,3 +2498,9 @@ bool CMiniDexed::InitNetwork()
 		return false;
 	}
 }
+
+void CMiniDexed::GetCurrentVoiceData(uint8_t* dest, unsigned nTG) {
+    if (nTG < m_nToneGenerators && m_pTG[nTG]) {
+        m_pTG[nTG]->getVoiceData(dest);
+    }
+}

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -2504,3 +2504,9 @@ void CMiniDexed::GetCurrentVoiceData(uint8_t* dest, unsigned nTG) {
         m_pTG[nTG]->getVoiceData(dest);
     }
 }
+
+void CMiniDexed::SetPendingVoicePerformanceUpdate(const uint8_t* voiceData, uint8_t tg) {
+    m_PendingVoicePerformanceUpdate.pending = true;
+    memcpy(m_PendingVoicePerformanceUpdate.voiceData, voiceData, 156);
+    m_PendingVoicePerformanceUpdate.tg = tg;
+}

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -2505,8 +2505,17 @@ void CMiniDexed::GetCurrentVoiceData(uint8_t* dest, unsigned nTG) {
     }
 }
 
-void CMiniDexed::SetPendingVoicePerformanceUpdate(const uint8_t* voiceData, uint8_t tg) {
-    m_PendingVoicePerformanceUpdate.pending = true;
-    memcpy(m_PendingVoicePerformanceUpdate.voiceData, voiceData, 156);
-    m_PendingVoicePerformanceUpdate.tg = tg;
+void CMiniDexed::SetPendingVoicePerformanceUpdate(unsigned nTG) {
+    if (nTG < m_nToneGenerators && m_pTG[nTG]) {
+		// Get the current voice data from the synthesizer
+		uint8_t currentVoiceData[155];
+		m_pTG[nTG]->getVoiceData(currentVoiceData);
+		// We need to set the voice data in the synthesizer's performance config
+		// to ensure that the performance is not changed back to the previous one
+		// when a parameter is changed.
+		// This is a workaround for the fact that the performance config
+		// is not updated when the voice data is changed because it would be
+		// too costly to do in the thread.
+		this->GetPerformanceConfig()->SetVoiceDataToTxt(currentVoiceData, nTG);
+    }
 }

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -244,10 +244,12 @@ public:
 	bool InitNetwork();
 	void UpdateNetwork();
 
+public:
+	void LoadPerformanceParameters(void); 
+
 private:
 	int16_t ApplyNoteLimits (int16_t pitch, unsigned nTG);	// returns < 0 to ignore note
 	uint8_t m_uchOPMask[CConfig::AllToneGenerators];
-	void LoadPerformanceParameters(void); 
 	void ProcessSound (void);
 	const char* GetNetworkDeviceShortName() const;
 

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -248,6 +248,9 @@ public:
 
 	void GetCurrentVoiceData(uint8_t* dest, unsigned nTG);
 
+public:
+    void SetPendingVoicePerformanceUpdate(const uint8_t* voiceData, uint8_t tg);
+
 private:
 	int16_t ApplyNoteLimits (int16_t pitch, unsigned nTG);	// returns < 0 to ignore note
 	uint8_t m_uchOPMask[CConfig::AllToneGenerators];
@@ -367,6 +370,13 @@ private:
 	bool m_bLoadPerformanceBusy;
 	bool m_bLoadPerformanceBankBusy;
 	bool m_bSaveAsDeault;
+
+	// Add for deferred performance update after SysEx voice load
+	struct PendingVoicePerformanceUpdate {
+		bool pending = false;
+		uint8_t voiceData[156];
+		uint8_t tg = 0;
+	} m_PendingVoicePerformanceUpdate;
 };
 
 #endif

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -244,8 +244,9 @@ public:
 	bool InitNetwork();
 	void UpdateNetwork();
 
-public:
 	void LoadPerformanceParameters(void); 
+
+	void GetCurrentVoiceData(uint8_t* dest, unsigned nTG);
 
 private:
 	int16_t ApplyNoteLimits (int16_t pitch, unsigned nTG);	// returns < 0 to ignore note

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -249,7 +249,7 @@ public:
 	void GetCurrentVoiceData(uint8_t* dest, unsigned nTG);
 
 public:
-    void SetPendingVoicePerformanceUpdate(const uint8_t* voiceData, uint8_t tg);
+    void SetPendingVoicePerformanceUpdate(unsigned nTG);
 
 private:
 	int16_t ApplyNoteLimits (int16_t pitch, unsigned nTG);	// returns < 0 to ignore note

--- a/src/net/applemidi.cpp
+++ b/src/net/applemidi.cpp
@@ -919,6 +919,6 @@ bool CAppleMIDIParticipant::SendMIDIToHost(const u8* pData, size_t nSize)
 		return false;
 	}
 	
-	LOGDBG("Successfully sent %zu bytes of MIDI data", nSize);
+	LOGDBG("Successfully sent %u bytes of MIDI data", nSize);
 	return true;
 }

--- a/src/performance_sysex.cpp
+++ b/src/performance_sysex.cpp
@@ -1,0 +1,205 @@
+//
+// performance_sysex_handler.cpp
+//
+// MiniDexed - Dexed FM synthesizer for bare metal Raspberry Pi
+// Copyright (C) 2025  The MiniDexed Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "performance_sysex.h"
+#include "performanceconfig.h"
+#include <circle/logger.h>
+#include <cstring>
+#include "minidexed.h"
+#include "mididevice.h"
+
+LOGMODULE ("PerformanceSysEx");
+
+static constexpr uint8_t SYSEX_START = 0xF0;
+static constexpr uint8_t SYSEX_END   = 0xF7;
+static constexpr uint8_t MANUFACTURER_ID = 0x7D;
+static constexpr uint8_t CMD_GET = 0x10;
+static constexpr uint8_t CMD_SET = 0x20;
+
+static void send_sysex_response(const uint8_t* data, size_t len, CMIDIDevice* pDevice, unsigned nCable) {
+    if (pDevice) {
+        pDevice->Send(data, len, nCable);
+        LOGNOTE("Sent SysEx response (%u bytes) on cable %u", (unsigned)len, nCable);
+    }
+}
+
+void handle_performance_sysex(const uint8_t* pMessage, CMIDIDevice* pDevice, CPerformanceConfig* perf, unsigned nCable) {
+    if (!pMessage || !perf) {
+        LOGERR("handle_performance_sysex: Null pointer or PerformanceConfig not set");
+        return;
+    }
+    if (pMessage[0] != SYSEX_START) {
+        LOGERR("SysEx: Invalid start byte: 0x%02X", pMessage[0]);
+        return;
+    }
+    int len = 0;
+    while (len < 256 && pMessage[len] != SYSEX_END) ++len;
+    if (len < 3 || pMessage[len] != SYSEX_END) {
+        LOGERR("SysEx: No end byte or too short");
+        return;
+    }
+    if (pMessage[1] != MANUFACTURER_ID) {
+        LOGERR("SysEx: Invalid manufacturer ID: 0x%02X", pMessage[1]);
+        return;
+    }
+
+    uint8_t tg = 0xFF; // 0xFF = global
+    uint8_t cmd = 0;
+    uint8_t offset = 0;
+
+    if (pMessage[2] == CMD_GET || pMessage[2] == CMD_SET) {
+        cmd = pMessage[2];
+        offset = 3;
+        LOGNOTE("SysEx: Global %s request", cmd == CMD_GET ? "GET" : "SET");
+    } else if (pMessage[2] < 0x80 && (pMessage[3] == CMD_GET || pMessage[3] == CMD_SET)) {
+        tg = pMessage[2];
+        cmd = pMessage[3];
+        offset = 4;
+        LOGNOTE("SysEx: TG-specific %s request for TG %u", cmd == CMD_GET ? "GET" : "SET", tg);
+    } else {
+        LOGERR("SysEx: Unrecognized message structure");
+        return;
+    }
+
+    if (offset == len) {
+        // Dump all global or all TG parameters
+        if (cmd == CMD_GET) {
+            if (tg == 0xFF) {
+                // Dump all global
+                size_t count = 0;
+                const uint16_t* params = CPerformanceConfig::GetAllGlobalParams(count);
+                uint16_t values[16] = {0};
+                if (perf->GetGlobalParameters(params, values, count)) {
+                    LOGNOTE("SysEx: Dumping all global parameters");
+                    uint8_t resp[64] = {0};
+                    resp[0] = SYSEX_START;
+                    resp[1] = MANUFACTURER_ID;
+                    resp[2] = CMD_GET;
+                    size_t idx = 3;
+                    for (size_t i = 0; i < count; ++i) {
+                        resp[idx++] = (params[i] >> 8) & 0xFF;
+                        resp[idx++] = params[i] & 0xFF;
+                        resp[idx++] = (values[i] >> 8) & 0xFF;
+                        resp[idx++] = values[i] & 0xFF;
+                        LOGNOTE("  Param 0x%04X = 0x%04X", params[i], values[i]);
+                    }
+                    resp[idx++] = SYSEX_END;
+                    send_sysex_response(resp, idx, pDevice, nCable);
+                } else {
+                    LOGERR("SysEx: Failed to get all global parameters");
+                }
+            } else {
+                // Dump all TG
+                size_t count = 0;
+                const uint16_t* params = CPerformanceConfig::GetAllTGParams(count);
+                uint16_t values[32] = {0};
+                if (perf->GetTGParameters(params, values, count, tg)) {
+                    LOGNOTE("SysEx: Dumping all TG parameters for TG %u", tg);
+                    uint8_t resp[128] = {0};
+                    resp[0] = SYSEX_START;
+                    resp[1] = MANUFACTURER_ID;
+                    resp[2] = tg;
+                    resp[3] = CMD_GET;
+                    size_t idx = 4;
+                    for (size_t i = 0; i < count; ++i) {
+                        resp[idx++] = (params[i] >> 8) & 0xFF;
+                        resp[idx++] = params[i] & 0xFF;
+                        resp[idx++] = (values[i] >> 8) & 0xFF;
+                        resp[idx++] = values[i] & 0xFF;
+                        LOGNOTE("  Param 0x%04X = 0x%04X", params[i], values[i]);
+                    }
+                    resp[idx++] = SYSEX_END;
+                    send_sysex_response(resp, idx, pDevice, nCable);
+                } else {
+                    LOGERR("SysEx: Failed to get all TG parameters for TG %u", tg);
+                }
+            }
+        }
+        return;
+    }
+    while (offset + 1 < len) {
+        uint16_t param = (pMessage[offset] << 8) | pMessage[offset+1];
+        offset += 2;
+        if (cmd == CMD_GET) {
+            uint16_t value = 0;
+            bool ok = false;
+            if (tg == 0xFF) {
+                ok = perf->GetGlobalParameters(&param, &value, 1);
+                LOGNOTE("SysEx: GET global param 0x%04X -> 0x%04X (%s)", param, value, ok ? "OK" : "FAIL");
+                // Build and send response
+                uint8_t resp[9] = {SYSEX_START, MANUFACTURER_ID, CMD_GET, (uint8_t)(param >> 8), (uint8_t)(param & 0xFF), (uint8_t)(value >> 8), (uint8_t)(value & 0xFF), SYSEX_END};
+                send_sysex_response(resp, 8, pDevice, nCable);
+            } else {
+                ok = perf->GetTGParameters(&param, &value, 1, tg);
+                LOGNOTE("SysEx: GET TG %u param 0x%04X -> 0x%04X (%s)", tg, param, value, ok ? "OK" : "FAIL");
+                uint8_t resp[10] = {SYSEX_START, MANUFACTURER_ID, tg, CMD_GET, (uint8_t)(param >> 8), (uint8_t)(param & 0xFF), (uint8_t)(value >> 8), (uint8_t)(value & 0xFF), SYSEX_END};
+                send_sysex_response(resp, 9, pDevice, nCable);
+            }
+        } else if (cmd == CMD_SET) {
+            if (offset + 1 >= len) {
+                LOGERR("SysEx: SET param 0x%04X missing value bytes", param);
+                break;
+            }
+            uint16_t value = (pMessage[offset] << 8) | pMessage[offset+1];
+            offset += 2;
+            bool ok = false;
+            if (tg == 0xFF) {
+                ok = perf->SetGlobalParameters(&param, &value, 1);
+                LOGNOTE("SysEx: SET global param 0x%04X = 0x%04X (%s)", param, value, ok ? "OK" : "FAIL");
+            } else {
+                ok = perf->SetTGParameters(&param, &value, 1, tg);
+                LOGNOTE("SysEx: SET TG %u param 0x%04X = 0x%04X (%s)", tg, param, value, ok ? "OK" : "FAIL");
+            }
+        }
+    }
+}
+
+/*
+Examples of MiniDexed Performance SysEx messages and expected handler behavior:
+
+1. Get a Global Parameter (e.g., CompressorEnable)
+  Send: F0 7D 10 00 00 F7
+  - Logs GET for global param 0x0000, queries value, logs result.
+
+2. Set a Global Parameter (e.g., ReverbEnable ON)
+  Send: F0 7D 20 00 01 00 01 F7
+  - Logs SET for global param 0x0001, updates value, logs result.
+
+3. Get All Global Parameters
+  Send: F0 7D 10 F7
+  - Logs and dumps all global parameters and values.
+
+4. Get a TG Parameter (e.g., Volume for TG 2)
+  Send: F0 7D 02 10 00 03 F7
+  - Logs GET for TG 2 param 0x0003, queries value, logs result.
+
+5. Set a TG Parameter (e.g., Pan for TG 1 to 64)
+  Send: F0 7D 01 20 00 04 00 40 F7
+  - Logs SET for TG 1 param 0x0004, updates value, logs result.
+
+6. Get All Parameters for TG 0
+  Send: F0 7D 00 10 F7
+  - Logs and dumps all TG 0 parameters and values.
+
+7. Malformed or Unknown Parameter
+  Send: F0 7D 10 12 34 F7
+  - Logs GET for global param 0x1234, logs FAIL if unsupported.
+
+*/

--- a/src/performance_sysex.cpp
+++ b/src/performance_sysex.cpp
@@ -25,19 +25,18 @@
 #include "minidexed.h"
 #include "mididevice.h"
 
-// Helper functions for 2's complement 14-bit MIDI-safe encoding/decoding
+// Helper functions for standard MIDI 14-bit signed value encoding/decoding (offset method)
 static void encode_midi14_signed_7bit(int value, uint8_t& msb, uint8_t& lsb) {
     // Clamp to 14-bit signed range
     if (value < -8192) value = -8192;
     if (value > 8191) value = 8191;
-    uint16_t midi14 = (value < 0) ? (0x2000 + value) : value;
-    midi14 &= 0x3FFF;
+    uint16_t midi14 = (uint16_t)(value + 8192); // MIDI standard: center is 8192
     msb = (midi14 >> 7) & 0x7F;
     lsb = midi14 & 0x7F;
 }
 static int decode_midi14_signed_7bit(uint8_t msb, uint8_t lsb) {
     uint16_t midi14 = ((msb & 0x7F) << 7) | (lsb & 0x7F);
-    return (midi14 & 0x2000) ? (midi14 - 0x4000) : midi14;
+    return (int)midi14 - 8192;
 }
 
 LOGMODULE ("PerformanceSysEx");

--- a/src/performance_sysex.h
+++ b/src/performance_sysex.h
@@ -1,0 +1,35 @@
+//
+// performance_sysex_handler.h
+//
+// MiniDexed - Dexed FM synthesizer for bare metal Raspberry Pi
+// Copyright (C) 2025  The MiniDexed Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef PERFORMANCE_SYSEX_H
+#define PERFORMANCE_SYSEX_H
+
+#include <cstdint>
+#include <cstddef>
+#include "performanceconfig.h"
+
+class CMIDIDevice;
+// Handles a MiniDexed performance SysEx message.
+// pMessage: pointer to the SysEx message (must be at least 2 bytes)
+// pDevice: the MIDI device to send the response to
+// perf: the performance config to operate on
+void handle_performance_sysex(const uint8_t* pMessage, CMIDIDevice* pDevice, CPerformanceConfig* perf, unsigned nCable = 0);
+
+#endif // PERFORMANCE_SYSEX_H

--- a/src/performance_sysex.h
+++ b/src/performance_sysex.h
@@ -29,7 +29,8 @@ class CMIDIDevice;
 // Handles a MiniDexed performance SysEx message.
 // pMessage: pointer to the SysEx message (must be at least 2 bytes)
 // pDevice: the MIDI device to send the response to
-// perf: the performance config to operate on
-void handle_performance_sysex(const uint8_t* pMessage, CMIDIDevice* pDevice, CPerformanceConfig* perf, unsigned nCable = 0);
+// miniDexed: pointer to the main synth instance (for applying changes)
+// Protocol: 0x10 = global, 0x11 = per-TG
+void handle_performance_sysex(const uint8_t* pMessage, CMIDIDevice* pDevice, class CMiniDexed* miniDexed, unsigned nCable = 0);
 
 #endif // PERFORMANCE_SYSEX_H

--- a/src/performanceconfig.cpp
+++ b/src/performanceconfig.cpp
@@ -1314,3 +1314,307 @@ bool CPerformanceConfig::IsValidPerformanceBank(unsigned nBankID)
 	}
 	return true;
 }
+
+// Static arrays for all parameter numbers
+static const uint16_t s_globalParams[] = {
+    CPerformanceConfig::PARAM_COMPRESSOR_ENABLE,
+    CPerformanceConfig::PARAM_REVERB_ENABLE,
+    CPerformanceConfig::PARAM_REVERB_SIZE,
+    CPerformanceConfig::PARAM_REVERB_HIGHDAMP,
+    CPerformanceConfig::PARAM_REVERB_LOWDAMP,
+    CPerformanceConfig::PARAM_REVERB_LOWPASS,
+    CPerformanceConfig::PARAM_REVERB_DIFFUSION,
+    CPerformanceConfig::PARAM_REVERB_LEVEL
+};
+static const uint16_t s_tgParams[] = {
+    CPerformanceConfig::PARAM_BANK_NUMBER,
+    CPerformanceConfig::PARAM_VOICE_NUMBER,
+    CPerformanceConfig::PARAM_MIDI_CHANNEL,
+    CPerformanceConfig::PARAM_VOLUME,
+    CPerformanceConfig::PARAM_PAN,
+    CPerformanceConfig::PARAM_DETUNE,
+    CPerformanceConfig::PARAM_CUTOFF,
+    CPerformanceConfig::PARAM_RESONANCE,
+    CPerformanceConfig::PARAM_NOTE_LIMIT_LOW,
+    CPerformanceConfig::PARAM_NOTE_LIMIT_HIGH,
+    CPerformanceConfig::PARAM_NOTE_SHIFT,
+    CPerformanceConfig::PARAM_REVERB_SEND,
+    CPerformanceConfig::PARAM_PITCH_BEND_RANGE,
+    CPerformanceConfig::PARAM_PITCH_BEND_STEP,
+    CPerformanceConfig::PARAM_PORTAMENTO_MODE,
+    CPerformanceConfig::PARAM_PORTAMENTO_GLISSANDO,
+    CPerformanceConfig::PARAM_PORTAMENTO_TIME,
+    CPerformanceConfig::PARAM_MONO_MODE,
+    CPerformanceConfig::PARAM_MODWHEEL_RANGE,
+    CPerformanceConfig::PARAM_MODWHEEL_TARGET,
+    CPerformanceConfig::PARAM_FOOTCTRL_RANGE,
+    CPerformanceConfig::PARAM_FOOTCTRL_TARGET,
+    CPerformanceConfig::PARAM_BREATHCTRL_RANGE,
+    CPerformanceConfig::PARAM_BREATHCTRL_TARGET,
+    CPerformanceConfig::PARAM_AFTERTOUCH_RANGE,
+    CPerformanceConfig::PARAM_AFTERTOUCH_TARGET
+};
+
+const uint16_t* CPerformanceConfig::GetAllGlobalParams(size_t& count) {
+    count = sizeof(s_globalParams) / sizeof(s_globalParams[0]);
+    return s_globalParams;
+}
+const uint16_t* CPerformanceConfig::GetAllTGParams(size_t& count) {
+    count = sizeof(s_tgParams) / sizeof(s_tgParams[0]);
+    return s_tgParams;
+}
+
+// Generic parameter access for SysEx (pp pp, vv vv scheme)
+bool CPerformanceConfig::GetGlobalParameters(const uint16_t *params, uint16_t *values, size_t count) const {
+	bool allOk = true;
+	for (size_t i = 0; i < count; ++i) {
+		switch (params[i]) {
+			case PARAM_COMPRESSOR_ENABLE:
+				values[i] = GetCompressorEnable() ? 1 : 0;
+				break;
+			case PARAM_REVERB_ENABLE:
+				values[i] = GetReverbEnable() ? 1 : 0;
+				break;
+			case PARAM_REVERB_SIZE:
+				values[i] = GetReverbSize();
+				break;
+			case PARAM_REVERB_HIGHDAMP:
+				values[i] = GetReverbHighDamp();
+				break;
+			case PARAM_REVERB_LOWDAMP:
+				values[i] = GetReverbLowDamp();
+				break;
+			case PARAM_REVERB_LOWPASS:
+				values[i] = GetReverbLowPass();
+				break;
+			case PARAM_REVERB_DIFFUSION:
+				values[i] = GetReverbDiffusion();
+				break;
+			case PARAM_REVERB_LEVEL:
+				values[i] = GetReverbLevel();
+				break;
+			default:
+				allOk = false;
+				break;
+		}
+	}
+	return allOk;
+}
+
+bool CPerformanceConfig::SetGlobalParameters(const uint16_t *params, const uint16_t *values, size_t count) {
+	bool allOk = true;
+	for (size_t i = 0; i < count; ++i) {
+		switch (params[i]) {
+			case PARAM_COMPRESSOR_ENABLE:
+				SetCompressorEnable(values[i] != 0);
+				break;
+			case PARAM_REVERB_ENABLE:
+				SetReverbEnable(values[i] != 0);
+				break;
+			case PARAM_REVERB_SIZE:
+				SetReverbSize(values[i]);
+				break;
+			case PARAM_REVERB_HIGHDAMP:
+				SetReverbHighDamp(values[i]);
+				break;
+			case PARAM_REVERB_LOWDAMP:
+				SetReverbLowDamp(values[i]);
+				break;
+			case PARAM_REVERB_LOWPASS:
+				SetReverbLowPass(values[i]);
+				break;
+			case PARAM_REVERB_DIFFUSION:
+				SetReverbDiffusion(values[i]);
+				break;
+			case PARAM_REVERB_LEVEL:
+				SetReverbLevel(values[i]);
+				break;
+			default:
+				allOk = false;
+				break;
+		}
+	}
+	return allOk;
+}
+
+bool CPerformanceConfig::GetTGParameters(const uint16_t *params, uint16_t *values, size_t count, unsigned tg) const {
+	if (tg >= CConfig::AllToneGenerators) return false;
+	bool allOk = true;
+	for (size_t i = 0; i < count; ++i) {
+		switch (params[i]) {
+			case PARAM_BANK_NUMBER:
+				values[i] = GetBankNumber(tg);
+				break;
+			case PARAM_VOICE_NUMBER:
+				values[i] = GetVoiceNumber(tg);
+				break;
+			case PARAM_MIDI_CHANNEL:
+				values[i] = GetMIDIChannel(tg);
+				break;
+			case PARAM_VOLUME:
+				values[i] = GetVolume(tg);
+				break;
+			case PARAM_PAN:
+				values[i] = GetPan(tg);
+				break;
+			case PARAM_DETUNE:
+				values[i] = static_cast<uint16_t>(GetDetune(tg));
+				break;
+			case PARAM_CUTOFF:
+				values[i] = GetCutoff(tg);
+				break;
+			case PARAM_RESONANCE:
+				values[i] = GetResonance(tg);
+				break;
+			case PARAM_NOTE_LIMIT_LOW:
+				values[i] = GetNoteLimitLow(tg);
+				break;
+			case PARAM_NOTE_LIMIT_HIGH:
+				values[i] = GetNoteLimitHigh(tg);
+				break;
+			case PARAM_NOTE_SHIFT:
+				values[i] = static_cast<uint16_t>(GetNoteShift(tg));
+				break;
+			case PARAM_REVERB_SEND:
+				values[i] = GetReverbSend(tg);
+				break;
+			case PARAM_PITCH_BEND_RANGE:
+				values[i] = GetPitchBendRange(tg);
+				break;
+			case PARAM_PITCH_BEND_STEP:
+				values[i] = GetPitchBendStep(tg);
+				break;
+			case PARAM_PORTAMENTO_MODE:
+				values[i] = GetPortamentoMode(tg);
+				break;
+			case PARAM_PORTAMENTO_GLISSANDO:
+				values[i] = GetPortamentoGlissando(tg);
+				break;
+			case PARAM_PORTAMENTO_TIME:
+				values[i] = GetPortamentoTime(tg);
+				break;
+			case PARAM_MONO_MODE:
+				values[i] = GetMonoMode(tg) ? 1 : 0;
+				break;
+			case PARAM_MODWHEEL_RANGE:
+				values[i] = GetModulationWheelRange(tg);
+				break;
+			case PARAM_MODWHEEL_TARGET:
+				values[i] = GetModulationWheelTarget(tg);
+				break;
+			case PARAM_FOOTCTRL_RANGE:
+				values[i] = GetFootControlRange(tg);
+				break;
+			case PARAM_FOOTCTRL_TARGET:
+				values[i] = GetFootControlTarget(tg);
+				break;
+			case PARAM_BREATHCTRL_RANGE:
+				values[i] = GetBreathControlRange(tg);
+				break;
+			case PARAM_BREATHCTRL_TARGET:
+				values[i] = GetBreathControlTarget(tg);
+				break;
+			case PARAM_AFTERTOUCH_RANGE:
+				values[i] = GetAftertouchRange(tg);
+				break;
+			case PARAM_AFTERTOUCH_TARGET:
+				values[i] = GetAftertouchTarget(tg);
+				break;
+			default:
+				allOk = false;
+				break;
+		}
+	}
+	return allOk;
+}
+
+bool CPerformanceConfig::SetTGParameters(const uint16_t *params, const uint16_t *values, size_t count, unsigned tg) {
+	if (tg >= CConfig::AllToneGenerators) return false;
+	bool allOk = true;
+	for (size_t i = 0; i < count; ++i) {
+		switch (params[i]) {
+			case PARAM_BANK_NUMBER:
+				SetBankNumber(values[i], tg);
+				break;
+			case PARAM_VOICE_NUMBER:
+				SetVoiceNumber(values[i], tg);
+				break;
+			case PARAM_MIDI_CHANNEL:
+				SetMIDIChannel(values[i], tg);
+				break;
+			case PARAM_VOLUME:
+				SetVolume(values[i], tg);
+				break;
+			case PARAM_PAN:
+				SetPan(values[i], tg);
+				break;
+			case PARAM_DETUNE:
+				SetDetune(static_cast<int16_t>(values[i]), tg);
+				break;
+			case PARAM_CUTOFF:
+				SetCutoff(values[i], tg);
+				break;
+			case PARAM_RESONANCE:
+				SetResonance(values[i], tg);
+				break;
+			case PARAM_NOTE_LIMIT_LOW:
+				SetNoteLimitLow(values[i], tg);
+				break;
+			case PARAM_NOTE_LIMIT_HIGH:
+				SetNoteLimitHigh(values[i], tg);
+				break;
+			case PARAM_NOTE_SHIFT:
+				SetNoteShift(static_cast<int16_t>(values[i]), tg);
+				break;
+			case PARAM_REVERB_SEND:
+				SetReverbSend(values[i], tg);
+				break;
+			case PARAM_PITCH_BEND_RANGE:
+				SetPitchBendRange(values[i], tg);
+				break;
+			case PARAM_PITCH_BEND_STEP:
+				SetPitchBendStep(values[i], tg);
+				break;
+			case PARAM_PORTAMENTO_MODE:
+				SetPortamentoMode(values[i], tg);
+				break;
+			case PARAM_PORTAMENTO_GLISSANDO:
+				SetPortamentoGlissando(values[i], tg);
+				break;
+			case PARAM_PORTAMENTO_TIME:
+				SetPortamentoTime(values[i], tg);
+				break;
+			case PARAM_MONO_MODE:
+				SetMonoMode(values[i] != 0, tg);
+				break;
+			case PARAM_MODWHEEL_RANGE:
+				SetModulationWheelRange(values[i], tg);
+				break;
+			case PARAM_MODWHEEL_TARGET:
+				SetModulationWheelTarget(values[i], tg);
+				break;
+			case PARAM_FOOTCTRL_RANGE:
+				SetFootControlRange(values[i], tg);
+				break;
+			case PARAM_FOOTCTRL_TARGET:
+				SetFootControlTarget(values[i], tg);
+				break;
+			case PARAM_BREATHCTRL_RANGE:
+				SetBreathControlRange(values[i], tg);
+				break;
+			case PARAM_BREATHCTRL_TARGET:
+				SetBreathControlTarget(values[i], tg);
+				break;
+			case PARAM_AFTERTOUCH_RANGE:
+				SetAftertouchRange(values[i], tg);
+				break;
+			case PARAM_AFTERTOUCH_TARGET:
+				SetAftertouchTarget(values[i], tg);
+				break;
+			default:
+				allOk = false;
+				break;
+		}
+	}
+	return allOk;
+}

--- a/src/performanceconfig.cpp
+++ b/src/performanceconfig.cpp
@@ -830,6 +830,26 @@ std::string CPerformanceConfig::GetPerformanceName(unsigned nID)
 	}
 }
 
+std::string CPerformanceConfig::GetPerformanceDisplayName(unsigned nID, unsigned maxLength)
+{
+	std::string fullName = GetPerformanceName(nID);
+	if (fullName.length() > maxLength && maxLength > 3)
+	{
+		return fullName.substr(0, maxLength - 3) + "...";
+	}
+	return fullName;
+}
+
+std::string CPerformanceConfig::GetPerformanceBankDisplayName(unsigned nBankID, unsigned maxLength)
+{
+	std::string fullName = GetPerformanceBankName(nBankID);
+	if (fullName.length() > maxLength && maxLength > 3)
+	{
+		return fullName.substr(0, maxLength - 3) + "...";
+	}
+	return fullName;
+}
+
 unsigned CPerformanceConfig::GetLastPerformance()
 {
 	return m_nLastPerformance;
@@ -938,7 +958,7 @@ bool CPerformanceConfig::CreateNewPerformanceFile(void)
 	}		
 	else
 	{
-		nFileName +=sPerformanceName.substr(0,14);
+		nFileName += sPerformanceName;
 	}
 	nFileName += ".ini";
 	m_PerformanceFileName[nNewPerformance]= sPerformanceName;
@@ -965,7 +985,7 @@ bool CPerformanceConfig::CreateNewPerformanceFile(void)
 	
 	m_nLastPerformance = nNewPerformance;
 	m_nActualPerformance = nNewPerformance;
-	new (&m_Properties) CPropertiesFatFsFile(nFileName.c_str(), m_pFileSystem);
+	m_Properties = CPropertiesFatFsFile(nFileName.c_str(), m_pFileSystem);
 	
 	return true;
 }
@@ -1007,7 +1027,7 @@ bool CPerformanceConfig::ListPerformances()
 			{
 				std::string OriFileName = FileInfo.fname;
 				size_t nLen = OriFileName.length();
-				if (   nLen > 8 && nLen <26	 && strcmp(OriFileName.substr(6,1).c_str(), "_")==0)
+				if (   nLen > 8 && nLen < 255 && strcmp(OriFileName.substr(6,1).c_str(), "_")==0)
 				{
 					// Note: m_nLastPerformance - refers to the number (index) of the last performance in memory,
 					//       which includes a default performance.
@@ -1033,12 +1053,12 @@ bool CPerformanceConfig::ListPerformances()
 						nPIndex = nPIndex-1;
 						if (m_PerformanceFileName[nPIndex].empty())
 						{
-							if(nPIndex > m_nLastPerformance)
+							if (nPIndex > m_nLastPerformance)
 							{
 								m_nLastPerformance=nPIndex;
 							}
 
-							std::string FileName = OriFileName.substr(0,OriFileName.length()-4).substr(7,14);
+						    std::string FileName = OriFileName.substr(0,OriFileName.length()-4).substr(7);
 
 							m_PerformanceFileName[nPIndex] = FileName;
 #ifdef VERBOSE_DEBUG
@@ -1067,7 +1087,7 @@ void CPerformanceConfig::SetNewPerformance (unsigned nID)
 	m_nActualPerformance=nID;
 	std::string FileN = GetPerformanceFullFilePath(nID);
 
-	new (&m_Properties) CPropertiesFatFsFile(FileN.c_str(), m_pFileSystem);
+	m_Properties = CPropertiesFatFsFile(FileN.c_str(), m_pFileSystem);
 #ifdef VERBOSE_DEBUG
 	LOGNOTE("Selecting Performance: %d (%s)", nID+1, FileN.c_str());
 #endif
@@ -1183,7 +1203,7 @@ bool CPerformanceConfig::ListPerformanceBanks()
 			//
 			std::string OriFileName = FileInfo.fname;
 			size_t nLen = OriFileName.length();
-			if (   nLen > 4 && nLen <26	 && strcmp(OriFileName.substr(3,1).c_str(), "_")==0)
+			if (   nLen > 4 && nLen < 255 && strcmp(OriFileName.substr(3,1).c_str(), "_")==0)
 			{
 				unsigned nBankIndex = stoi(OriFileName.substr(0,3));
 				// Recall user index numbered 002..NUM_PERFORMANCE_BANKS
@@ -1194,7 +1214,7 @@ bool CPerformanceConfig::ListPerformanceBanks()
 					nBankIndex = nBankIndex-1;
 					if (m_PerformanceBankName[nBankIndex].empty())
 					{
-						std::string BankName = OriFileName.substr(4,nLen);
+						std::string BankName = OriFileName.substr(4);
 
 						m_PerformanceBankName[nBankIndex] = BankName;
 #ifdef VERBOSE_DEBUG

--- a/src/performanceconfig.h
+++ b/src/performanceconfig.h
@@ -169,6 +169,8 @@ public:
 	std::string GetPerformanceFileName(unsigned nID);
 	std::string GetPerformanceFullFilePath(unsigned nID);
 	std::string GetPerformanceName(unsigned nID);
+	std::string GetPerformanceDisplayName(unsigned nID, unsigned maxLength = 14);
+	std::string GetPerformanceBankDisplayName(unsigned nBankID, unsigned maxLength = 20);
 	unsigned GetLastPerformance();
 	unsigned GetLastPerformanceBank();
 	void SetActualPerformanceID(unsigned nID);

--- a/src/performanceconfig.h
+++ b/src/performanceconfig.h
@@ -33,6 +33,47 @@
 class CPerformanceConfig	// Performance configuration
 {
 public:
+	// Parameter numbers for SysEx (MiniDexed Format)
+	enum ParameterNumber {
+		// Global parameters (pp pp)
+		PARAM_COMPRESSOR_ENABLE    = 0x0000,
+		PARAM_REVERB_ENABLE        = 0x0001,
+		PARAM_REVERB_SIZE          = 0x0002,
+		PARAM_REVERB_HIGHDAMP      = 0x0003,
+		PARAM_REVERB_LOWDAMP       = 0x0004,
+		PARAM_REVERB_LOWPASS       = 0x0005,
+		PARAM_REVERB_DIFFUSION     = 0x0006,
+		PARAM_REVERB_LEVEL         = 0x0007,
+
+		// TG-specific parameters (pp pp)
+		PARAM_BANK_NUMBER          = 0x0000,
+		PARAM_VOICE_NUMBER         = 0x0001,
+		PARAM_MIDI_CHANNEL         = 0x0002,
+		PARAM_VOLUME               = 0x0003,
+		PARAM_PAN                  = 0x0004,
+		PARAM_DETUNE               = 0x0005,
+		PARAM_CUTOFF               = 0x0006,
+		PARAM_RESONANCE            = 0x0007,
+		PARAM_NOTE_LIMIT_LOW       = 0x0008,
+		PARAM_NOTE_LIMIT_HIGH      = 0x0009,
+		PARAM_NOTE_SHIFT           = 0x000A,
+		PARAM_REVERB_SEND          = 0x000B,
+		PARAM_PITCH_BEND_RANGE     = 0x000C,
+		PARAM_PITCH_BEND_STEP      = 0x000D,
+		PARAM_PORTAMENTO_MODE      = 0x000E,
+		PARAM_PORTAMENTO_GLISSANDO = 0x000F,
+		PARAM_PORTAMENTO_TIME      = 0x0010,
+		PARAM_MONO_MODE            = 0x0011,
+		PARAM_MODWHEEL_RANGE       = 0x0012,
+		PARAM_MODWHEEL_TARGET      = 0x0013,
+		PARAM_FOOTCTRL_RANGE       = 0x0014,
+		PARAM_FOOTCTRL_TARGET      = 0x0015,
+		PARAM_BREATHCTRL_RANGE     = 0x0016,
+		PARAM_BREATHCTRL_TARGET    = 0x0017,
+		PARAM_AFTERTOUCH_RANGE     = 0x0018,
+		PARAM_AFTERTOUCH_TARGET    = 0x0019
+	};
+
 	CPerformanceConfig (FATFS *pFileSystem);
 	~CPerformanceConfig (void);
 	
@@ -148,6 +189,14 @@ public:
 	unsigned GetPerformanceBank(void);
 	std::string GetPerformanceBankName(unsigned nBankID);
 	bool IsValidPerformanceBank(unsigned nBankID);
+
+	bool GetGlobalParameters(const uint16_t *params, uint16_t *values, size_t count) const;
+	bool SetGlobalParameters(const uint16_t *params, const uint16_t *values, size_t count);
+	bool GetTGParameters(const uint16_t *params, uint16_t *values, size_t count, unsigned tg) const;
+	bool SetTGParameters(const uint16_t *params, const uint16_t *values, size_t count, unsigned tg);
+
+	static const uint16_t* GetAllGlobalParams(size_t& count);
+	static const uint16_t* GetAllTGParams(size_t& count);
 
 private:
 	CPropertiesFatFsFile m_Properties;

--- a/src/serialmididevice.cpp
+++ b/src/serialmididevice.cpp
@@ -75,30 +75,24 @@ void CSerialMIDIDevice::Process (void)
 		return;
 	}
 
-/*        if (m_pConfig->GetMIDIDumpEnabled ())
-	{
-		printf("Incoming MIDI data:");
-		for (uint16_t i = 0; i < nResult; i++)
-		{
-			if((i % 8) == 0)
-				printf("\n%04d:",i);
-			printf(" 0x%02x",Buffer[i]);
-		}
-		printf("\n");
-	}*/
-
-	// Process MIDI messages
-	// See: https://www.midi.org/specifications/item/table-1-summary-of-midi-message
-	// "Running status" see: https://www.lim.di.unimi.it/IEEE/MIDI/SOT5.HTM#Running-	
-	
 	for (int i = 0; i < nResult; i++)
 	{
 		u8 uchData = Buffer[i];
 
-		if(uchData == 0xF0)
-		{
-			// SYSEX found
-			m_SerialMessage[m_nSysEx++]=uchData;
+		// SysEx reassembly logic
+		if (uchData == 0xF0 && !m_SysExActive) {
+			m_SysExActive = true;
+			m_SysExLen = 0;
+		}
+		if (m_SysExActive) {
+			if (m_SysExLen < MAX_MIDI_MESSAGE) {
+				m_SysExBuffer[m_SysExLen++] = uchData;
+			}
+			if (uchData == 0xF7 || m_SysExLen >= MAX_MIDI_MESSAGE) {
+				MIDIMessageHandler(m_SysExBuffer, m_SysExLen, 0);
+				m_SysExActive = false;
+				m_SysExLen = 0;
+			}
 			continue;
 		}
 

--- a/src/serialmididevice.h
+++ b/src/serialmididevice.h
@@ -53,6 +53,11 @@ private:
 	u8 m_SerialMessage[MAX_MIDI_MESSAGE];
 
 	CWriteBufferDevice m_SendBuffer;
+
+	// SysEx reassembly buffer for serial MIDI
+	uint8_t m_SysExBuffer[MAX_MIDI_MESSAGE];
+	size_t m_SysExLen = 0;
+	bool m_SysExActive = false;
 };
 
 #endif

--- a/src/udpmididevice.cpp
+++ b/src/udpmididevice.cpp
@@ -76,6 +76,35 @@ boolean CUDPMIDIDevice::Initialize (void)
 	return true;
 }
 
+void CUDPMIDIDevice::UdpMidiReassembly(uint8_t byte, unsigned cable) {
+    // System Real Time messages (single byte)
+    if (byte == 0xF8 || byte == 0xFA || byte == 0xFB || byte == 0xFC || byte == 0xFE || byte == 0xFF) {
+        MIDIMessageHandler(&byte, 1, cable);
+        return;
+    }
+    // Status byte
+    if ((byte & 0x80) == 0x80 && (byte & 0xF0) != 0xF0) {
+        m_udpMidiMsg[0] = byte;
+        m_udpMidiState = 1;
+        return;
+    }
+    // Data byte
+    if (m_udpMidiState > 0) {
+        m_udpMidiMsg[m_udpMidiState++] = byte;
+        if ((m_udpMidiMsg[0] & 0xE0) == 0xC0 || (m_udpMidiMsg[0] & 0xF0) == 0xD0) {
+            // Program Change or Channel Pressure (2 bytes)
+            if (m_udpMidiState == 2) {
+                MIDIMessageHandler(m_udpMidiMsg, 2, cable);
+                m_udpMidiState = 0;
+            }
+        } else if (m_udpMidiState == 3) {
+            // All other channel messages (3 bytes)
+            MIDIMessageHandler(m_udpMidiMsg, 3, cable);
+            m_udpMidiState = 0;
+        }
+    }
+}
+
 // Methods to handle MIDI events
 
 void CUDPMIDIDevice::OnAppleMIDIDataReceived(const u8* pData, size_t nSize)
@@ -87,17 +116,22 @@ void CUDPMIDIDevice::OnAppleMIDIDataReceived(const u8* pData, size_t nSize)
 			m_SysExLen = 0;
 		}
 		if (m_SysExActive) {
-			if (m_SysExLen < MAX_MIDI_MESSAGE) {
-				m_SysExBuffer[m_SysExLen++] = byte;
-			}
-			if (byte == 0xF7 || m_SysExLen >= MAX_MIDI_MESSAGE) {
-				MIDIMessageHandler(m_SysExBuffer, m_SysExLen, VIRTUALCABLE);
+			if ((byte & 0x80) && byte != 0xF0 && byte != 0xF7) {
 				m_SysExActive = false;
 				m_SysExLen = 0;
+			} else {
+				if (m_SysExLen < MAX_MIDI_MESSAGE) {
+					m_SysExBuffer[m_SysExLen++] = byte;
+				}
+				if (byte == 0xF7 || m_SysExLen >= MAX_MIDI_MESSAGE) {
+					MIDIMessageHandler(m_SysExBuffer, m_SysExLen, VIRTUALCABLE);
+					m_SysExActive = false;
+					m_SysExLen = 0;
+				}
+				if (m_SysExActive) continue;
 			}
-			continue;
 		}
-		MIDIMessageHandler(&byte, 1, VIRTUALCABLE);
+		UdpMidiReassembly(byte, VIRTUALCABLE);
 	}
 }
 
@@ -120,17 +154,22 @@ void CUDPMIDIDevice::OnUDPMIDIDataReceived(const u8* pData, size_t nSize)
 			m_SysExLen = 0;
 		}
 		if (m_SysExActive) {
-			if (m_SysExLen < MAX_MIDI_MESSAGE) {
-				m_SysExBuffer[m_SysExLen++] = byte;
-			}
-			if (byte == 0xF7 || m_SysExLen >= MAX_MIDI_MESSAGE) {
-				MIDIMessageHandler(m_SysExBuffer, m_SysExLen, VIRTUALCABLE);
+			if ((byte & 0x80) && byte != 0xF0 && byte != 0xF7) {
 				m_SysExActive = false;
 				m_SysExLen = 0;
+			} else {
+				if (m_SysExLen < MAX_MIDI_MESSAGE) {
+					m_SysExBuffer[m_SysExLen++] = byte;
+				}
+				if (byte == 0xF7 || m_SysExLen >= MAX_MIDI_MESSAGE) {
+					MIDIMessageHandler(m_SysExBuffer, m_SysExLen, VIRTUALCABLE);
+					m_SysExActive = false;
+					m_SysExLen = 0;
+				}
+				if (m_SysExActive) continue;
 			}
-			continue;
 		}
-		MIDIMessageHandler(&byte, 1, VIRTUALCABLE);
+		UdpMidiReassembly(byte, VIRTUALCABLE);
 	}
 }
 

--- a/src/udpmididevice.h
+++ b/src/udpmididevice.h
@@ -62,6 +62,10 @@ private:
 	uint8_t m_SysExBuffer[MAX_MIDI_MESSAGE];
 	size_t m_SysExLen = 0;
 	bool m_SysExActive = false;
+
+	void UdpMidiReassembly(uint8_t byte, unsigned cable);
+	uint8_t m_udpMidiMsg[4] = {0};
+	uint8_t m_udpMidiState = 0;
 };
 
 #endif

--- a/src/udpmididevice.h
+++ b/src/udpmididevice.h
@@ -57,6 +57,11 @@ private:
 	unsigned m_UDPDestPort = 1999;
 	CIPAddress m_LastUDPSenderAddress;
 	unsigned m_LastUDPSenderPort = 0;
+
+	// SysEx reassembly buffer for UDP/AppleMIDI
+	uint8_t m_SysExBuffer[MAX_MIDI_MESSAGE];
+	size_t m_SysExLen = 0;
+	bool m_SysExActive = false;
 };
 
 #endif

--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -1614,7 +1614,7 @@ void CUIMenu::PerformanceMenu (CUIMenu *pUIMenu, TMenuEvent Event)
 			break;
 
 		case MenuEventStepUp:
-			do
+							do
 			{
 				if (nValue == nLastPerformance)
 				{
@@ -1821,7 +1821,7 @@ void CUIMenu::InputTxt (CUIMenu *pUIMenu, TMenuEvent Event)
 	{
 		case 1: // save new performance
 			NoValidChars = {92, 47, 58, 42, 63, 34, 60,62, 124};
-			MaxChars=14;
+			MaxChars=64;  // Support longer performance names
 			MenuTitleL="Performance Name";
 			MenuTitleR="";
 			OkTitleL="New Performance"; // \E[?25l
@@ -1830,7 +1830,7 @@ void CUIMenu::InputTxt (CUIMenu *pUIMenu, TMenuEvent Event)
 		 
 		case 2: // Rename performance - NOT Implemented yet
 			NoValidChars = {92, 47, 58, 42, 63, 34, 60,62, 124};
-			MaxChars=14;
+			MaxChars=64;  // Support longer performance names
 			MenuTitleL="Performance Name";
 			MenuTitleR="";
 			OkTitleL="Rename Perf."; // \E[?25l
@@ -1863,8 +1863,9 @@ void CUIMenu::InputTxt (CUIMenu *pUIMenu, TMenuEvent Event)
 		if(pUIMenu->m_nCurrentParameter == 1 || pUIMenu->m_nCurrentParameter == 2)
 		{
 			pUIMenu->m_InputText = pUIMenu->m_pMiniDexed->GetNewPerformanceDefaultName();
-			pUIMenu->m_InputText += "              ";
-			pUIMenu->m_InputText =  pUIMenu->m_InputText.substr(0,14);
+			// Pad to MaxChars instead of hardcoded 14
+			pUIMenu->m_InputText += std::string(MaxChars, ' ');
+			pUIMenu->m_InputText =  pUIMenu->m_InputText.substr(0, MaxChars);
 			pUIMenu->m_InputTextPosition=0;
 			nPosition=pUIMenu->m_InputTextPosition;
 			nChar = pUIMenu->m_InputText[nPosition];


### PR DESCRIPTION
So far, MiniDexed Performances were not entirely editable via MIDI commands.

To change this, and to allow for interactive ways to change the performance parameters in user interfaces like this, we need MIDI commands.

![image](https://github.com/user-attachments/assets/8539b4ec-8c6a-4ebd-82f7-9b1155157238)

### Proposed MiniDexed Performance SysEx Message Format (still subject to change)

````
F0 7D XX pp pp vv vv F7
````

Where:

* `F0` and `F7` are the start and end of the SysEx message.
* `7D` is the Manufacturer ID reserved for prototyping, test, private use and experimentation.
* `XX`
    * `10` is the **get** (dump) command ID for MiniDexed **global** performance parameter request.
    * `11` is the **get** (dump) command ID for **per-TG** performance parameter request.
    * `20` is the **set** (write) command ID for MiniDexed **global** performance parameter change.
    * `21` is the **set** (write) command ID for **per-TG** performance parameter change.
* `pp` is the parameter number.
* `vv vv` is the parameter value (or empty if requesting a dump).
* The sequence `pp pp vv vv` may be repeated as often as needed if more than one parameter shall be set.

To request a dump of the corresponding value, leave the `vv vv` away.

To request a dump of all global parameters:

````
F0 7D 10 F7
````

The response to this **get** request will be in the format:

````
F0 7D 20 pp pp vv vv pp pp vv vv F7
````

To request a dump of all parameters of TG `nn`:

````
F0 7D 11 nn F7
````

The response to this **get** request will be in the format:

````
F0 7D 21 nn pp pp vv vv pp pp vv vv F7
````

### Table 1: Global Parameters (Non-Tone Generator-Specific)

| Parameter        | SysEx Command (MiniDexed Format)                            | Allowed Values (`vv vv`)      |
| ---------------- | ----------------------------------------------------------- | ----------------------------- |
| CompressorEnable | `F0 7D 10 00 00 F7` (get) / `F0 7D 20 00 00 vv vv F7` (set) | `00 00` (off) .. `00 01` (on) |                       
| ReverbEnable     | `F0 7D 10 00 01 F7` (get) / `F0 7D 20 00 01 vv vv F7` (set) | `00 00` (off) .. `00 01` (on) |                       
| ReverbSize       | `F0 7D 10 00 02 F7` (get) / `F0 7D 20 00 02 vv vv F7` (set) | `00 00` (0) .. `00 63` (99)   |                       
| ReverbHighDamp   | `F0 7D 10 00 03 F7` (get) / `F0 7D 20 00 03 vv vv F7` (set) | `00 00` (0) .. `00 63` (99)   |                       
| ReverbLowDamp    | `F0 7D 10 00 04 F7` (get) / `F0 7D 20 00 04 vv vv F7` (set) | `00 00` (0) .. `00 63` (99)   |                       
| ReverbLowPass    | `F0 7D 10 00 05 F7` (get) / `F0 7D 20 00 05 vv vv F7` (set) | `00 00` (0) .. `00 63` (99)   |                       
| ReverbDiffusion  | `F0 7D 10 00 06 F7` (get) / `F0 7D 20 00 06 vv vv F7` (set) | `00 00` (0) .. `00 63` (99)   |                       
| ReverbLevel      | `F0 7D 10 00 07 F7` (get) / `F0 7D 20 00 07 vv vv F7` (set) | `00 00` (0) .. `00 63` (99)   |                       
---

### Table 2: Tone Generator-Specific Parameters

| Parameter           | SysEx Command (MiniDexed Format)                                     | Allowed Values (`vv vv`)            |
| -------------------| -------------------------------------------------------------------- | -------------------------------------|
| BankNumber          | `F0 7D 11 nn 00 00 F7` / `F0 7D 21 nn 00 00 vv vv F7`                | `00 00` (0) .. `00 7F` (127)                               |
| VoiceNumber         | `F0 7D 11 nn 00 01 F7` / `F0 7D 21 nn 00 01 vv vv F7`                | `00 00` (0) .. `00 1F` (31)                                |
| MIDIChannel         | `F0 7D 11 nn 00 02 F7` / `F0 7D 21 nn 00 02 vv vv F7`                | `00 00` (0) .. `00 0F` (15), `00 10` (omni), `00 11` (off) |
| Volume              | `F0 7D 11 nn 00 03 F7` / `F0 7D 21 nn 00 03 vv vv F7`                | `00 00` (0) .. `00 7F` (127)                               |
| Pan                 | `F0 7D 11 nn 00 04 F7` / `F0 7D 21 nn 00 04 vv vv F7`                | `00 00` (0) .. `00 7F` (127)                               |
| Detune              | `F0 7D 11 nn 00 05 F7` / `F0 7D 21 nn 00 05 vv vv F7`                | `3F 1D` (-99) .. `00 63` (99) **7-bit note**  |
| Cutoff              | `F0 7D 11 nn 00 06 F7` / `F0 7D 21 nn 00 06 vv vv F7`                | `00 00` (0) .. `00 63` (99)                                |
| Resonance           | `F0 7D 11 nn 00 07 F7` / `F0 7D 21 nn 00 07 vv vv F7`                | `00 00` (0) .. `00 63` (99)                                |
| NoteLimitLow        | `F0 7D 11 nn 00 08 F7` / `F0 7D 21 nn 00 08 vv vv F7`                | `00 00` (0) .. `00 7F` (127)                               |
| NoteLimitHigh       | `F0 7D 11 nn 00 09 F7` / `F0 7D 21 nn 00 09 vv vv F7`                | `00 00` (0) .. `00 7F` (127)                               |
| NoteShift           | `F0 7D 11 nn 00 0A F7` / `F0 7D 21 nn 00 0A vv vv F7`                | `3F 38` (-24) .. `00 18` (24) **7-bit note**   |
| ReverbSend          | `F0 7D 11 nn 00 0B F7` / `F0 7D 21 nn 00 0B vv vv F7`                | `00 00` (0) .. `00 7F` (127)                               |
| PitchBendRange      | `F0 7D 11 nn 00 0C F7` / `F0 7D 21 nn 00 0C vv vv F7`                | `00 00` (0) .. `00 0C` (12)                                |
| PitchBendStep       | `F0 7D 11 nn 00 0D F7` / `F0 7D 21 nn 00 0D vv vv F7`                | `00 00` (0) .. `00 0C` (12)                                |
| PortamentoMode      | `F0 7D 11 nn 00 0E F7` / `F0 7D 21 nn 00 0E vv vv F7`                | `00 00` (off) .. `00 01` (on)                              |
| PortamentoGlissando | `F0 7D 11 nn 00 0F F7` / `F0 7D 21 nn 00 0F vv vv F7`                | `00 00` (off) .. `00 01` (on)                              |
| PortamentoTime      | `F0 7D 11 nn 00 10 F7` / `F0 7D 21 nn 00 10 vv vv F7`                | `00 00` (0) .. `00 63` (99)                                |
| MonoMode            | `F0 7D 11 nn 00 11 F7` / `F0 7D 21 nn 00 11 vv vv F7`                | `00 00` (off) .. `00 01` (on)                              |
| ModWheelRange       | `F0 7D 11 nn 00 12 F7` / `F0 7D 21 nn 00 12 vv vv F7`                | `00 00` (0) .. `00 63` (99)                                |
| ModWheelTarget      | `F0 7D 11 nn 00 13 F7` / `F0 7D 21 nn 00 13 vv vv F7`                | `00 00` .. `00 07`                                         |
| FootCtrlRange       | `F0 7D 11 nn 00 14 F7` / `F0 7D 21 nn 00 14 vv vv F7`                | `00 00` (0) .. `00 63` (99)                                |
| FootCtrlTarget      | `F0 7D 11 nn 00 15 F7` / `F0 7D 21 nn 00 15 vv vv F7`                | `00 00` .. `00 07`                                         |
| BreathCtrlRange     | `F0 7D 11 nn 00 16 F7` / `F0 7D 21 nn 00 16 vv vv F7`                | `00 00` (0) .. `00 63` (99)                                |
| BreathCtrlTarget    | `F0 7D 11 nn 00 17 F7` / `F0 7D 21 nn 00 17 vv vv F7`                | `00 00` .. `00 07`                                         |
| AftertouchRange     | `F0 7D 11 nn 00 18 F7` / `F0 7D 21 nn 00 18 vv vv F7`                | `00 00` (0) .. `00 63` (99)                                |
| AftertouchTarget    | `F0 7D 11 nn 00 19 F7` / `F0 7D 21 nn 00 19 vv vv F7`                | `00 00` .. `00 07`                                         |


### Notes:

* For **get** (dump) requests: Leave the `vv vv` field empty. For example, to get the `CompressorEnable` status:

  ````
  F0 7D 10 00 00 F7
  ````

  The system will respond with:

  ````
  F0 7D 20 00 00 00 01 F7
  ````

  indicating the value is `00 01` (on).

* For **set** (write) requests: Include the `vv vv` field to specify the value. For example, to set the `CompressorEnable` to `on`:

  ````
  F0 7D 20 00 00 00 01 F7
  ````

  This writes the value `00 01` (on) to the `CompressorEnable` parameter.

* **7-bit note**: For signed values (Detune, NoteShift), use 2's complement (2 bytes across two 7-bit bytes), split into two MIDI-safe 7-bit bytes:

  * Detune: `3F 1D` (-99) .. `00 63` (99)
  * NoteShift: `3F 38` (-24) .. `00 18` (24)

* For boolean values, `00 00` = off/false, `00 01` = on/true.

* For MIDI Channel: `00 00` (0) .. `00 0F` (15), `00 10` (omni), `00 11` (off).

* `nn` in the SysEx command is the Tone Generator (TG) number, not the MIDI channel.

* For unknown or unsupported parameter numbers, or malformed SysEx messages, the system should simply ignore the message and take no action.
