### PR TITLE
applemidi: fix stringpop-truncation warning

### DIFF
--- a/src/net/applemidi.cpp
+++ b/src/net/applemidi.cpp
@@ -813,6 +813,8 @@ bool CAppleMIDIParticipant::SendAcceptInvitationPacket(CSocket* pSocket, CIPAddr
 	else
 		strncpy(AcceptPacket.Name, "MiniDexed", sizeof(AcceptPacket.Name));
 
+	AcceptPacket.Name[sizeof(AcceptPacket.Name) - 1] = 0;
+
 #ifdef APPLEMIDI_DEBUG
 	LOGNOTE("--> Accept invitation");
 #endif


### PR DESCRIPTION
net/applemidi.cpp: In member function 'bool CAppleMIDIParticipant::SendAcceptInvitationPacket(CSocket*, CIPAddress*, u16)':
net/applemidi.cpp:812:10: warning: 'char* strncpy(char*, const char*, size_t)' specified bound 256 equals destination size [-Wstringop-truncation]
strncpy(AcceptPacket.Name, m_pSessionName, sizeof(AcceptPacket.Name));