### PR TITLE
MIDI CC 07 (Volume) on PCCH sets Master Volume

### DIFF
--- a/src/mididevice.cpp
+++ b/src/mididevice.cpp
@@ -284,7 +284,7 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 						float fMasterVolume = (float)pMessage[2] / 127.0f;
 						m_pSynthesizer->setMasterVolume(fMasterVolume);
 						LOGNOTE("MIDI CC07 (Volume) on PCCH: Set Master Volume to %d (%.3f)", pMessage[2], fMasterVolume);
-						break; // Do not process further for TGs
+						return; // Do not process further for TGs
 					}
 					else
 					{

--- a/src/mididevice.cpp
+++ b/src/mididevice.cpp
@@ -279,12 +279,12 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 					{
 						m_pSynthesizer->BankSelectLSBPerformance (pMessage[2]);
 					}
-					else if (pMessage[1] == MIDI_CC_VOLUME) // CC 07 on PCCH: Master Volume
+					else if (pMessage[1] == MIDI_CC_VOLUME && nLength == 3) // CC 07 on PCCH: Master Volume
 					{
-						float fMasterVolume = (float)pMessage[2] / 127.0f;
-						m_pSynthesizer->setMasterVolume(fMasterVolume);
-						LOGNOTE("MIDI CC07 (Volume) on PCCH: Set Master Volume to %d (%.3f)", pMessage[2], fMasterVolume);
-						return; // Do not process further for TGs
+							float fMasterVolume = (float)pMessage[2] / 127.0f;
+							m_pSynthesizer->setMasterVolume(fMasterVolume);
+							LOGNOTE("MIDI CC07 (Volume) on PCCH: Set Master Volume to %d (%.3f)", pMessage[2], fMasterVolume);
+							return; // Do not process further for TGs
 					}
 					else
 					{

--- a/src/mididevice.cpp
+++ b/src/mididevice.cpp
@@ -279,10 +279,18 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 					{
 						m_pSynthesizer->BankSelectLSBPerformance (pMessage[2]);
 					}
+					else if (pMessage[1] == MIDI_CC_VOLUME) // CC 07 on PCCH: Master Volume
+					{
+						float fMasterVolume = (float)pMessage[2] / 127.0f;
+						m_pSynthesizer->setMasterVolume(fMasterVolume);
+						LOGNOTE("MIDI CC07 (Volume) on PCCH: Set Master Volume to %d (%.3f)", pMessage[2], fMasterVolume);
+						break; // Do not process further for TGs
+					}
 					else
 					{
 						// Ignore any other CC messages at this time
 						LOGNOTE("Ignoring CC %d (%d) on Performance Select Channel %d\n", pMessage[1], pMessage[2], nPerfCh);
+						break; // Already handled PCCH message
 					}
 				}
 			}


### PR DESCRIPTION
Closes #920

- When a MIDI CC 07 message is received on the PCCH (if enabled), it sets the global Master Volume (`setMasterVolume`), allowing direct control from a MIDI keyboard slider.
- When PCCH is off, normal per-TG volume operation is preserved.
- The change is implemented in mididevice.cpp and includes a log message for traceability.

**Code excerpt:**
```cpp
else if (pMessage[1] == MIDI_CC_VOLUME) // CC 07 on PCCH: Master Volume
{
    float fMasterVolume = (float)pMessage[2] / 127.0f;
    m_pSynthesizer->setMasterVolume(fMasterVolume);
    LOGNOTE("MIDI CC07 (Volume) on PCCH: Set Master Volume to %d (%.3f)", pMessage[2], fMasterVolume);
    break; // Do not process further for TGs
}
```

**Testing:**  
- Send MIDI CC 07 on the PCCH: Master Volume changes.
- Send MIDI CC 07 on other channels: Only TG volume changes.