### PR TITLE
midi: remove the BANK typo from MIDI_CC_BANK_SUSTAIN

### DIFF
--- a/src/midi.h
+++ b/src/midi.h
@@ -35,7 +35,7 @@
 #define MIDI_CC_PAN_POSITION		10
 #define MIDI_CC_EXPRESSION		11
 #define MIDI_CC_BANK_SELECT_LSB		32
-#define MIDI_CC_BANK_SUSTAIN		64
+#define MIDI_CC_SUSTAIN	                64
 #define MIDI_CC_PORTAMENTO		65
 #define MIDI_CC_SOSTENUTO		66
 #define MIDI_CC_HOLD2		        69

--- a/src/mididevice.cpp
+++ b/src/mididevice.cpp
@@ -548,7 +548,7 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 							m_pSynthesizer->BankSelectLSB (pMessage[2], nTG);
 							break;
 		
-						case MIDI_CC_BANK_SUSTAIN:
+						case MIDI_CC_SUSTAIN:
 							m_pSynthesizer->setSustain (pMessage[2] >= 64, nTG);
 							break;
 


### PR DESCRIPTION
This is a typo. BANK_ was probably included because of BANK_SELECT above it.

## Summary by Sourcery

Remove the incorrect 'BANK_' prefix from the sustain control macro and update its usage in the MIDI message handler.

Bug Fixes:
- Rename MIDI_CC_BANK_SUSTAIN to MIDI_CC_SUSTAIN in midi.h to correct the typo
- Update the corresponding case label in CMIDIDevice::MIDIMessageHandler from MIDI_CC_BANK_SUSTAIN to MIDI_CC_SUSTAIN