### PR TITLE
Revert "Skip ./circle-stdlib/libs/circle/boot (it fails) (#906)"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,15 +64,11 @@ jobs:
         run: |
           set -ex
           export PATH=$(readlink -f ./gcc-arm-10.3-2021.07-x86_64-aarch64-none-elf/bin):$PATH
-          # cd ./circle-stdlib/libs/circle/boot
-          # make
-          # make armstub64
-          # cd -
-          # cp -r ./circle-stdlib/libs/circle/boot/* sdcard
-          cd ./sdcard
-          wget https://github.com/probonopd/MiniDexed/releases/download/assets/boot.zip
-          unzip boot.zip && rm boot.zip
-          cd ..
+          cd ./circle-stdlib/libs/circle/boot
+          make
+          make armstub64
+          cd -
+          cp -r ./circle-stdlib/libs/circle/boot/* sdcard
           rm -rf sdcard/config*.txt sdcard/README sdcard/Makefile sdcard/armstub sdcard/COPYING.linux
           cp ./src/config.txt ./src/minidexed.ini ./src/performance.ini sdcard/
           cp ./getsysex.sh sdcard/


### PR DESCRIPTION
This reverts commit 1ec9cb2d4026feb0b9652ed20b6a0d982df97c8d.

Fixed in Circle:
https://github.com/rsta2/circle/commit/2e5bda37a75f5891a049b39eeb9d3dfcf907314a