### PR TITLE
move compressor to TG menu and add parameters

### DIFF
--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -116,6 +116,8 @@ CMiniDexed::CMiniDexed (CConfig *pConfig, CInterruptSystem *pInterrupt,
 		
 		m_nReverbSend[i] = 0;
 
+		m_bCompressorEnable[i] = 1;
+
 		// Active the required number of active TGs
 		if (i<m_nToneGenerators)
 		{
@@ -253,8 +255,6 @@ CMiniDexed::CMiniDexed (CConfig *pConfig, CInterruptSystem *pInterrupt,
 	SetParameter (ParameterReverbDiffusion, 65);
 	SetParameter (ParameterReverbLevel, 99);
 	// END setup reverb
-
-	SetParameter (ParameterCompressorEnable, 1);
 
 	SetPerformanceSelectChannel(m_pConfig->GetPerformanceSelectChannel());
 		
@@ -1004,14 +1004,6 @@ void CMiniDexed::SetParameter (TParameter Parameter, int nValue)
 
 	switch (Parameter)
 	{
-	case ParameterCompressorEnable:
-		for (unsigned nTG = 0; nTG < m_nToneGenerators; nTG++)
-		{
-			assert (m_pTG[nTG]);
-			m_pTG[nTG]->setCompressor (!!nValue);
-		}
-		break;
-
 	case ParameterReverbEnable:
 		nValue=constrain((int)nValue,0,1);
 		m_ReverbSpinLock.Acquire ();
@@ -1132,6 +1124,8 @@ void CMiniDexed::SetTGParameter (TTGParameter Parameter, int nValue, unsigned nT
 
 	case TGParameterReverbSend:	SetReverbSend (nValue, nTG);	break;
 
+	case TGParameterCompressorEnable:	SetCompressorEnable (nValue, nTG); break;
+
 	default:
 		assert (0);
 		break;
@@ -1182,7 +1176,8 @@ int CMiniDexed::GetTGParameter (TTGParameter Parameter, unsigned nTG)
 	case TGParameterATAmplitude:				return getModController(3, 2,  nTG); 
 	case TGParameterATEGBias:					return getModController(3, 3,  nTG); 
 	
-	
+	case TGParameterCompressorEnable:	return m_bCompressorEnable[nTG];
+
 	default:
 		assert (0);
 		return 0;
@@ -1547,9 +1542,10 @@ bool CMiniDexed::DoSavePerformance (void)
 		m_PerformanceConfig.SetAftertouchTarget (m_nAftertouchTarget[nTG], nTG);
 		
 		m_PerformanceConfig.SetReverbSend (m_nReverbSend[nTG], nTG);
+
+		m_PerformanceConfig.SetCompressorEnable (m_bCompressorEnable[nTG], nTG);
 	}
 
-	m_PerformanceConfig.SetCompressorEnable (!!m_nParameter[ParameterCompressorEnable]);
 	m_PerformanceConfig.SetReverbEnable (!!m_nParameter[ParameterReverbEnable]);
 	m_PerformanceConfig.SetReverbSize (m_nParameter[ParameterReverbSize]);
 	m_PerformanceConfig.SetReverbHighDamp (m_nParameter[ParameterReverbHighDamp]);
@@ -1565,6 +1561,17 @@ bool CMiniDexed::DoSavePerformance (void)
 		
 	}
 	return m_PerformanceConfig.Save ();
+}
+
+void CMiniDexed::SetCompressorEnable(bool compressor, unsigned nTG)
+{
+	assert (nTG < CConfig::AllToneGenerators);
+	if (nTG >= m_nToneGenerators) return;  // Not an active TG
+
+	assert (m_pTG[nTG]);
+	m_bCompressorEnable[nTG] = compressor;
+	m_pTG[nTG]->setCompressor (compressor);
+	m_UI.ParameterChanged ();
 }
 
 void CMiniDexed::setMonoMode(uint8_t mono, uint8_t nTG)
@@ -2037,12 +2044,11 @@ void CMiniDexed::LoadPerformanceParameters(void)
 			setBreathControllerTarget (m_PerformanceConfig.GetBreathControlTarget (nTG),  nTG);
 			setAftertouchRange (m_PerformanceConfig.GetAftertouchRange (nTG),  nTG);
 			setAftertouchTarget (m_PerformanceConfig.GetAftertouchTarget (nTG),  nTG);
-			
-		
+
+			SetCompressorEnable (m_PerformanceConfig.GetCompressorEnable (nTG), nTG);
 		}
 
 		// Effects
-		SetParameter (ParameterCompressorEnable, m_PerformanceConfig.GetCompressorEnable () ? 1 : 0);
 		SetParameter (ParameterReverbEnable, m_PerformanceConfig.GetReverbEnable () ? 1 : 0);
 		SetParameter (ParameterReverbSize, m_PerformanceConfig.GetReverbSize ());
 		SetParameter (ParameterReverbHighDamp, m_PerformanceConfig.GetReverbHighDamp ());

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -106,6 +106,8 @@ public:
 
 	void SetReverbSend (unsigned nReverbSend, unsigned nTG);			// 0 .. 127
 
+	void SetCompressorEnable (bool compressor, unsigned nTG);
+
 	void setMonoMode(uint8_t mono, uint8_t nTG);
 	void setPitchbendRange(uint8_t range, uint8_t nTG);
 	void setPitchbendStep(uint8_t step, uint8_t nTG);
@@ -158,7 +160,6 @@ public:
 	// Must match the order in CUIMenu::TParameter
 	enum TParameter
 	{
-		ParameterCompressorEnable,
 		ParameterReverbEnable,
 		ParameterReverbSize,
 		ParameterReverbHighDamp,
@@ -220,6 +221,8 @@ public:
 		TGParameterATPitch,
 		TGParameterATAmplitude,
 		TGParameterATEGBias,
+
+		TGParameterCompressorEnable,
 		
 		TGParameterUnknown
 	};
@@ -304,6 +307,8 @@ private:
 	int m_nNoteShift[CConfig::AllToneGenerators];
 
 	unsigned m_nReverbSend[CConfig::AllToneGenerators];
+
+	bool m_bCompressorEnable[CConfig::AllToneGenerators];
   
 	uint8_t m_nRawVoiceData[156]; 
 	

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -50,6 +50,7 @@
 #include "effect_platervbstereo.h"
 #include "udpmididevice.h"
 #include "net/ftpdaemon.h"
+#include "../Synth_Dexed/src/compressor.h"
  
 class CMiniDexed
 #ifdef ARM_ALLOW_MULTI_CORE
@@ -174,6 +175,13 @@ public:
 		ParameterReverbLevel,
 		ParameterPerformanceSelectChannel,
 		ParameterPerformanceBank,
+		ParameterLimiterEnable,
+		ParameterLimiterPreGain,
+		ParameterLimiterAttack,
+		ParameterLimiterRelease,
+		ParameterLimiterThresh,
+		ParameterLimiterRatio,
+		ParameterLimiterHPFilterEnable,
 		ParameterUnknown
 	};
 
@@ -359,6 +367,9 @@ private:
 	AudioStereoMixer<CConfig::AllToneGenerators>* reverb_send_mixer;
 
 	CSpinLock m_ReverbSpinLock;
+
+	Compressor m_Limiter[2];
+	CSpinLock m_LimiterSpinLock;
 
 	// Network
 	CNetSubSystem* m_pNet;

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -106,7 +106,12 @@ public:
 
 	void SetReverbSend (unsigned nReverbSend, unsigned nTG);			// 0 .. 127
 
-	void SetCompressorEnable (bool compressor, unsigned nTG);
+	void SetCompressorEnable (bool compressor, unsigned nTG);	// 0 .. 1 (default 1)
+	void SetCompressorPreGain (int preGain, unsigned nTG);		// -20 .. 20 dB (default 0)
+	void SetCompressorAttack (unsigned attack, unsigned nTG);	// 0 .. 1000 ms (default 5)
+	void SetCompressorRelease (unsigned release, unsigned nTG);	// 0 .. 1000 ms (default 200)
+	void SetCompressorThresh (int thresh, unsigned nTG);		// -60 .. 0 dBFS (default -20)
+	void SetCompressorRatio (unsigned ratio, unsigned nTG);		// 1 .. 20 (default 5)
 
 	void setMonoMode(uint8_t mono, uint8_t nTG);
 	void setPitchbendRange(uint8_t range, uint8_t nTG);
@@ -223,6 +228,11 @@ public:
 		TGParameterATEGBias,
 
 		TGParameterCompressorEnable,
+		TGParameterCompressorPreGain,
+		TGParameterCompressorAttack,
+		TGParameterCompressorRelease,
+		TGParameterCompressorThresh,
+		TGParameterCompressorRatio,
 		
 		TGParameterUnknown
 	};
@@ -309,6 +319,11 @@ private:
 	unsigned m_nReverbSend[CConfig::AllToneGenerators];
 
 	bool m_bCompressorEnable[CConfig::AllToneGenerators];
+	int m_nCompressorPreGain[CConfig::AllToneGenerators];
+	unsigned m_nCompressorAttack[CConfig::AllToneGenerators];
+	unsigned m_nCompressorRelease[CConfig::AllToneGenerators];
+	int m_nCompressorThresh[CConfig::AllToneGenerators];
+	unsigned m_nCompressorRatio[CConfig::AllToneGenerators];
   
 	uint8_t m_nRawVoiceData[156]; 
 	

--- a/src/performanceconfig.cpp
+++ b/src/performanceconfig.cpp
@@ -208,10 +208,11 @@ bool CPerformanceConfig::Load (void)
 		
 		PropertyName.Format ("AftertouchTarget%u", nTG+1);
 		m_nAftertouchTarget[nTG] = m_Properties.GetNumber (PropertyName, 0);
+
+		PropertyName.Format ("CompressorEnable%u", nTG+1);
+		m_bCompressorEnable[nTG] = m_Properties.GetNumber (PropertyName, 1);
 		
 		}
-
-	m_bCompressorEnable = m_Properties.GetNumber ("CompressorEnable", 1) != 0;
 
 	m_bReverbEnable = m_Properties.GetNumber ("ReverbEnable", 1) != 0;
 	m_nReverbSize = m_Properties.GetNumber ("ReverbSize", 70);
@@ -220,6 +221,15 @@ bool CPerformanceConfig::Load (void)
 	m_nReverbLowPass = m_Properties.GetNumber ("ReverbLowPass", 30);
 	m_nReverbDiffusion = m_Properties.GetNumber ("ReverbDiffusion", 65);
 	m_nReverbLevel = m_Properties.GetNumber ("ReverbLevel", 99);
+
+	// Compatibility
+	if (m_Properties.IsSet ("CompressorEnable") && m_Properties.GetNumber ("CompressorEnable", 1) == 0)
+	{
+		for (unsigned nTG = 0; nTG < CConfig::AllToneGenerators; nTG++)
+		{
+			m_bCompressorEnable[nTG] = 0;
+		}
+	}
 
 	return bResult;
 }
@@ -327,9 +337,10 @@ bool CPerformanceConfig::Save (void)
 		PropertyName.Format ("AftertouchTarget%u", nTG+1);
 		m_Properties.SetNumber (PropertyName, m_nAftertouchTarget[nTG]);			
 
-		}
+		PropertyName.Format ("CompressorEnable%u", nTG+1);
+		m_Properties.SetNumber (PropertyName, m_bCompressorEnable[nTG]);
 
-	m_Properties.SetNumber ("CompressorEnable", m_bCompressorEnable ? 1 : 0);
+		}
 
 	m_Properties.SetNumber ("ReverbEnable", m_bReverbEnable ? 1 : 0);
 	m_Properties.SetNumber ("ReverbSize", m_nReverbSize);
@@ -486,11 +497,6 @@ void CPerformanceConfig::SetReverbSend (unsigned nValue, unsigned nTG)
 	m_nReverbSend[nTG] = nValue;
 }
 
-bool CPerformanceConfig::GetCompressorEnable (void) const
-{
-	return m_bCompressorEnable;
-}
-
 bool CPerformanceConfig::GetReverbEnable (void) const
 {
 	return m_bReverbEnable;
@@ -524,11 +530,6 @@ unsigned CPerformanceConfig::GetReverbDiffusion (void) const
 unsigned CPerformanceConfig::GetReverbLevel (void) const
 {
 	return m_nReverbLevel;
-}
-
-void CPerformanceConfig::SetCompressorEnable (bool bValue)
-{
-	m_bCompressorEnable = bValue;
 }
 
 void CPerformanceConfig::SetReverbEnable (bool bValue)
@@ -735,6 +736,18 @@ unsigned CPerformanceConfig::GetAftertouchTarget (unsigned nTG) const
 {
 	assert (nTG < CConfig::AllToneGenerators);
 	return m_nAftertouchTarget[nTG];
+}
+
+void CPerformanceConfig::SetCompressorEnable (bool bValue, unsigned nTG)
+{
+	assert (nTG < CConfig::AllToneGenerators);
+	m_bCompressorEnable[nTG] = bValue;
+}
+
+bool CPerformanceConfig::GetCompressorEnable (unsigned nTG) const
+{
+	assert (nTG < CConfig::AllToneGenerators);
+	return m_bCompressorEnable[nTG];
 }
 
 void CPerformanceConfig::SetVoiceDataToTxt (const uint8_t *pData, unsigned nTG)  

--- a/src/performanceconfig.cpp
+++ b/src/performanceconfig.cpp
@@ -237,6 +237,14 @@ bool CPerformanceConfig::Load (void)
 	m_nReverbDiffusion = m_Properties.GetNumber ("ReverbDiffusion", 65);
 	m_nReverbLevel = m_Properties.GetNumber ("ReverbLevel", 99);
 
+	m_bLimiterEnable = m_Properties.GetNumber ("LimiterEnable", 1);
+	m_nLimiterPreGain = m_Properties.GetSignedNumber ("LimiterPreGain", 0);
+	m_nLimiterAttack = m_Properties.GetNumber ("LimiterAttack", 5);
+	m_nLimiterRelease = m_Properties.GetNumber ("LimiterRelease", 5);
+	m_nLimiterThresh = m_Properties.GetSignedNumber ("LimiterThresh", -3);
+	m_nLimiterRatio = m_Properties.GetNumber ("LimiterRatio", 20);
+	m_bLimiterHPFilterEnable = m_Properties.GetNumber ("LimiterHPFilterEnable", 0);
+
 	// Compatibility
 	if (m_Properties.IsSet ("CompressorEnable") && m_Properties.GetNumber ("CompressorEnable", 1) == 0)
 	{
@@ -379,6 +387,14 @@ bool CPerformanceConfig::Save (void)
 	m_Properties.SetNumber ("ReverbLowPass", m_nReverbLowPass);
 	m_Properties.SetNumber ("ReverbDiffusion", m_nReverbDiffusion);
 	m_Properties.SetNumber ("ReverbLevel", m_nReverbLevel);
+
+	m_Properties.SetNumber ("LimiterEnable", m_bLimiterEnable);
+	m_Properties.SetSignedNumber ("LimiterPreGain", m_nLimiterPreGain);
+	m_Properties.SetNumber ("LimiterAttack", m_nLimiterAttack);
+	m_Properties.SetNumber ("LimiterRelease", m_nLimiterRelease);
+	m_Properties.SetSignedNumber ("LimiterThresh", m_nLimiterThresh);
+	m_Properties.SetNumber ("LimiterRatio", m_nLimiterRatio);
+	m_Properties.SetNumber ("LimiterHPFilterEnable", m_bLimiterHPFilterEnable);
 
 	return m_Properties.Save ();
 }
@@ -596,6 +612,77 @@ void CPerformanceConfig::SetReverbLevel (unsigned nValue)
 {
 	m_nReverbLevel = nValue;
 }
+
+bool CPerformanceConfig::GetLimiterEnable () const
+{
+	return m_bLimiterEnable;
+}
+
+int CPerformanceConfig::GetLimiterPreGain () const
+{
+	return m_nLimiterPreGain;
+}
+
+unsigned CPerformanceConfig::GetLimiterAttack () const
+{
+	return m_nLimiterAttack;
+}
+
+unsigned CPerformanceConfig::GetLimiterRelease () const
+{
+	return m_nLimiterRelease;
+}
+
+int CPerformanceConfig::GetLimiterThresh () const
+{
+	return m_nLimiterThresh;
+}
+
+unsigned CPerformanceConfig::GetLimiterRatio () const
+{
+	return m_nLimiterRatio;
+}
+
+bool CPerformanceConfig::GetLimiterHPFilterEnable () const
+{
+	return m_bLimiterHPFilterEnable;
+}
+
+void CPerformanceConfig::SetLimiterEnable (bool nValue)
+{
+	m_bLimiterEnable = nValue;
+}
+
+void CPerformanceConfig::SetLimiterPreGain (int nValue)
+{
+	m_nLimiterPreGain= nValue;
+}
+
+void CPerformanceConfig::SetLimiterAttack (unsigned nValue)
+{
+	m_nLimiterAttack = nValue;
+}
+
+void CPerformanceConfig::SetLimiterRelease (unsigned nValue)
+{
+	m_nLimiterRelease = nValue;
+}
+
+void CPerformanceConfig::SetLimiterThresh (int nValue)
+{
+	m_nLimiterThresh = nValue;
+}
+
+void CPerformanceConfig::SetLimiterRatio (unsigned nValue)
+{
+	m_nLimiterRatio = nValue;
+}
+
+void CPerformanceConfig::SetLimiterHPFilterEnable (bool nValue)
+{
+	m_bLimiterHPFilterEnable = nValue;
+}
+
 // Pitch bender and portamento:
 void CPerformanceConfig::SetPitchBendRange (unsigned nValue, unsigned nTG)
 {

--- a/src/performanceconfig.cpp
+++ b/src/performanceconfig.cpp
@@ -212,6 +212,21 @@ bool CPerformanceConfig::Load (void)
 		PropertyName.Format ("CompressorEnable%u", nTG+1);
 		m_bCompressorEnable[nTG] = m_Properties.GetNumber (PropertyName, 1);
 		
+		PropertyName.Format ("CompressorPreGain%u", nTG+1);
+		m_nCompressorPreGain[nTG] = m_Properties.GetSignedNumber (PropertyName, 0);
+
+		PropertyName.Format ("CompressorAttack%u", nTG+1);
+		m_nCompressorAttack[nTG] = m_Properties.GetNumber (PropertyName, 5);
+
+		PropertyName.Format ("CompressorRelease%u", nTG+1);
+		m_nCompressorRelease[nTG] = m_Properties.GetNumber (PropertyName, 200);
+
+		PropertyName.Format ("CompressorThresh%u", nTG+1);
+		m_nCompressorThresh[nTG] = m_Properties.GetSignedNumber (PropertyName, -20);
+
+		PropertyName.Format ("CompressorRatio%u", nTG+1);
+		m_nCompressorRatio[nTG] = m_Properties.GetNumber (PropertyName, 5);
+
 		}
 
 	m_bReverbEnable = m_Properties.GetNumber ("ReverbEnable", 1) != 0;
@@ -339,6 +354,21 @@ bool CPerformanceConfig::Save (void)
 
 		PropertyName.Format ("CompressorEnable%u", nTG+1);
 		m_Properties.SetNumber (PropertyName, m_bCompressorEnable[nTG]);
+
+		PropertyName.Format ("CompressorPreGain%u", nTG+1);
+		m_Properties.SetSignedNumber (PropertyName, m_nCompressorPreGain[nTG]);
+
+		PropertyName.Format ("CompressorAttack%u", nTG+1);
+		m_Properties.SetNumber (PropertyName, m_nCompressorAttack[nTG]);
+
+		PropertyName.Format ("CompressorRelease%u", nTG+1);
+		m_Properties.SetNumber (PropertyName, m_nCompressorRelease[nTG]);
+
+		PropertyName.Format ("CompressorThresh%u", nTG+1);
+		m_Properties.SetSignedNumber (PropertyName, m_nCompressorThresh[nTG]);
+
+		PropertyName.Format ("CompressorRatio%u", nTG+1);
+		m_Properties.SetNumber (PropertyName, m_nCompressorRatio[nTG]);
 
 		}
 
@@ -749,6 +779,67 @@ bool CPerformanceConfig::GetCompressorEnable (unsigned nTG) const
 	assert (nTG < CConfig::AllToneGenerators);
 	return m_bCompressorEnable[nTG];
 }
+
+void CPerformanceConfig::SetCompressorPreGain (int nValue, unsigned nTG)
+{
+	assert (nTG < CConfig::AllToneGenerators);
+	m_nCompressorPreGain[nTG] = nValue;
+}
+
+int CPerformanceConfig::GetCompressorPreGain (unsigned nTG) const
+{
+	assert (nTG < CConfig::AllToneGenerators);
+	return m_nCompressorPreGain[nTG];
+}
+
+void CPerformanceConfig::SetCompressorAttack (unsigned nValue, unsigned nTG)
+{
+	assert (nTG < CConfig::AllToneGenerators);
+	m_nCompressorAttack[nTG] = nValue;
+}
+
+unsigned CPerformanceConfig::GetCompressorAttack (unsigned nTG) const
+{
+	assert (nTG < CConfig::AllToneGenerators);
+	return m_nCompressorAttack[nTG];
+}
+
+void CPerformanceConfig::SetCompressorRelease (unsigned nValue, unsigned nTG)
+{
+	assert (nTG < CConfig::AllToneGenerators);
+	m_nCompressorRelease[nTG] = nValue;
+}
+
+unsigned CPerformanceConfig::GetCompressorRelease (unsigned nTG) const
+{
+	assert (nTG < CConfig::AllToneGenerators);
+	return m_nCompressorRelease[nTG];
+}
+
+void CPerformanceConfig::SetCompressorThresh (int nValue, unsigned nTG)
+{
+	assert (nTG < CConfig::AllToneGenerators);
+	m_nCompressorThresh[nTG] = nValue;
+}
+
+int CPerformanceConfig::GetCompressorThresh (unsigned nTG) const
+{
+	assert (nTG < CConfig::AllToneGenerators);
+	return m_nCompressorThresh[nTG];
+}
+
+void CPerformanceConfig::SetCompressorRatio (unsigned nValue, unsigned nTG)
+{
+	assert (nTG < CConfig::AllToneGenerators);
+	m_nCompressorRatio[nTG] = nValue;
+}
+
+unsigned CPerformanceConfig::GetCompressorRatio (unsigned nTG) const
+{
+	assert (nTG < CConfig::AllToneGenerators);
+	return m_nCompressorRatio[nTG];
+}
+
 
 void CPerformanceConfig::SetVoiceDataToTxt (const uint8_t *pData, unsigned nTG)  
 {

--- a/src/performanceconfig.h
+++ b/src/performanceconfig.h
@@ -132,6 +132,22 @@ public:
 	void SetReverbDiffusion (unsigned nValue);
 	void SetReverbLevel (unsigned nValue);
 
+	bool GetLimiterEnable () const;
+	int GetLimiterPreGain () const;
+	unsigned GetLimiterAttack () const;
+	unsigned GetLimiterRelease () const;
+	int GetLimiterThresh () const;
+	unsigned GetLimiterRatio () const;
+	bool GetLimiterHPFilterEnable () const;
+
+	void SetLimiterEnable (bool nValue);
+	void SetLimiterPreGain (int nValue);
+	void SetLimiterAttack (unsigned nValue);
+	void SetLimiterRelease (unsigned nValue);	
+	void SetLimiterThresh (int nValue);
+	void SetLimiterRatio (unsigned nValue);
+	void SetLimiterHPFilterEnable (bool nValue);
+
 	bool VoiceDataFilled(unsigned nTG);
 	bool ListPerformances(); 
 	//std::string m_DirName;
@@ -222,6 +238,14 @@ private:
 	unsigned m_nReverbLowPass;
 	unsigned m_nReverbDiffusion;
 	unsigned m_nReverbLevel;
+
+	bool m_bLimiterEnable;
+	int m_nLimiterPreGain;
+	unsigned m_nLimiterAttack;
+	unsigned m_nLimiterRelease;
+	int m_nLimiterThresh;
+	unsigned m_nLimiterRatio;
+	bool m_bLimiterHPFilterEnable;
 };
 
 #endif

--- a/src/performanceconfig.h
+++ b/src/performanceconfig.h
@@ -71,6 +71,8 @@ public:
 	unsigned GetAftertouchRange (unsigned nTG) const; // 0 .. 99
 	unsigned GetAftertouchTarget (unsigned nTG) const;  // 0 .. 7
 
+	bool GetCompressorEnable (unsigned nTG) const; 		// 0 .. 1
+
 	void SetBankNumber (unsigned nValue, unsigned nTG);
 	void SetVoiceNumber (unsigned nValue, unsigned nTG);
 	void SetMIDIChannel (unsigned nValue, unsigned nTG);
@@ -101,8 +103,9 @@ public:
 	void SetAftertouchRange (unsigned nValue, unsigned nTG);
 	void SetAftertouchTarget (unsigned nValue, unsigned nTG);
 
+	void SetCompressorEnable (bool bCompressor, unsigned nTG);
+
 	// Effects
-	bool GetCompressorEnable (void) const;
 	bool GetReverbEnable (void) const;
 	unsigned GetReverbSize (void) const;			// 0 .. 99
 	unsigned GetReverbHighDamp (void) const;		// 0 .. 99
@@ -111,7 +114,6 @@ public:
 	unsigned GetReverbDiffusion (void) const;		// 0 .. 99
 	unsigned GetReverbLevel (void) const;			// 0 .. 99
 
-	void SetCompressorEnable (bool bValue);
 	void SetReverbEnable (bool bValue);
 	void SetReverbSize (unsigned nValue);
 	void SetReverbHighDamp (unsigned nValue);
@@ -181,7 +183,9 @@ private:
 	unsigned m_nBreathControlRange[CConfig::AllToneGenerators];	
 	unsigned m_nBreathControlTarget[CConfig::AllToneGenerators];	
 	unsigned m_nAftertouchRange[CConfig::AllToneGenerators];	
-	unsigned m_nAftertouchTarget[CConfig::AllToneGenerators];	
+	unsigned m_nAftertouchTarget[CConfig::AllToneGenerators];
+	
+	bool m_bCompressorEnable[CConfig::AllToneGenerators];
 
 	unsigned m_nLastPerformance;  
 	unsigned m_nActualPerformance = 0;  
@@ -196,7 +200,6 @@ private:
 
 	std::string NewPerformanceName="";
 	
-	bool m_bCompressorEnable;
 	bool m_bReverbEnable;
 	unsigned m_nReverbSize;
 	unsigned m_nReverbHighDamp;

--- a/src/performanceconfig.h
+++ b/src/performanceconfig.h
@@ -72,6 +72,11 @@ public:
 	unsigned GetAftertouchTarget (unsigned nTG) const;  // 0 .. 7
 
 	bool GetCompressorEnable (unsigned nTG) const; 		// 0 .. 1
+	int GetCompressorPreGain (unsigned nTG) const;
+	unsigned GetCompressorAttack (unsigned nTG) const;
+	unsigned GetCompressorRelease (unsigned nTG) const;
+	int GetCompressorThresh (unsigned nTG) const;
+	unsigned GetCompressorRatio (unsigned nTG) const;
 
 	void SetBankNumber (unsigned nValue, unsigned nTG);
 	void SetVoiceNumber (unsigned nValue, unsigned nTG);
@@ -103,7 +108,12 @@ public:
 	void SetAftertouchRange (unsigned nValue, unsigned nTG);
 	void SetAftertouchTarget (unsigned nValue, unsigned nTG);
 
-	void SetCompressorEnable (bool bCompressor, unsigned nTG);
+	void SetCompressorEnable (bool nValue, unsigned nTG);
+	void SetCompressorPreGain (int nValue, unsigned nTG);
+	void SetCompressorAttack (unsigned nValue, unsigned nTG);
+	void SetCompressorRelease (unsigned nValue, unsigned nTG);	
+	void SetCompressorThresh (int nValue, unsigned nTG);
+	void SetCompressorRatio (unsigned nValue, unsigned nTG);
 
 	// Effects
 	bool GetReverbEnable (void) const;
@@ -186,6 +196,11 @@ private:
 	unsigned m_nAftertouchTarget[CConfig::AllToneGenerators];
 	
 	bool m_bCompressorEnable[CConfig::AllToneGenerators];
+	int m_nCompressorPreGain[CConfig::AllToneGenerators];
+	unsigned m_nCompressorAttack[CConfig::AllToneGenerators];
+	unsigned m_nCompressorRelease[CConfig::AllToneGenerators];
+	int m_nCompressorThresh[CConfig::AllToneGenerators];
+	unsigned m_nCompressorRatio[CConfig::AllToneGenerators];
 
 	unsigned m_nLastPerformance;  
 	unsigned m_nActualPerformance = 0;  

--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -63,7 +63,9 @@ const CUIMenu::TMenuItem CUIMenu::s_MainMenu[] =
 	{"TG16",	MenuHandler,	s_TGMenu, 15},
 #endif
 #endif
+#ifdef ARM_ALLOW_MULTI_CORE
 	{"Effects",	MenuHandler,	s_EffectsMenu},
+#endif
 	{"Master Volume", EditMasterVolume, 0, 0},
 	{"Performance",	MenuHandler, s_PerformanceMenu}, 
 	{0}
@@ -86,13 +88,19 @@ const CUIMenu::TMenuItem CUIMenu::s_TGMenu[] =
 	{"Poly/Mono",		EditTGParameter,	0,	CMiniDexed::TGParameterMonoMode}, 
 	{"Modulation",		MenuHandler,		s_ModulationMenu},
 	{"Channel",	EditTGParameter,	0,	CMiniDexed::TGParameterMIDIChannel},
+	{"Compressor",	MenuHandler,		s_EditCompressorMenu},
 	{"Edit Voice",	MenuHandler,		s_EditVoiceMenu},
+	{0}
+};
+
+const CUIMenu::TMenuItem CUIMenu::s_EditCompressorMenu[] =
+{
+	{"Enable",	EditTGParameter2,	0,	CMiniDexed::TGParameterCompressorEnable},
 	{0}
 };
 
 const CUIMenu::TMenuItem CUIMenu::s_EffectsMenu[] =
 {
-	{"Compress",	EditGlobalParameter,	0,	CMiniDexed::ParameterCompressorEnable},
 #ifdef ARM_ALLOW_MULTI_CORE
 	{"Reverb",	MenuHandler,		s_ReverbMenu},
 #endif
@@ -218,7 +226,6 @@ const CUIMenu::TMenuItem CUIMenu::s_SaveMenu[] =
 // must match CMiniDexed::TParameter
 const CUIMenu::TParameter CUIMenu::s_GlobalParameter[CMiniDexed::ParameterUnknown] =
 {
-	{0,	1,	1,	ToOnOff},		// ParameterCompessorEnable
 	{0,	1,	1,	ToOnOff},		// ParameterReverbEnable
 	{0,	99,	1},				// ParameterReverbSize
 	{0,	99,	1},				// ParameterReverbHighDamp
@@ -265,7 +272,8 @@ const CUIMenu::TParameter CUIMenu::s_TGParameter[CMiniDexed::TGParameterUnknown]
 	{0, 99, 1}, //AT Range
 	{0, 1, 1, ToOnOff}, //AT Pitch
 	{0, 1, 1, ToOnOff}, //AT Amp
-	{0, 1, 1, ToOnOff} //AT EGBias	
+	{0, 1, 1, ToOnOff}, //AT EGBias	
+	{0,	1,	1,	ToOnOff},	// TGParameterCompressorEnable
 };
 
 // must match DexedVoiceParameters in Synth_Dexed

--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -108,6 +108,7 @@ const CUIMenu::TMenuItem CUIMenu::s_EffectsMenu[] =
 {
 #ifdef ARM_ALLOW_MULTI_CORE
 	{"Reverb",	MenuHandler,		s_ReverbMenu},
+	{"Limiter",	MenuHandler,		s_LimiterMenu},
 #endif
 	{0}
 };
@@ -156,6 +157,18 @@ const CUIMenu::TMenuItem CUIMenu::s_ReverbMenu[] =
 	{"Low pass",	EditGlobalParameter,	0,	CMiniDexed::ParameterReverbLowPass},
 	{"Diffusion",	EditGlobalParameter,	0,	CMiniDexed::ParameterReverbDiffusion},
 	{"Level",	EditGlobalParameter,	0,	CMiniDexed::ParameterReverbLevel},
+	{0}
+};
+
+const CUIMenu::TMenuItem CUIMenu::s_LimiterMenu[] =
+{
+	{"Enable",	EditGlobalParameter,	0,	CMiniDexed::ParameterLimiterEnable},
+	{"Pre Gain",	EditGlobalParameter,	0,	CMiniDexed::ParameterLimiterPreGain},
+	{"Attack",	EditGlobalParameter,	0,	CMiniDexed::ParameterLimiterAttack},
+	{"Release",	EditGlobalParameter,	0,	CMiniDexed::ParameterLimiterRelease},
+	{"Threshold",	EditGlobalParameter,	0,	CMiniDexed::ParameterLimiterThresh},
+	{"Ratio",	EditGlobalParameter,	0,	CMiniDexed::ParameterLimiterRatio},
+	{"HPFilter",	EditGlobalParameter,	0,	CMiniDexed::ParameterLimiterHPFilterEnable},
 	{0}
 };
 
@@ -239,7 +252,14 @@ const CUIMenu::TParameter CUIMenu::s_GlobalParameter[CMiniDexed::ParameterUnknow
 	{0,	99,	1},				// ParameterReverbDiffusion
 	{0,	99,	1},				// ParameterReverbLevel
 	{0,	CMIDIDevice::ChannelUnknown-1,		1, ToMIDIChannel}, 	// ParameterPerformanceSelectChannel
-	{0, NUM_PERFORMANCE_BANKS, 1}	// ParameterPerformanceBank
+	{0, NUM_PERFORMANCE_BANKS, 1},			// ParameterPerformanceBank
+	{0,	1,	1,	ToOnOff},		// ParameterLimiterEnable
+	{-20,	20,	1,	TodB},			// ParameterLimiterPreGain
+	{0,	1000,	5,	ToMillisec},		// ParameterLimiterAttack
+	{0,	1000,	5,	ToMillisec},		// ParameterLimiterRelease
+	{-60,	0,	1,	TodBFS},		// ParameterLimiterThresh
+	{1,	20,	1,	ToRatio},		// ParameterLimiterRatio
+	{0,	1,	1,	ToOnOff},		// ParameterLimiterHPFilterEnable
 };
 
 // must match CMiniDexed::TTGParameter

--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -96,6 +96,11 @@ const CUIMenu::TMenuItem CUIMenu::s_TGMenu[] =
 const CUIMenu::TMenuItem CUIMenu::s_EditCompressorMenu[] =
 {
 	{"Enable",	EditTGParameter2,	0,	CMiniDexed::TGParameterCompressorEnable},
+	{"Pre Gain",	EditTGParameter2,	0,	CMiniDexed::TGParameterCompressorPreGain},
+	{"Attack",	EditTGParameter2,	0,	CMiniDexed::TGParameterCompressorAttack},
+	{"Release",	EditTGParameter2,	0,	CMiniDexed::TGParameterCompressorRelease},
+	{"Threshold",	EditTGParameter2,	0,	CMiniDexed::TGParameterCompressorThresh},
+	{"Ratio",	EditTGParameter2,	0,	CMiniDexed::TGParameterCompressorRatio},
 	{0}
 };
 
@@ -274,6 +279,11 @@ const CUIMenu::TParameter CUIMenu::s_TGParameter[CMiniDexed::TGParameterUnknown]
 	{0, 1, 1, ToOnOff}, //AT Amp
 	{0, 1, 1, ToOnOff}, //AT EGBias	
 	{0,	1,	1,	ToOnOff},	// TGParameterCompressorEnable
+	{-20,	20,	1,	TodB},		// TGParameterCompressorPreGain
+	{0,	1000,	5,	ToMillisec},	// TGParameterCompressorAttack
+	{0,	1000,	5,	ToMillisec},	// TGParameterCompressorRelease
+	{-60,	0,	1,	TodBFS},	// TGParameterCompressorThresh
+	{1,	20,	1,	ToRatio},	// TGParameterCompressorRatio
 };
 
 // must match DexedVoiceParameters in Synth_Dexed
@@ -1245,6 +1255,26 @@ string CUIMenu::ToPolyMono (int nValue)
 	case 1:		return "Mono";
 	default:	return to_string (nValue);
 	}
+}
+
+std::string CUIMenu::TodB (int nValue)
+{
+	return std::to_string (nValue) + " dB";
+}
+
+std::string CUIMenu::TodBFS (int nValue)
+{
+	return std::to_string (nValue) + " dBFS";
+}
+
+std::string CUIMenu::ToMillisec (int nValue)
+{
+	return std::to_string (nValue) + " ms";
+}
+
+std::string CUIMenu::ToRatio (int nValue)
+{
+	return std::to_string (nValue) + ":1";
 }
 
 void CUIMenu::TGShortcutHandler (TMenuEvent Event)

--- a/src/uimenu.h
+++ b/src/uimenu.h
@@ -160,6 +160,7 @@ private:
 	static const TMenuItem s_TGMenu[];
 	static const TMenuItem s_EffectsMenu[];
 	static const TMenuItem s_ReverbMenu[];
+	static const TMenuItem s_LimiterMenu[];
 	static const TMenuItem s_EditCompressorMenu[];
 	static const TMenuItem s_EditVoiceMenu[];
 	static const TMenuItem s_OperatorMenu[];

--- a/src/uimenu.h
+++ b/src/uimenu.h
@@ -156,6 +156,7 @@ private:
 	static const TMenuItem s_TGMenu[];
 	static const TMenuItem s_EffectsMenu[];
 	static const TMenuItem s_ReverbMenu[];
+	static const TMenuItem s_EditCompressorMenu[];
 	static const TMenuItem s_EditVoiceMenu[];
 	static const TMenuItem s_OperatorMenu[];
 	static const TMenuItem s_SaveMenu[];

--- a/src/uimenu.h
+++ b/src/uimenu.h
@@ -118,6 +118,10 @@ private:
 	static std::string ToPortaMode (int nValue);  
 	static std::string ToPortaGlissando (int nValue);   
 	static std::string ToPolyMono (int nValue);
+	static std::string TodB (int nValue);
+	static std::string TodBFS (int nValue);
+	static std::string ToMillisec (int nValue);
+	static std::string ToRatio (int nValue);
 
 	void TGShortcutHandler (TMenuEvent Event);
 	void OPShortcutHandler (TMenuEvent Event);

--- a/submod.sh
+++ b/submod.sh
@@ -18,6 +18,6 @@ cd -
 #cd -
 
 # Use fixed master branch of Synth_Dexed
-cd Synth_Dexed/
-git checkout -f 3c683fc801
-cd -
+#cd Synth_Dexed/
+#git checkout -f a02b5c0bf2da132f49a923f9c69796220a8ea93f
+#cd -


### PR DESCRIPTION
## Summary by Sourcery

Introduce per-tone generator compressor controls by adding enable, pregain, attack, release, threshold, and ratio parameters to performance configuration, synthesizer engine, and the UI, and move compressor settings from global effects to the TG menu.

New Features:
- Add per-TG compressor parameters (enable, pregain, attack, release, threshold, ratio) to CPerformanceConfig and CMiniDexed
- Expose compressor controls in the UI under a dedicated TG submenu with custom formatting for dB, ms, and ratio values

Enhancements:
- Move compressor settings from the global effects menu into the tone generator menu for individual TG configuration
- Provide compatibility handling for the legacy global compressor enable flag in performance loading