### PR TITLE
Fix high-pass filter in compressor

### DIFF
--- a/submod.sh
+++ b/submod.sh
@@ -19,5 +19,5 @@ cd -
 
 # Use fixed master branch of Synth_Dexed
 cd Synth_Dexed/
-git checkout -f 3c683fc801
+git checkout -f 8ae8bb1cea7cffa07d2d258218130b90b744893e
 cd -


### PR DESCRIPTION
The coefficients of the high-pass filter were calculated for a sampling frequency of 44100 Hz.
This causes the filter to behave differently at different sampling rates.
I calculated the values for all the common frequencies and this was [included](https://codeberg.org/dcoredump/Synth_Dexed/pulls/30) in Synth_Dexed.
This may cause a slight difference in the sound at a sampling rate of 48000 Hz. So this can be tested here.

These are the diagrams:
44100 Hz
<img width="1038" height="382" alt="Screenshot From 2025-07-31 16-17-33" src="https://github.com/user-attachments/assets/386b7ea2-d298-4005-83f7-b0e02a31d47b" />

48000 Hz (previous)
<img width="1038" height="382" alt="Screenshot From 2025-07-31 16-17-45" src="https://github.com/user-attachments/assets/2a66d034-d1e4-48f7-95aa-061b85223708" />

96000 Hz (previous)
<img width="1038" height="382" alt="Screenshot From 2025-07-31 16-17-50" src="https://github.com/user-attachments/assets/d3305dd1-3f01-4992-ac46-e1522b093d65" />

48000 Hz (fixed)
<img width="1038" height="382" alt="Screenshot From 2025-07-31 16-19-49" src="https://github.com/user-attachments/assets/0d265122-bbe6-4c2e-b184-2c2ca370bdb1" />

96000 Hz (fixed)
<img width="1038" height="382" alt="Screenshot From 2025-07-31 16-20-56" src="https://github.com/user-attachments/assets/8fd6a38b-2f85-4d17-97e8-a400ff3803da" />

## Summary by Sourcery

Chores:
- Bump Synth_Dexed submodule reference to commit 8ae8bb1cea7cffa07d2d258218130b90b744893e containing the high-pass filter fix