### PR TITLE
bugfix: midi thru from udp to usb triggers an assert()

### DIFF
--- a/src/udpmididevice.cpp
+++ b/src/udpmididevice.cpp
@@ -28,7 +28,7 @@
 #include <circle/net/netsubsystem.h>
 #include <circle/net/in.h>
 
-#define VIRTUALCABLE 24
+#define VIRTUALCABLE 0
 
 LOGMODULE("udpmididevice");
 


### PR DESCRIPTION
usbmidi.cpp(91): assertion failed: Cable <= 15

usbmidi supports 16 virtual cables (nCable in the code).
Midi message received from udp sets this to 24 which is invalid. 
This replaces 24 with 0 but perhaps something configurable or dynamic could be done.

## Summary by Sourcery

Bug Fixes:
- Normalize UDP-originated MIDI messages that use an out-of-range virtual cable number so they map to a valid USB MIDI cable and avoid assertion failures.