### PR TITLE
WIP: UI can be sent over udp

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -238,6 +238,8 @@ void CConfig::Load (void)
 	if (const u8 *pIP = m_Properties.GetIPAddress ("NetworkSyslogServerIPAddress")) m_INetworkSyslogServerIPAddress.Set (pIP);
 	m_bUDPMIDIEnabled = m_Properties.GetNumber("UDPMIDIEnabled", 0) != 0;
 	if (const u8 *pIP = m_Properties.GetIPAddress("UDPMIDIIPAddress")) m_IUDPMIDIIPAddress.Set (pIP);
+	m_bUDPDisplayEnabled = m_Properties.GetNumber("UDPDisplayEnabled", 0) != 0;
+	if (const u8 *pIP = m_Properties.GetIPAddress("UDPDisplayIPAddress")) m_IUDPDisplayIPAddress.Set (pIP);
 
 	m_nMasterVolume = m_Properties.GetNumber ("MasterVolume", 64);
 }
@@ -847,4 +849,14 @@ bool CConfig::GetUDPMIDIEnabled (void) const
 const CIPAddress& CConfig::GetUDPMIDIIPAddress (void) const
 {
 	return m_IUDPMIDIIPAddress;
+}
+
+bool CConfig::GetUDPDisplayEnabled (void) const
+{
+	return m_bUDPDisplayEnabled;
+}
+
+const CIPAddress& CConfig::GetUDPDisplayIPAddress (void) const
+{
+	return m_IUDPDisplayIPAddress;
 }

--- a/src/config.h
+++ b/src/config.h
@@ -260,6 +260,8 @@ public:
 	bool GetNetworkFTPEnabled (void) const;
 	bool GetUDPMIDIEnabled (void) const;
 	const CIPAddress& GetUDPMIDIIPAddress (void) const;
+	bool GetUDPDisplayEnabled (void) const;
+	const CIPAddress& GetUDPDisplayIPAddress (void) const;
 
 private:
 	CPropertiesFatFsFile m_Properties;
@@ -396,6 +398,8 @@ private:
 	bool m_bNetworkFTPEnabled;
 	bool m_bUDPMIDIEnabled;
 	CIPAddress m_IUDPMIDIIPAddress;
+	bool m_bUDPDisplayEnabled;
+	CIPAddress m_IUDPDisplayIPAddress;
 };
 
 #endif

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -2276,6 +2276,8 @@ void CMiniDexed::UpdateNetwork()
 		CString IPString;
 		m_pNet->GetConfig()->GetIPAddress()->Format(&IPString);
 
+		m_UI.InitUDP ();
+
 		if (m_UDPMIDI)
 		{
 			m_UDPMIDI->Initialize();
@@ -2339,8 +2341,6 @@ void CMiniDexed::UpdateNetwork()
 		{
 			LOGNOTE ("Syslog server is not enabled in configuration");
 		}
-
-		m_UI.InitUDP ();
 
 		m_bNetworkReady = true;
 	}

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -2339,6 +2339,9 @@ void CMiniDexed::UpdateNetwork()
 		{
 			LOGNOTE ("Syslog server is not enabled in configuration");
 		}
+
+		m_UI.InitUDP ();
+
 		m_bNetworkReady = true;
 	}
 

--- a/src/net/ftpworker.cpp
+++ b/src/net/ftpworker.cpp
@@ -1057,7 +1057,15 @@ bool CFTPWorker::RenameTo(const char* pArgs)
 
 bool CFTPWorker::Bye(const char* pArgs)
 {
-	SendStatus(TFTPStatus::ClosingControl, "Goodbye.");
+	if (!CheckLoggedIn())
+	{
+		SendStatus(TFTPStatus::ClosingControl, "Goodbye.");
+		delete m_pControlSocket;
+		m_pControlSocket = nullptr;
+		return true;
+	}
+
+	SendStatus(TFTPStatus::ClosingControl, "Goodbye. Rebooting");
 	delete m_pControlSocket;
 	m_pControlSocket = nullptr;
 

--- a/src/userinterface.cpp
+++ b/src/userinterface.cpp
@@ -50,6 +50,7 @@ CUserInterface::~CUserInterface (void)
 	delete m_pUIButtons;
 	delete m_pLCDBuffered;
 	delete m_pLCD;
+	if (m_pUDPSendSocket) delete m_pUDPSendSocket;
 }
 
 bool CUserInterface::InitUDP (void)
@@ -329,12 +330,13 @@ void CUserInterface::LCDWrite (const char *pString)
 
 void CUserInterface::UDPWrite (const char *pString)
 {
+	size_t len = strlen(pString);
 	if (m_pUDPSendSocket) {
-		int res = m_pUDPSendSocket->SendTo(pString, strlen(pString), 0, m_UDPDestAddress, m_UDPDestPort);
+		int res = m_pUDPSendSocket->SendTo(pString, len, 0, m_UDPDestAddress, m_UDPDestPort);
 		if (res < 0) {
-			LOGERR("Failed to send %u bytes to UDP display", strlen(pString));
+			LOGERR("Failed to send %u bytes to UDP display", (unsigned long) len);
 		} else {
-//            		LOGDBG("Sent %u bytes to UDP display", strlen(pString));
+//            		LOGDBG("Sent %u bytes to UDP display", (unsigned long) len);
 		}
 	}
 }

--- a/src/userinterface.h
+++ b/src/userinterface.h
@@ -31,6 +31,8 @@
 #include <circle/writebuffer.h>
 #include <circle/i2cmaster.h>
 #include <circle/spimaster.h>
+#include <circle/net/ipaddress.h>
+#include <circle/net/socket.h>
 
 class CMiniDexed;
 
@@ -41,6 +43,8 @@ public:
 	~CUserInterface (void);
 
 	bool Initialize (void);
+
+	bool InitUDP (void);
 
 	void Process (void);
 
@@ -60,6 +64,7 @@ public:
 
 private:
 	void LCDWrite (const char *pString);		// Print to optional HD44780 display
+	void UDPWrite (const char *pString);		// Print to optional HD44780 display
 
 	void EncoderEventHandler (CKY040::TEvent Event);
 	static void EncoderEventStub (CKY040::TEvent Event, void *pParam);
@@ -89,6 +94,10 @@ private:
 	bool m_bSwitchPressed;
 
 	CUIMenu m_Menu;
+
+	CSocket* m_pUDPSendSocket = nullptr;
+	CIPAddress m_UDPDestAddress;
+	unsigned m_UDPDestPort = 1306;
 };
 
 #endif


### PR DESCRIPTION
For your review only at this stage.

VERY! incomplete, but it does work.

If you're interested in getting this in I will:
- [ ]  Make it configurable!
- [ ] Look to eliminate Msg2. I may have to tweak the existing menu display code to explicitly move the cursor to the second line.

## Summary by Sourcery

Add support for mirroring the LCD user interface over UDP when networking is available.

New Features:
- Send the rendered two-line LCD menu display over UDP to a configured destination when the network stack becomes ready.

Enhancements:
- Extend the user interface component with UDP socket initialization and write helpers tied into the existing network startup flow.