### PR TITLE
[WIP] Part 1-3 + Part Drum + Layer 1 performance loading

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -10,7 +10,7 @@ OBJS = main.o kernel.o minidexed.o config.o userinterface.o uimenu.o \
        mididevice.o midikeyboard.o serialmididevice.o pckeyboard.o \
        sysexfileloader.o performanceconfig.o perftimer.o \
        effect_platervbstereo.o uibuttons.o midipin.o \
-       arm_float_to_q23.o arm_scale_zip_f32.o \
+       arm_float_to_q23.o arm_scale_zip_f32.o arm_scale_zip_f32_to_q23.o \
        net/ftpdaemon.o net/ftpworker.o net/applemidi.o net/udpmidi.o net/mdnspublisher.o udpmididevice.o
 
 OPTIMIZE = -O3

--- a/src/arm_scale_zip_f32.c
+++ b/src/arm_scale_zip_f32.c
@@ -28,21 +28,21 @@ void arm_scale_zip_f32(
 {
     uint32_t blkCnt;                               /* Loop counter */
 
-    f32x2x2_t res;
+    f32x4x2_t res;
 
-    /* Compute 2 outputs at a time */
-    blkCnt = blockSize >> 1U;
+    /* Compute 4 outputs at a time */
+    blkCnt = blockSize >> 2U;
 
     while (blkCnt > 0U)
     {
-        res.val[0] = vmul_n_f32(vld1_f32(pSrc1), scale);
-        res.val[1] = vmul_n_f32(vld1_f32(pSrc2), scale);
-        vst2_f32(pDst, res);
+        res.val[0] = vmulq_n_f32(vld1q_f32(pSrc1), scale);
+        res.val[1] = vmulq_n_f32(vld1q_f32(pSrc2), scale);
+        vst2q_f32(pDst, res);
 
         /* Increment pointers */
-        pSrc1 += 2;
-        pSrc2 += 2;
-        pDst += 4;
+        pSrc1 += 4;
+        pSrc2 += 4;
+        pDst += 8;
         
         /* Decrement the loop counter */
         blkCnt--;
@@ -50,7 +50,7 @@ void arm_scale_zip_f32(
 
     /* If the blockSize is not a multiple of 4, compute any remaining output samples here.
     ** No loop unrolling is used. */
-    blkCnt = blockSize & 1;
+    blkCnt = blockSize & 3;
 
     while (blkCnt > 0U)
     {

--- a/src/arm_scale_zip_f32_to_q23.c
+++ b/src/arm_scale_zip_f32_to_q23.c
@@ -1,0 +1,82 @@
+#include "arm_scale_zip_f32_to_q23.h"
+
+/**
+* @brief Scale two floating-point vector with a scalar and zip after.
+* @param[in]  pSrc1      points to the input vector 1
+* @param[in]  pSrc2      points to the input vector 2
+* @param[in]  scale      scale scalar
+* @param[out] pDst       points to the output vector
+* @param[in]  blockSize  number of samples in the vector
+*/
+
+#if defined(ARM_MATH_NEON_EXPERIMENTAL)
+void arm_scale_zip_f32_to_q23(
+  const float32_t * pSrc1,
+  const float32_t * pSrc2,
+        float32_t scale,
+        q23_t * pDst,
+        uint32_t blockSize)
+{
+    uint32_t blkCnt;                               /* Loop counter */
+
+    int32x4x2_t res;
+
+    /* Compute 4 outputs at a time */
+    blkCnt = blockSize >> 2U;
+
+    while (blkCnt > 0U)
+    {
+        res.val[0] = vcvtq_n_s32_f32(vmulq_n_f32(vld1q_f32(pSrc1), scale), 23);
+        res.val[0] = vminq_s32(res.val[0], vdupq_n_s32(0x007fffff));
+        res.val[0] = vmaxq_s32(res.val[0], vdupq_n_s32(0xff800000));
+
+        res.val[1] = vcvtq_n_s32_f32(vmulq_n_f32(vld1q_f32(pSrc2), scale), 23);
+        res.val[1] = vminq_s32(res.val[1], vdupq_n_s32(0x007fffff));
+        res.val[1] = vmaxq_s32(res.val[1], vdupq_n_s32(0xff800000));
+
+        vst2q_s32(pDst, res);
+
+        /* Increment pointers */
+        pSrc1 += 4;
+        pSrc2 += 4;
+        pDst += 8;
+        
+        /* Decrement the loop counter */
+        blkCnt--;
+    }
+
+    /* If the blockSize is not a multiple of 4, compute any remaining output samples here.
+    ** No loop unrolling is used. */
+    blkCnt = blockSize & 3;
+
+    while (blkCnt > 0U)
+    {
+        *pDst++ = (q23_t) __SSAT((q31_t) (*pSrc1++ * scale * 8388608.0f), 24);
+        *pDst++ = (q23_t) __SSAT((q31_t) (*pSrc2++ * scale * 8388608.0f), 24);
+
+        /* Decrement the loop counter */
+        blkCnt--;
+    }
+}
+#else
+void arm_scale_zip_f32_to_q23(
+  const float32_t * pSrc1,
+  const float32_t * pSrc2,
+        float32_t scale,
+        q23_t * pDst,
+        uint32_t blockSize)
+{
+  uint32_t blkCnt;                               /* Loop counter */
+
+  blkCnt = blockSize;
+
+  while (blkCnt > 0U)
+  {
+      *pDst++ = (q23_t) __SSAT((q31_t) (*pSrc1++ * scale * 8388608.0f), 24);
+      *pDst++ = (q23_t) __SSAT((q31_t) (*pSrc2++ * scale * 8388608.0f), 24);
+
+      /* Decrement the loop counter */
+      blkCnt--;
+  }
+}
+#endif

--- a/src/arm_scale_zip_f32_to_q23.h
+++ b/src/arm_scale_zip_f32_to_q23.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "arm_math_types.h"
+
+typedef int32_t q23_t;
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+* @brief Scale two floating-point vector with a scalar and zip after.
+* @param[in]  pSrc1      points to the input vector 1
+* @param[in]  pSrc2      points to the input vector 2
+* @param[in]  scale      scale scalar
+* @param[out] pDst       points to the output vector
+* @param[in]  blockSize  number of samples in the vector
+*/
+void arm_scale_zip_f32_to_q23(const float32_t * pSrc1, const float32_t * pSrc2, float32_t scale, q23_t * pDst, uint32_t blockSize);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/config.h
+++ b/src/config.h
@@ -49,8 +49,8 @@ public:
 	// These are max values, default is to support 8 in total with optional 16 TGs
 	static const unsigned TGsCore1 = 2;		// process 2 TGs on core 1
 	static const unsigned TGsCore23 = 3;		// process 3 TGs on core 2 and 3 each
-	static const unsigned TGsCore1Opt = 2;		// process optional additional 2 TGs on core 1
-	static const unsigned TGsCore23Opt = 3;		// process optional additional 3 TGs on core 2 and 3 each
+	static const unsigned TGsCore1Opt = 8;		// process optional additional 2 TGs on core 1
+	static const unsigned TGsCore23Opt = 12;	// process optional additional 3 TGs on core 2 and 3 each
 	static const unsigned MinToneGenerators = TGsCore1 + 2*TGsCore23;
 	static const unsigned AllToneGenerators = TGsCore1 + TGsCore1Opt + 2*TGsCore23 + 2*TGsCore23Opt;
 	static const unsigned DefToneGenerators = MinToneGenerators;

--- a/src/effect_platervbstereo.cpp
+++ b/src/effect_platervbstereo.cpp
@@ -158,7 +158,7 @@ AudioEffectPlateReverb::AudioEffectPlateReverb(float32_t samplerate)
 
 // #define sat16(n, rshift) signed_saturate_rshift((n), 16, (rshift))
 
-void AudioEffectPlateReverb::doReverb(const float32_t* inblockL, const float32_t* inblockR, float32_t* rvbblockL, float32_t* rvbblockR, uint16_t len)
+void AudioEffectPlateReverb::addReverb(const float32_t* inblockL, const float32_t* inblockR, float32_t* addblockL, float32_t* addblockR, uint16_t len)
 {
     float32_t input, acc, temp1, temp2;
     uint16_t temp16;
@@ -405,7 +405,7 @@ void AudioEffectPlateReverb::doReverb(const float32_t* inblockL, const float32_t
         temp1 = acc - master_lowpass_l;
         master_lowpass_l += temp1 * master_lowpass_f;
 
-	rvbblockL[i] = master_lowpass_l;
+	addblockL[i] += master_lowpass_l * reverb_level;
 
         // Channel R
         #ifdef TAP1_MODULATED
@@ -449,6 +449,6 @@ void AudioEffectPlateReverb::doReverb(const float32_t* inblockL, const float32_t
         temp1 = acc - master_lowpass_r;
         master_lowpass_r += temp1 * master_lowpass_f;
 
-	rvbblockR[i] = master_lowpass_r;
+	addblockR[i] += master_lowpass_r * reverb_level;
     }
 }

--- a/src/effect_platervbstereo.h
+++ b/src/effect_platervbstereo.h
@@ -60,7 +60,7 @@ class AudioEffectPlateReverb
 {
 public:
     AudioEffectPlateReverb(float32_t samplerate);
-    void doReverb(const float32_t* inblockL, const float32_t* inblockR, float32_t* rvbblockL, float32_t* rvbblockR,uint16_t len);
+    void addReverb(const float32_t* inblockL, const float32_t* inblockR, float32_t* addblockL, float32_t* addblockR, uint16_t len);
 
     void size(float n)
     {

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -35,6 +35,7 @@ CKernel::CKernel (void)
 :	
 	CStdlibAppStdio ("minidexed"),
 	m_Config (&mFileSystem),
+	m_CPUThrottle (CPUSpeedMaximum),
 	m_GPIOManager (&mInterrupt),
  	m_I2CMaster (CMachineInfo::Get ()->GetDevice (DeviceI2CMaster), TRUE),
 	m_pSPIMaster (nullptr),

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -483,7 +483,7 @@ void CMiniDexed::Run (unsigned nCore)
 		{
 			while (m_CoreStatus[nCore] != CoreStatusIdle)
 			{
-				// just wait
+				WaitForEvent ();
 			}
 		}
 
@@ -497,9 +497,11 @@ void CMiniDexed::Run (unsigned nCore)
 		while (1)
 		{
 			m_CoreStatus[nCore] = CoreStatusIdle;		// ready to be kicked
+			SendIPI (1, IPI_USER);
+
 			while (m_CoreStatus[nCore] == CoreStatusIdle)
 			{
-				// just wait
+				WaitForEvent ();
 			}
 
 			// now kicked from core 1
@@ -1322,6 +1324,7 @@ void CMiniDexed::ProcessSound (void)
 		{
 			assert (m_CoreStatus[nCore] == CoreStatusIdle);
 			m_CoreStatus[nCore] = CoreStatusBusy;
+			SendIPI (nCore, IPI_USER);
 		}
 
 		// process the TGs assigned to core 1
@@ -1337,7 +1340,7 @@ void CMiniDexed::ProcessSound (void)
 		{
 			while (m_CoreStatus[nCore] != CoreStatusIdle)
 			{
-				// just wait
+				WaitForEvent ();
 			}
 		}
 

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -1410,8 +1410,6 @@ void CMiniDexed::ProcessSound (void)
 			// BEGIN adding reverb
 			if (m_nParameter[ParameterReverbEnable])
 			{
-				float32_t ReverbBuffer[2][nFrames];
-
 				float32_t *ReverbSendBuffer[2];
 				reverb_send_mixer->getBuffers(ReverbSendBuffer);
 
@@ -1424,14 +1422,7 @@ void CMiniDexed::ProcessSound (void)
 
 				m_ReverbSpinLock.Acquire ();
 
-				reverb->doReverb(ReverbSendBuffer[indexL],ReverbSendBuffer[indexR],ReverbBuffer[indexL], ReverbBuffer[indexR],nFrames);
-
-				// scale down and add left reverb buffer by reverb level 
-				arm_scale_f32(ReverbBuffer[indexL], reverb->get_level(), ReverbBuffer[indexL], nFrames);
-				arm_add_f32(SampleBuffer[indexL], ReverbBuffer[indexL], SampleBuffer[indexL], nFrames);
-				// scale down and add right reverb buffer by reverb level 
-				arm_scale_f32(ReverbBuffer[indexR], reverb->get_level(), ReverbBuffer[indexR], nFrames);
-				arm_add_f32(SampleBuffer[indexR], ReverbBuffer[indexR], SampleBuffer[indexR], nFrames);
+				reverb->addReverb(ReverbSendBuffer[indexL], ReverbSendBuffer[indexR], SampleBuffer[indexL], SampleBuffer[indexR], nFrames);
 
 				m_ReverbSpinLock.Release ();
 			}

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -30,7 +30,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include "arm_float_to_q23.h"
-#include "arm_scale_zip_f32.h"
+#include "arm_scale_zip_f32_to_q23.h"
 
 const char WLANFirmwarePath[] = "SD:firmware/";
 const char WLANConfigFile[]   = "SD:wpa_supplicant.conf";
@@ -1392,7 +1392,6 @@ void CMiniDexed::ProcessSound (void)
 			uint8_t indexL=0, indexR=1;
 
 			// BEGIN TG mixing
-			float32_t tmp_float[nFrames*2];
 			int32_t tmp_int[nFrames*2];
 
 			// get the mix buffer of all TGs
@@ -1436,9 +1435,7 @@ void CMiniDexed::ProcessSound (void)
 			}
 
 			// Convert dual float array (left, right) to single int16 array (left/right)
-			arm_scale_zip_f32(SampleBuffer[indexL], SampleBuffer[indexR], nMasterVolume, tmp_float, nFrames);
-
-			arm_float_to_q23(tmp_float,tmp_int,nFrames*2);
+			arm_scale_zip_f32_to_q23(SampleBuffer[indexL], SampleBuffer[indexR], nMasterVolume, tmp_int, nFrames);
 
 			// Prevent PCM510x analog mute from kicking in
 			if (tmp_int[nFrames * 2 - 1] == 0)

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -52,6 +52,8 @@
 #include "udpmididevice.h"
 #include "net/ftpdaemon.h"
  
+#define NPART 5
+
 class CMiniDexed
 #ifdef ARM_ALLOW_MULTI_CORE
 :	public CMultiCoreSupport
@@ -140,14 +142,14 @@ public:
 	void SetActualPerformanceID(unsigned nID);
 	unsigned GetActualPerformanceBankID();
 	void SetActualPerformanceBankID(unsigned nBankID);
-	bool SetNewPerformance(unsigned nID);
+	bool SetNewPerformance(unsigned part, unsigned nID);
 	bool SetNewPerformanceBank(unsigned nBankID);
 	void SetFirstPerformance(void);
 	void DoSetFirstPerformance(void);
 	bool SavePerformanceNewFile ();
 	
 	bool DoSavePerformanceNewFile (void);
-	bool DoSetNewPerformance (void);
+	bool DoSetNewPerformance (unsigned part);
 	bool DoSetNewPerformanceBank (void);
 	bool GetPerformanceSelectToLoad(void);
 	bool SavePerformance (bool bSaveAsDeault);
@@ -173,6 +175,7 @@ public:
 	};
 
 	void SetParameter (TParameter Parameter, int nValue);
+	void SetParameter (unsigned part, TParameter Parameter, int nValue);
 	int GetParameter (TParameter Parameter);
 
 	std::string GetNewPerformanceDefaultName(void);
@@ -247,7 +250,7 @@ public:
 private:
 	int16_t ApplyNoteLimits (int16_t pitch, unsigned nTG);	// returns < 0 to ignore note
 	uint8_t m_uchOPMask[CConfig::AllToneGenerators];
-	void LoadPerformanceParameters(void); 
+	void LoadPerformanceParameters(unsigned part); 
 	void ProcessSound (void);
 	const char* GetNetworkDeviceShortName() const;
 
@@ -335,7 +338,7 @@ private:
 	CPerformanceTimer m_GetChunkTimer;
 	bool m_bProfileEnabled;
 
-	AudioEffectPlateReverb* reverb;
+	AudioEffectPlateReverb* reverb[NPART];
 	AudioStereoMixer<CConfig::AllToneGenerators>* tg_mixer;
 	AudioStereoMixer<CConfig::AllToneGenerators>* reverb_send_mixer;
 
@@ -354,14 +357,14 @@ private:
 
 	bool m_bSavePerformance;
 	bool m_bSavePerformanceNewFile;
-	bool m_bSetNewPerformance;
-	unsigned m_nSetNewPerformanceID;	
+	bool m_bSetNewPerformance[NPART];
+	unsigned m_nSetNewPerformanceID[NPART];
 	bool m_bSetNewPerformanceBank;
 	unsigned m_nSetNewPerformanceBankID;	
 	bool m_bSetFirstPerformance;
 	bool	m_bDeletePerformance;
 	unsigned m_nDeletePerformanceID;
-	bool m_bLoadPerformanceBusy;
+	bool m_bLoadPerformanceBusy[NPART];
 	bool m_bLoadPerformanceBankBusy;
 	bool m_bSaveAsDeault;
 };

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -30,6 +30,7 @@
 #include "serialmididevice.h"
 #include "perftimer.h"
 #include <fatfs/ff.h>
+#include <atomic>
 #include <stdint.h>
 #include <string>
 #include <circle/types.h>
@@ -326,8 +327,8 @@ private:
 
 #ifdef ARM_ALLOW_MULTI_CORE
 //	unsigned m_nActiveTGsLog2;
-	volatile TCoreStatus m_CoreStatus[CORES];
-	volatile unsigned m_nFramesToProcess;
+	std::atomic<TCoreStatus> m_CoreStatus[CORES];
+	std::atomic<unsigned> m_nFramesToProcess;
 	float32_t m_OutputLevel[CConfig::AllToneGenerators][CConfig::MaxChunkSize];
 #endif
 

--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -61,6 +61,30 @@ const CUIMenu::TMenuItem CUIMenu::s_MainMenu[] =
 	{"TG14",	MenuHandler,	s_TGMenu, 13},
 	{"TG15",	MenuHandler,	s_TGMenu, 14},
 	{"TG16",	MenuHandler,	s_TGMenu, 15},
+	{"TG17",	MenuHandler,	s_TGMenu, 16},
+	{"TG18",	MenuHandler,	s_TGMenu, 17},
+	{"TG19",	MenuHandler,	s_TGMenu, 18},
+	{"TG20",	MenuHandler,	s_TGMenu, 19},
+	{"TG21",	MenuHandler,	s_TGMenu, 20},
+	{"TG22",	MenuHandler,	s_TGMenu, 21},
+	{"TG23",	MenuHandler,	s_TGMenu, 22},
+	{"TG24",	MenuHandler,	s_TGMenu, 23},
+	{"TG25",	MenuHandler,	s_TGMenu, 24},
+	{"TG26",	MenuHandler,	s_TGMenu, 25},
+	{"TG27",	MenuHandler,	s_TGMenu, 26},
+	{"TG28",	MenuHandler,	s_TGMenu, 27},
+	{"TG29",	MenuHandler,	s_TGMenu, 28},
+	{"TG30",	MenuHandler,	s_TGMenu, 29},
+	{"TG31",	MenuHandler,	s_TGMenu, 30},
+	{"TG32",	MenuHandler,	s_TGMenu, 31},
+	{"TG33",	MenuHandler,	s_TGMenu, 32},
+	{"TG34",	MenuHandler,	s_TGMenu, 33},
+	{"TG35",	MenuHandler,	s_TGMenu, 34},
+	{"TG36",	MenuHandler,	s_TGMenu, 35},
+	{"TG37",	MenuHandler,	s_TGMenu, 36},
+	{"TG38",	MenuHandler,	s_TGMenu, 37},
+	{"TG39",	MenuHandler,	s_TGMenu, 38},
+	{"TG40",	MenuHandler,	s_TGMenu, 39},
 #endif
 #endif
 	{"Effects",	MenuHandler,	s_EffectsMenu},
@@ -337,9 +361,13 @@ static const unsigned NoteC3 = 39;
 
 const CUIMenu::TMenuItem CUIMenu::s_PerformanceMenu[] =
 {
-	{"Load",	PerformanceMenu, 0, 0}, 
+	{"Part 1",	PerformanceMenu, 0, 0}, 
+	{"Part 2",	PerformanceMenu, 0, 1},
+	{"Part 3",	PerformanceMenu, 0, 2},
+	{"Part Drum",	PerformanceMenu, 0, 3},
+	{"Layer 1",	PerformanceMenu, 0, 4},
 	{"Save",	MenuHandler,	s_SaveMenu},
-	{"Delete",	PerformanceMenu, 0, 1},
+	{"Delete",	PerformanceMenu, 0, 10},
 	{"Bank",	EditPerformanceBankNumber, 0, 0},
 	{"PCCH",	EditGlobalParameter,	0,	CMiniDexed::ParameterPerformanceSelectChannel},
 	{0}
@@ -1323,7 +1351,7 @@ void CUIMenu::PgmUpDownHandler (TMenuEvent Event)
 				}
 			} while ((m_pMiniDexed->IsValidPerformance(nPerformance) != true) && (nPerformance != nStart));
 			m_nSelectedPerformanceID = nPerformance;
-			m_pMiniDexed->SetNewPerformance(m_nSelectedPerformanceID);
+			m_pMiniDexed->SetNewPerformance(0, m_nSelectedPerformanceID);
 			//LOGNOTE("Performance new=%d, last=%d", m_nSelectedPerformanceID, nLastPerformance);
 		}
 		else // MenuEventPgmUp
@@ -1341,7 +1369,7 @@ void CUIMenu::PgmUpDownHandler (TMenuEvent Event)
 				}
 			} while ((m_pMiniDexed->IsValidPerformance(nPerformance) != true) && (nPerformance != nStart));
 			m_nSelectedPerformanceID = nPerformance;
-			m_pMiniDexed->SetNewPerformance(m_nSelectedPerformanceID);
+			m_pMiniDexed->SetNewPerformance(0, m_nSelectedPerformanceID);
 			//LOGNOTE("Performance new=%d, last=%d", m_nSelectedPerformanceID, nLastPerformance);
 		}
 	}
@@ -1612,9 +1640,9 @@ void CUIMenu::PerformanceMenu (CUIMenu *pUIMenu, TMenuEvent Event)
 				}
 			} while ((pUIMenu->m_pMiniDexed->IsValidPerformance(nValue) != true) && (nValue != nStart));
 			pUIMenu->m_nSelectedPerformanceID = nValue;
-			if (!bPerformanceSelectToLoad && pUIMenu->m_nCurrentParameter==0)
+			if (!bPerformanceSelectToLoad && pUIMenu->m_nCurrentParameter != 10)
 			{
-				pUIMenu->m_pMiniDexed->SetNewPerformance(nValue);
+				pUIMenu->m_pMiniDexed->SetNewPerformance(pUIMenu->m_nCurrentParameter, nValue);
 			}
 			break;
 
@@ -1632,9 +1660,9 @@ void CUIMenu::PerformanceMenu (CUIMenu *pUIMenu, TMenuEvent Event)
 				}
 			} while ((pUIMenu->m_pMiniDexed->IsValidPerformance(nValue) != true) && (nValue != nStart));
 			pUIMenu->m_nSelectedPerformanceID = nValue;
-			if (!bPerformanceSelectToLoad && pUIMenu->m_nCurrentParameter==0)
+			if (!bPerformanceSelectToLoad && pUIMenu->m_nCurrentParameter != 10)
 			{
-				pUIMenu->m_pMiniDexed->SetNewPerformance(nValue);
+				pUIMenu->m_pMiniDexed->SetNewPerformance(pUIMenu->m_nCurrentParameter, nValue);
 			}
 			break;
 
@@ -1674,25 +1702,21 @@ void CUIMenu::PerformanceMenu (CUIMenu *pUIMenu, TMenuEvent Event)
 			pUIMenu->m_pMiniDexed->SetFirstPerformance();
 			break;
 
-		case MenuEventSelect:	
-			switch (pUIMenu->m_nCurrentParameter)
+		case MenuEventSelect:
+			if (pUIMenu->m_nCurrentParameter != 10)
 			{
-			case 0:
 				if (bPerformanceSelectToLoad)
 				{
-				pUIMenu->m_pMiniDexed->SetNewPerformance(nValue);
+					pUIMenu->m_pMiniDexed->SetNewPerformance(pUIMenu->m_nCurrentParameter, nValue);
 				}
-
-				break;
-			case 1:
+			}
+			else // Delete
+			{
 				if (pUIMenu->m_pMiniDexed->IsValidPerformance(pUIMenu->m_nSelectedPerformanceID))
 				{
 					pUIMenu->m_bPerformanceDeleteMode=true;
 					pUIMenu->m_bConfirmDeletePerformance=false;
 				}
-				break;
-			default:
-				break;
 			}
 			break;
 		default:


### PR DESCRIPTION
Demo:
Very basic part performance load implementation.
Performance > Part 1 loads the performance into to TG 1-8.
Performance > Part 2 loads the performance into to TG 9-16 and adds 3 to each TG channel.
Performance > Part 3 loads the performance into to TG 17-24 and adds 7 to each TG channel.
Performance > Part Drum loads the performance into to TG 25-32 and adds 8 to each TG channel.
Performance > Layer 1 loads the performance into to TG 33-40.

This is just a test of how it sounds this way.
Every part has a reverb.

ToneGenerators=40 should be added to the minidexed.ini so you need rpi4 or rpi5.
It starts the Pi with fast mode, so it is possible that you will need a heatsink.