### PR TITLE
fix ftp based denial of service attack.

### DIFF
--- a/src/net/ftpworker.cpp
+++ b/src/net/ftpworker.cpp
@@ -1057,7 +1057,15 @@ bool CFTPWorker::RenameTo(const char* pArgs)
 
 bool CFTPWorker::Bye(const char* pArgs)
 {
-	SendStatus(TFTPStatus::ClosingControl, "Goodbye.");
+	if (!CheckLoggedIn())
+	{
+		SendStatus(TFTPStatus::ClosingControl, "Goodbye.");
+		delete m_pControlSocket;
+		m_pControlSocket = nullptr;
+		return true;
+	}
+
+	SendStatus(TFTPStatus::ClosingControl, "Goodbye. Rebooting");
 	delete m_pControlSocket;
 	m_pControlSocket = nullptr;
 


### PR DESCRIPTION
The autoreboot feature can be abused as you dont need a valid login to trigger the reboot.

This fix will only auto reboot after you quit a logged in session.

## Summary by Sourcery

Bug Fixes:
- Require authentication to trigger FTP autoreboot, preventing denial-of-service via unauthenticated sessions.