### PR TITLE
mixer: fix pan channel order

### DIFF
--- a/src/effect_mixer.hpp
+++ b/src/effect_mixer.hpp
@@ -113,8 +113,8 @@ public:
 			pan = MIN_PANORAMA;
 
 		// From: https://stackoverflow.com/questions/67062207/how-to-pan-audio-sample-data-naturally
-		panorama[channel][0]=arm_sin_f32(mapfloat(pan, MIN_PANORAMA, MAX_PANORAMA, 0.0, M_PI/2.0));
-		panorama[channel][1]=arm_cos_f32(mapfloat(pan, MIN_PANORAMA, MAX_PANORAMA, 0.0, M_PI/2.0));
+		panorama[channel][0]=arm_cos_f32(mapfloat(pan, MIN_PANORAMA, MAX_PANORAMA, 0.0, M_PI/2.0));
+		panorama[channel][1]=arm_sin_f32(mapfloat(pan, MIN_PANORAMA, MAX_PANORAMA, 0.0, M_PI/2.0));
 	}
 
 	void doAddMix(uint8_t channel, float32_t* in)

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -213,10 +213,6 @@ CMiniDexed::CMiniDexed (CConfig *pConfig, CInterruptSystem *pInterrupt,
 
 		m_pSoundDevice = new CHDMISoundBaseDevice (pInterrupt, pConfig->GetSampleRate (),
 							   pConfig->GetChunkSize ());
-
-		// The channels are swapped by default in the HDMI sound driver.
-		// TODO: Remove this line, when this has been fixed in the driver.
-		m_bChannelsSwapped = !m_bChannelsSwapped;
 #endif
 	}
 	else


### PR DESCRIPTION
0.0 full left
1.0 full right

## Summary by Sourcery

Fix stereo panorama channel order and remove temporary HDMI channel swap workaround

Bug Fixes:
- Swap sine and cosine calculations to correct left/right pan channel ordering

Chores:
- Remove HDMI sound driver channel swap inversion workaround