### PR TITLE
Add support for half step and quarter step encoders

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -218,6 +218,7 @@ void CConfig::Load (void)
 	m_bEncoderEnabled = m_Properties.GetNumber ("EncoderEnabled", 0) != 0;
 	m_nEncoderPinClock = m_Properties.GetNumber ("EncoderPinClock", 10);
 	m_nEncoderPinData = m_Properties.GetNumber ("EncoderPinData", 9);
+	m_nEncoderDetents = m_Properties.GetNumber ("EncoderDetents", 4);
 
 	m_bMIDIDumpEnabled  = m_Properties.GetNumber ("MIDIDumpEnabled", 0) != 0;
 	m_bProfileEnabled = m_Properties.GetNumber ("ProfileEnabled", 0) != 0;
@@ -761,6 +762,11 @@ unsigned CConfig::GetEncoderPinClock (void) const
 unsigned CConfig::GetEncoderPinData (void) const
 {
 	return m_nEncoderPinData;
+}
+
+unsigned CConfig::GetEncoderDetents (void) const
+{
+	return m_nEncoderDetents;
 }
 
 bool CConfig::GetMIDIDumpEnabled (void) const

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -220,16 +220,16 @@ void CConfig::Load (void)
 	m_nEncoderPinData = m_Properties.GetNumber ("EncoderPinData", 9);
 	
 	// Parse encoder resolution
-	const char *pResolution = m_Properties.GetString ("EncoderResolution", "full");
-	if (strcasecmp (pResolution, "full") == 0)
+	std::string EncoderResolution = m_Properties.GetString ("EncoderResolution", "full");
+	if (EncoderResolution == "full")
 	{
 		m_nEncoderDetents = 4;
 	}
-	else if (strcasecmp (pResolution, "half") == 0)
+	else if (EncoderResolution == "half")
 	{
 		m_nEncoderDetents = 2;
 	}
-	else if (strcasecmp (pResolution, "quarter") == 0)
+	else if (EncoderResolution == "quarter")
 	{
 		m_nEncoderDetents = 1;
 	}

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -218,7 +218,26 @@ void CConfig::Load (void)
 	m_bEncoderEnabled = m_Properties.GetNumber ("EncoderEnabled", 0) != 0;
 	m_nEncoderPinClock = m_Properties.GetNumber ("EncoderPinClock", 10);
 	m_nEncoderPinData = m_Properties.GetNumber ("EncoderPinData", 9);
-	m_nEncoderDetents = m_Properties.GetNumber ("EncoderDetents", 4);
+	
+	// Parse encoder resolution
+	const char *pResolution = m_Properties.GetString ("EncoderResolution", "full");
+	if (strcasecmp (pResolution, "full") == 0)
+	{
+		m_nEncoderDetents = 4;
+	}
+	else if (strcasecmp (pResolution, "half") == 0)
+	{
+		m_nEncoderDetents = 2;
+	}
+	else if (strcasecmp (pResolution, "quarter") == 0)
+	{
+		m_nEncoderDetents = 1;
+	}
+	else
+	{
+		// Invalid value, use default
+		m_nEncoderDetents = 4;
+	}
 
 	m_bMIDIDumpEnabled  = m_Properties.GetNumber ("MIDIDumpEnabled", 0) != 0;
 	m_bProfileEnabled = m_Properties.GetNumber ("ProfileEnabled", 0) != 0;

--- a/src/config.h
+++ b/src/config.h
@@ -235,6 +235,7 @@ public:
 	bool GetEncoderEnabled (void) const;
 	unsigned GetEncoderPinClock (void) const;
 	unsigned GetEncoderPinData (void) const;
+	unsigned GetEncoderDetents (void) const;
 
 	// Debug
 	bool GetMIDIDumpEnabled (void) const;
@@ -374,6 +375,7 @@ private:
 	bool m_bEncoderEnabled;
 	unsigned m_nEncoderPinClock;
 	unsigned m_nEncoderPinData;
+	unsigned m_nEncoderDetents;
 
 	bool m_bMIDIDumpEnabled;
 	bool m_bProfileEnabled;

--- a/src/minidexed.ini
+++ b/src/minidexed.ini
@@ -151,6 +151,11 @@ MIDIButtonTGDown=56
 EncoderEnabled=1
 EncoderPinClock=10
 EncoderPinData=9
+# Detents per rotation to be recognized:
+#   1 = Quarter Step Encoder
+#   2 = Half Step Encoder
+#   4 = Full Step Encoder (default)
+EncoderDetents=4
 
 # Debug
 MIDIDumpEnabled=0

--- a/src/minidexed.ini
+++ b/src/minidexed.ini
@@ -151,11 +151,8 @@ MIDIButtonTGDown=56
 EncoderEnabled=1
 EncoderPinClock=10
 EncoderPinData=9
-# Detents per rotation to be recognized:
-#   1 = Quarter Step Encoder
-#   2 = Half Step Encoder
-#   4 = Full Step Encoder (default)
-EncoderDetents=4
+# Encoder resolution: full, half, or quarter (default: full)
+EncoderResolution=full
 
 # Debug
 MIDIDumpEnabled=0

--- a/src/userinterface.cpp
+++ b/src/userinterface.cpp
@@ -181,7 +181,8 @@ bool CUserInterface::Initialize (void)
 		m_pRotaryEncoder = new CKY040 (m_pConfig->GetEncoderPinClock (),
 					       m_pConfig->GetEncoderPinData (),
 					       m_pConfig->GetButtonPinShortcut (),
-					       m_pGPIOManager);
+					       m_pGPIOManager,
+					       m_pConfig->GetEncoderDetents ());
 		assert (m_pRotaryEncoder);
 
 		if (!m_pRotaryEncoder->Initialize ())

--- a/submod.sh
+++ b/submod.sh
@@ -6,12 +6,12 @@ git submodule update --init --recursive -f
 
 # Use fixed master branch of circle-stdlib then re-update
 cd circle-stdlib/
-git checkout -f --recurse-submodules 1111eee # Matches Circle Step49
+git checkout -f --recurse-submodules v17.2
 cd -
 
 # Optional update submodules explicitly
 cd circle-stdlib/libs/circle
-git checkout -f --recurse-submodules f18c60fa38042ea7132533e658abfafd5bd63435
+git checkout -f --recurse-submodules b42d060
 cd -
 #cd circle-stdlib/libs/circle-newlib
 #git checkout develop


### PR DESCRIPTION
### Summary
Adds a new `EncoderDetents` configuration option to support different rotary encoder hardware types, fixing compatibility issues with half-step and quarter-step encoders.

### Problem
MiniDexed uses the circle library to implement rotary encoders. This library only worked correctly with full-step encoders. Users with half-step encoders (increasingly common) experienced missed steps. This issue was discussed at

* https://github.com/probonopd/MiniDexed/discussions/803 and
* https://github.com/probonopd/MiniDexed/issues/89#issuecomment-1100604231

### Solution

1. Added support for half step and quarter step encoders in Circle and circle-stddlib
  * https://github.com/rsta2/circle/pull/638
  * https://github.com/smuehlst/circle-stdlib/pull/55
2. Added EncoderDetents configuration parameter in 'minidexed.ini' that allows users to specify their encoder type (4: full step encoder (default), 2: half step encoder, 1: quarter step encoder - other values also possible but likely not sensible)

### Changes
#### Configuration

* `minidexed.ini`: Added `EncoderDetents=4` with documentation
* `config.h`: Added `m_nEncoderDetents` member and getter
* `config.cpp`: Added parsing for `EncoderDetents`

#### Integration
* `userinterface.cpp`: Pass encoder detents value to CKY040 constructor
* `circle-stdlib`: Updated submodule for KY040 driver improvements

### Dependencies
This PR depends on:

* Circle PR: https://github.com/rsta2/circle/pull/683
* circle-stdlib PR: https://github.com/smuehlst/circle-stdlib/pull/55

### Testing
Build verified on Raspberry Pi 3
Tested on a Raspberry Pi 3 with a half step encoder (HW-040)
`EncoderDetents=2`: works correctly
`EncoderDetents=4`: maintains existing behaviour (only every second step is recognised)
`EncoderDetents=1`: two steps per detent

### Backward Compatibility
The default value (EncoderDetents=4) maintains existing behavior, so users with full-step encoders don't need to change anything.

## Summary by Sourcery

Add configurable support for different rotary encoder detent resolutions to improve compatibility with various encoder hardware.

New Features:
- Introduce an EncoderDetents configuration option to control the number of encoder detents per rotation.
- Pass the configured encoder detent value to the rotary encoder driver to support different encoder hardware types.

Enhancements:
- Extend the configuration system to store and expose encoder detent settings.
- Update the circle-stdlib submodule reference to pick up improved KY040 encoder handling.

Documentation:
- Document the new EncoderDetents option and its recommended values in minidexed.ini.