### PR TITLE
pckeyboard: add UI navigation buttons by sending MIDI CC.

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -265,16 +265,23 @@ void CConfig::Load (void)
 	m_nMasterVolume = m_Properties.GetNumber ("MasterVolume", 64);
 
 	// PC Keyboard
-	m_bPCKeyUseDefaultNotes = m_Properties.GetNumber("PCKeyUseDefaultNotes", 1) != 0;
 
 	CString PropertyName;
+	m_bPCKeyUseDefaultNotes = 1;
 	for (unsigned i = 0; i < 256; i++)
 	{
 		PropertyName.Format("PCKeyNote%d", i);
-		SetPCKeyNote(i, m_Properties.GetNumber((const char *)PropertyName, 0));
+		unsigned temp = m_Properties.GetNumber((const char *)PropertyName, 0);
+		SetPCKeyNote(i, temp);
+		if (temp)
+			m_bPCKeyUseDefaultNotes = 0;
 
 		PropertyName.Format("PCKeyCC%d", i);
 		SetPCKeyCC(i,m_Properties.GetNumber(PropertyName, 0));
+	}
+	if (m_bPCKeyUseDefaultNotes == 0) {
+		LOGNOTE("PC Keyboard using custom Note mapping");
+		CTimer::SimpleMsDelay(500);
 	}
 }
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -20,8 +20,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
+#include <circle/logger.h>
 #include "config.h"
 #include "../Synth_Dexed/src/dexed.h"
+
+LOGMODULE("config");
 
 CConfig::CConfig (FATFS *pFileSystem)
 :	m_Properties ("minidexed.ini", pFileSystem)
@@ -260,6 +263,19 @@ void CConfig::Load (void)
 	if (const u8 *pIP = m_Properties.GetIPAddress("UDPMIDIIPAddress")) m_IUDPMIDIIPAddress.Set (pIP);
 
 	m_nMasterVolume = m_Properties.GetNumber ("MasterVolume", 64);
+
+	// PC Keyboard
+	m_bPCKeyUseDefaultNotes = m_Properties.GetNumber("PCKeyUseDefaultNotes", 1) != 0;
+
+	CString PropertyName;
+	for (unsigned i = 0; i < 256; i++)
+	{
+		PropertyName.Format("PCKeyNote%d", i);
+		SetPCKeyNote(i, m_Properties.GetNumber((const char *)PropertyName, 0));
+
+		PropertyName.Format("PCKeyCC%d", i);
+		SetPCKeyCC(i,m_Properties.GetNumber(PropertyName, 0));
+	}
 }
 
 unsigned CConfig::GetToneGenerators (void) const
@@ -873,3 +889,29 @@ const CIPAddress& CConfig::GetUDPMIDIIPAddress (void) const
 {
 	return m_IUDPMIDIIPAddress;
 }
+
+const bool CConfig::GetPCKeyUseDefaultNotes (void) const
+{
+	return m_bPCKeyUseDefaultNotes;
+}
+
+const u8 CConfig::GetPCKeyNote (u8 usbkey) const
+{
+	return m_nPCKeyNoteMap[usbkey];
+}
+
+const u8 CConfig::GetPCKeyCC (u8 usbkey) const
+{
+	return m_nPCKeyCCMap[usbkey];
+}
+
+void CConfig::SetPCKeyNote (u8 usbkey, u8 note )
+{
+	m_nPCKeyNoteMap[usbkey] = note;
+}
+
+void CConfig::SetPCKeyCC (u8 usbkey, u8 cc )
+{
+	m_nPCKeyCCMap[usbkey] = cc;
+}
+

--- a/src/config.h
+++ b/src/config.h
@@ -262,6 +262,13 @@ public:
 	bool GetUDPMIDIEnabled (void) const;
 	const CIPAddress& GetUDPMIDIIPAddress (void) const;
 
+	// PC Keyboard mapping - USB HID key to note and CC
+	const bool GetPCKeyUseDefaultNotes () const;
+	const u8 GetPCKeyNote (u8 usbkey) const;
+	const u8 GetPCKeyCC (u8 usbkey) const;
+	void SetPCKeyNote (u8 usbkey, u8 note );
+	void SetPCKeyCC (u8 usbkey, u8 cc );
+
 private:
 	CPropertiesFatFsFile m_Properties;
 	
@@ -398,6 +405,11 @@ private:
 	bool m_bNetworkFTPEnabled;
 	bool m_bUDPMIDIEnabled;
 	CIPAddress m_IUDPMIDIIPAddress;
+
+	// PC Keyboard mapping - USB HID key to note and CC
+	bool m_bPCKeyUseDefaultNotes;
+	u8 m_nPCKeyNoteMap[256];
+	u8 m_nPCKeyCCMap[256];
 };
 
 #endif

--- a/src/minidexed.ini
+++ b/src/minidexed.ini
@@ -179,3 +179,25 @@ NetworkSyslogServerIPAddress=0
 
 # Performance
 PerformanceSelectToLoad=0
+
+# PC Keyboard mapping
+# use inbuilt map like vmpk
+PCKeyUseDefaultNotes=1
+# 12 is USB key 'I' and plays note 48
+#PCKeyNote12=48
+# Arrow left MIDIButtonPrev=46
+PCKeyCC80=46
+# Arrow right MIDIButtonNext=47
+PCKeyCC79=47
+# Arrow up MIDIButtonBack=48
+PCKeyCC82=48
+# Arrow down MIDIButtonSelect=49
+PCKeyCC81=49
+# Home button MIDIButtonHome=50
+PCKeyCC74=50
+# MIDIButtonPgmUp=51
+PCKeyCC58=51
+# MIDIButtonPgmDown=52
+PCKeyCC59=52
+# MIDIButtonBankUp=53
+

--- a/src/pckeyboard.cpp
+++ b/src/pckeyboard.cpp
@@ -31,6 +31,8 @@ struct TKeyInfo
 
 // KeyCode is valid for standard QWERTY keyboard
 // selected octave gets added to these
+// This is the default.
+// Any PCKeyNote<x> entries in minidexed.ini invalidate the entire table
 static TKeyInfo KeyTable[] =
 {
 	{KEY_Q, 36}, // C1
@@ -72,21 +74,6 @@ static TKeyInfo KeyTable[] =
 	{KEY_DOT, 38},
 	{KEY_SEMICOLON, 39},
 	{KEY_SLASH, 40}
-};
-
-static TKeyInfo CCTable[] =
-{
-	{KEY_LEFT, 46}, // MIDIButtonPrev=46
-	{KEY_RIGHT, 47}, // MIDIButtonNext=47
-	{KEY_UP, 48}, // MIDIButtonBack=48
-	{KEY_DOWN, 49}, // MIDIButtonSelect=49
-	{KEY_HOME, 50}, // MIDIButtonHome=50
-	{KEY_F1, 51}, // MIDIButtonPgmUp=51
-	{KEY_F2, 52}, // MIDIButtonPgmDown=52
-	{KEY_F3, 53}, // MIDIButtonBankUp=53
-	{KEY_F4, 54}, // MIDIButtonBankDown=54
-	{KEY_F5, 55}, // MIDIButtonTGUp=55
-	{KEY_F6, 56} // MIDIButtonTGDown=56
 };
 
 CPCKeyboard *CPCKeyboard::s_pThis = 0;
@@ -215,14 +202,6 @@ void CPCKeyboard::KeyStatusHandlerRaw (unsigned char ucModifiers, const unsigned
 u8 CPCKeyboard::KeyCodeToCC (u8 ucKeyCode)
 {
 	return(m_pConfig->GetPCKeyCC(ucKeyCode));
-	for (unsigned i = 0; i < sizeof CCTable / sizeof CCTable[0]; i++)
-	{
-		if (CCTable[i].KeyCode == ucKeyCode)
-		{
-			return CCTable[i].KeyNumber;
-		}
-	}
-	return 0;
 }
 
 u8 CPCKeyboard::KeyCodeToNote (u8 ucKeyCode)

--- a/src/pckeyboard.cpp
+++ b/src/pckeyboard.cpp
@@ -93,6 +93,7 @@ CPCKeyboard *CPCKeyboard::s_pThis = 0;
 
 CPCKeyboard::CPCKeyboard (CMiniDexed *pSynthesizer, CConfig *pConfig, CUserInterface *pUI)
 :	CMIDIDevice (pSynthesizer, pConfig, pUI),
+	m_pConfig (pConfig),
 	m_pKeyboard (0)
 {
 	s_pThis = this;
@@ -127,6 +128,9 @@ void CPCKeyboard::Process (boolean bPlugAndPlayUpdated)
 	}
 }
 
+#define CC_OCTAVE_UP	128
+#define CC_OCTAVE_DOWN	129
+#define CC_NOTES_OFF	130
 void CPCKeyboard::KeyStatusHandlerRaw (unsigned char ucModifiers, const unsigned char RawKeys[6])
 {
 	assert (s_pThis != 0);
@@ -138,16 +142,16 @@ void CPCKeyboard::KeyStatusHandlerRaw (unsigned char ucModifiers, const unsigned
 		if (   ucKeyCode != 0
 		    && !FindByte (RawKeys, ucKeyCode, 6))
 		{
-			u8 ucKeyNumber = KeyCodeToNote (ucKeyCode);
-			u8 ucKeyCC = KeyCodeToCC (ucKeyCode);
+			u8 ucKeyNumber = s_pThis->KeyCodeToNote (ucKeyCode);
+			u8 ucKeyCC = s_pThis->KeyCodeToCC (ucKeyCode);
 			// first see if this key should send a note on
-			if ( (ucKeyNumber != 0) && (ucKeyNumber <= 127) )
+			if ( (ucKeyNumber > 0) && (ucKeyNumber <= 127) )
 			{
 				u8 NoteOff[] = {0x80, ucKeyNumber, 0};
 				s_pThis->MIDIMessageHandler (NoteOff, sizeof NoteOff);
 			}
 			// then check if it should send a CC
-			else if (ucKeyCC != 0)
+			else if ( (ucKeyCC > 0) && (ucKeyCC <= 127) )
 			{
 				u8 ButtonOn[] = {0xb0, ucKeyCC, 0};
 				s_pThis->MIDIMessageHandler (ButtonOn, sizeof ButtonOn);
@@ -162,29 +166,29 @@ void CPCKeyboard::KeyStatusHandlerRaw (unsigned char ucModifiers, const unsigned
 		if (   ucKeyCode != 0
 		    && !FindByte (s_pThis->m_LastKeys, ucKeyCode, 6))
 		{
-			u8 ucKeyNumber = KeyCodeToNote (ucKeyCode);
-			u8 ucKeyCC = KeyCodeToCC (ucKeyCode);
+			u8 ucKeyNumber = s_pThis->KeyCodeToNote (ucKeyCode);
+			u8 ucKeyCC = s_pThis->KeyCodeToCC (ucKeyCode);
 			// first see if this key should send a note on
-			if (ucKeyNumber != 0)
+			if ( (ucKeyNumber > 0) && (ucKeyNumber <= 127) )
 			{
 				u8 NoteOn[] = {0x90, ucKeyNumber, 100};
 				s_pThis->MIDIMessageHandler (NoteOn, sizeof NoteOn);
 			}
 			// then check if it should send a CC
-			else if (ucKeyCC != 0)
+			else if ( (ucKeyCC > 0) && (ucKeyCC <= 127) )
 			{
 				u8 ButtonOn[] = {0xb0, ucKeyCC, 100};
 				s_pThis->MIDIMessageHandler (ButtonOn, sizeof ButtonOn);
 			}
-			else if (ucKeyCode == KEY_PAGEUP)
+			else if (ucKeyCC == CC_OCTAVE_UP)
 			{
 				if (++s_pThis->octave > 5) s_pThis->octave = 5;
 			}
-			else if (ucKeyCode == KEY_PAGEDOWN)
+			else if (ucKeyCC == CC_OCTAVE_DOWN)
 			{
 				if (s_pThis->octave > 0) s_pThis->octave--;
 			}
-			else if (ucKeyCode == KEY_ESC)
+			else if (ucKeyCC == CC_NOTES_OFF)
 			{
 				u8 NoteOff[] = {0x80, 60, 0};
 				for (u8 i=0; i<128; i++)
@@ -192,7 +196,6 @@ void CPCKeyboard::KeyStatusHandlerRaw (unsigned char ucModifiers, const unsigned
 					NoteOff[1] = i;
 					s_pThis->MIDIMessageHandler (NoteOff, sizeof NoteOff);
 				}
-
 			}
 			else if (ucKeyCode == KEY_DELETE)
 			{
@@ -211,6 +214,7 @@ void CPCKeyboard::KeyStatusHandlerRaw (unsigned char ucModifiers, const unsigned
 
 u8 CPCKeyboard::KeyCodeToCC (u8 ucKeyCode)
 {
+	return(m_pConfig->GetPCKeyCC(ucKeyCode));
 	for (unsigned i = 0; i < sizeof CCTable / sizeof CCTable[0]; i++)
 	{
 		if (CCTable[i].KeyCode == ucKeyCode)
@@ -223,14 +227,22 @@ u8 CPCKeyboard::KeyCodeToCC (u8 ucKeyCode)
 
 u8 CPCKeyboard::KeyCodeToNote (u8 ucKeyCode)
 {
-	for (unsigned i = 0; i < sizeof KeyTable / sizeof KeyTable[0]; i++)
+	u8 baseNote = 0;
+	if (m_pConfig->GetPCKeyUseDefaultNotes() )
 	{
-		if (KeyTable[i].KeyCode == ucKeyCode)
+		for (unsigned i = 0; i < sizeof KeyTable / sizeof KeyTable[0]; i++)
 		{
-			return KeyTable[i].KeyNumber + (s_pThis->octave * 12);
+			if (KeyTable[i].KeyCode == ucKeyCode)
+			{
+				baseNote = KeyTable[i].KeyNumber;
+			}
 		}
+	} else {
+		baseNote = m_pConfig->GetPCKeyNote(ucKeyCode);
 	}
-	return 0;
+
+	if (baseNote) baseNote += (s_pThis->octave*12);
+	return baseNote;
 }
 
 boolean CPCKeyboard::FindByte (const u8 *pBuffer, u8 ucByte, unsigned nLength)

--- a/src/pckeyboard.cpp
+++ b/src/pckeyboard.cpp
@@ -21,6 +21,7 @@
 #include <circle/devicenameservice.h>
 #include <circle/util.h>
 #include <assert.h>
+#include <circle/startup.h>
 
 struct TKeyInfo
 {
@@ -29,33 +30,64 @@ struct TKeyInfo
 };
 
 // KeyCode is valid for standard QWERTY keyboard
+// selected octave gets added to these
 static TKeyInfo KeyTable[] =
 {
-	{',', 72}, // C4
-	{'M', 71}, // B4
-	{'J', 70}, // A#4
-	{'N', 69}, // A4
-	{'H', 68}, // G#3
-	{'B', 67}, // G3
-	{'G', 66}, // F#3
-	{'V', 65}, // F3
-	{'C', 64}, // E3
-	{'D', 63}, // D#3
-	{'X', 62}, // D3
-	{'S', 61}, // C#3
-	{'Z', 60}, // C3
-	{'U', 59}, // B3
-	{'7', 58}, // A#3
-	{'Y', 57}, // A3
-	{'6', 56}, // G#2
-	{'T', 55}, // G2
-	{'5', 54}, // F#2
-	{'R', 53}, // F2
-	{'E', 52}, // E2
-	{'3', 51}, // D#2
-	{'W', 50}, // D2
-	{'2', 49}, // C#2
-	{'Q', 48}  // C2
+	{KEY_Q, 36}, // C1
+	{KEY_2, 37},
+	{KEY_W, 38},
+	{KEY_3, 39},
+	{KEY_E, 40},
+	{KEY_R, 41}, // F1
+	{KEY_5, 42},
+	{KEY_T, 43},
+	{KEY_6, 44},
+	{KEY_Y, 45},
+	{KEY_7, 46},
+	{KEY_U, 47},
+	{KEY_I, 48}, // C2
+	{KEY_9, 49},
+	{KEY_O, 50},
+	{KEY_0, 51},
+	{KEY_P, 52},
+	{KEY_LEFTBRACE, 53},
+	{KEY_EQUAL, 54},
+	{KEY_RIGHTBRACE, 55}, // G2
+	{KEY_BACKSLASH, 57}, // A2
+
+	{KEY_Z, 24},  // C0
+	{KEY_S, 25},
+	{KEY_X, 26},
+	{KEY_D, 27},
+	{KEY_C, 28},
+	{KEY_V, 29},  // F0
+	{KEY_G, 30},
+	{KEY_B, 31},
+	{KEY_H, 32},
+	{KEY_N, 33},
+	{KEY_J, 34},
+	{KEY_M, 35},
+	{KEY_COMMA, 36},  // C1
+	{KEY_L, 37},
+	{KEY_DOT, 38},
+	{KEY_SEMICOLON, 39},
+	{KEY_SLASH, 40}
+};
+
+// selected octave gets added to these
+static TKeyInfo CCTable[] =
+{
+	{KEY_LEFT, 46}, // MIDIButtonPrev=46
+	{KEY_RIGHT, 47}, // MIDIButtonNext=47
+	{KEY_UP, 48}, // MIDIButtonBack=48
+	{KEY_DOWN, 49}, // MIDIButtonSelect=49
+	{KEY_HOME, 50}, // MIDIButtonHome=50
+	{KEY_F1, 51}, // MIDIButtonPgmUp=51
+	{KEY_F2, 52}, // MIDIButtonPgmDown=52
+	{KEY_F3, 53}, // MIDIButtonBankUp=53
+	{KEY_F4, 54}, // MIDIButtonBankDown=54
+	{KEY_F5, 55}, // MIDIButtonTGUp=55
+	{KEY_F6, 56} // MIDIButtonTGDown=56
 };
 
 CPCKeyboard *CPCKeyboard::s_pThis = 0;
@@ -107,11 +139,19 @@ void CPCKeyboard::KeyStatusHandlerRaw (unsigned char ucModifiers, const unsigned
 		if (   ucKeyCode != 0
 		    && !FindByte (RawKeys, ucKeyCode, 6))
 		{
-			u8 ucKeyNumber = GetKeyNumber (ucKeyCode);
-			if (ucKeyNumber != 0)
+			u8 ucKeyNumber = KeyCodeToNote (ucKeyCode);
+			u8 ucKeyCC = KeyCodeToCC (ucKeyCode);
+			// first see if this key should send a note on
+			if ( (ucKeyNumber != 0) && (ucKeyNumber <= 127) )
 			{
 				u8 NoteOff[] = {0x80, ucKeyNumber, 0};
 				s_pThis->MIDIMessageHandler (NoteOff, sizeof NoteOff);
+			}
+			// then check if it should send a CC
+			else if (ucKeyCC != 0)
+			{
+				u8 ButtonOn[] = {0xb0, ucKeyCC, 0};
+				s_pThis->MIDIMessageHandler (ButtonOn, sizeof ButtonOn);
 			}
 		}
 	}
@@ -123,11 +163,45 @@ void CPCKeyboard::KeyStatusHandlerRaw (unsigned char ucModifiers, const unsigned
 		if (   ucKeyCode != 0
 		    && !FindByte (s_pThis->m_LastKeys, ucKeyCode, 6))
 		{
-			u8 ucKeyNumber = GetKeyNumber (ucKeyCode);
+			u8 ucKeyNumber = KeyCodeToNote (ucKeyCode);
+			u8 ucKeyCC = KeyCodeToCC (ucKeyCode);
+			// first see if this key should send a note on
 			if (ucKeyNumber != 0)
 			{
 				u8 NoteOn[] = {0x90, ucKeyNumber, 100};
 				s_pThis->MIDIMessageHandler (NoteOn, sizeof NoteOn);
+			}
+			// then check if it should send a CC
+			else if (ucKeyCC != 0)
+			{
+				u8 ButtonOn[] = {0xb0, ucKeyCC, 100};
+				s_pThis->MIDIMessageHandler (ButtonOn, sizeof ButtonOn);
+			}
+			else if (ucKeyCode == KEY_PAGEUP)
+			{
+				if (++s_pThis->octave > 5) s_pThis->octave = 5;
+			}
+			else if (ucKeyCode == KEY_PAGEDOWN)
+			{
+				if (s_pThis->octave > 0) s_pThis->octave--;
+			}
+			else if (ucKeyCode == KEY_ESC)
+			{
+				for (u8 i=0; i<128; i++)
+				{
+					u8 NoteOff[] = {0x80, i, 0};
+					s_pThis->MIDIMessageHandler (NoteOff, sizeof NoteOff);
+				}
+
+			}
+			else if (ucKeyCode == KEY_DELETE)
+			{
+				if ((ucModifiers & KEY_MOD_LCTRL) && (ucModifiers & KEY_MOD_LALT))
+				{
+					CLogger::Get ()->Write("keyboard", LogNotice, "Ctrl+Alt+Del detected! Rebooting system...");
+					// Safely request Circle to trigger a hardware reset
+					reboot();
+				}
 			}
 		}
 	}
@@ -135,34 +209,27 @@ void CPCKeyboard::KeyStatusHandlerRaw (unsigned char ucModifiers, const unsigned
 	memcpy (s_pThis->m_LastKeys, RawKeys, sizeof s_pThis->m_LastKeys);
 }
 
-u8 CPCKeyboard::GetKeyNumber (u8 ucKeyCode)
+u8 CPCKeyboard::KeyCodeToCC (u8 ucKeyCode)
 {
-	char chKey;
-	if (0x04 <= ucKeyCode && ucKeyCode <= 0x1D)
+	for (unsigned i = 0; i < sizeof CCTable / sizeof CCTable[0]; i++)
 	{
-		chKey = ucKeyCode-'\x04'+'A';	// key code of 'A' is 0x04
-	}
-	else if (0x1E <= ucKeyCode && ucKeyCode <= 0x26)
-	{
-		chKey = ucKeyCode-'\x1E'+'1';	// key code of '1' is 0x1E
-	}
-	else if (ucKeyCode == 0x36)
-	{
-		chKey = ',';			// key code of ',' is 0x36
-	}
-	else
-	{
-		return 0;
-	}
-
-	for (unsigned i = 0; i < sizeof KeyTable / sizeof KeyTable[0]; i++)
-	{
-		if (KeyTable[i].KeyCode == chKey)
+		if (CCTable[i].KeyCode == ucKeyCode)
 		{
-			return KeyTable[i].KeyNumber;
+			return CCTable[i].KeyNumber;
 		}
 	}
+	return 0;
+}
 
+u8 CPCKeyboard::KeyCodeToNote (u8 ucKeyCode)
+{
+	for (unsigned i = 0; i < sizeof KeyTable / sizeof KeyTable[0]; i++)
+	{
+		if (KeyTable[i].KeyCode == ucKeyCode)
+		{
+			return KeyTable[i].KeyNumber + (s_pThis->octave * 12);
+		}
+	}
 	return 0;
 }
 

--- a/src/pckeyboard.cpp
+++ b/src/pckeyboard.cpp
@@ -74,7 +74,6 @@ static TKeyInfo KeyTable[] =
 	{KEY_SLASH, 40}
 };
 
-// selected octave gets added to these
 static TKeyInfo CCTable[] =
 {
 	{KEY_LEFT, 46}, // MIDIButtonPrev=46
@@ -187,9 +186,10 @@ void CPCKeyboard::KeyStatusHandlerRaw (unsigned char ucModifiers, const unsigned
 			}
 			else if (ucKeyCode == KEY_ESC)
 			{
+				u8 NoteOff[] = {0x80, 60, 0};
 				for (u8 i=0; i<128; i++)
 				{
-					u8 NoteOff[] = {0x80, i, 0};
+					NoteOff[1] = i;
 					s_pThis->MIDIMessageHandler (NoteOff, sizeof NoteOff);
 				}
 

--- a/src/pckeyboard.h
+++ b/src/pckeyboard.h
@@ -38,11 +38,13 @@ public:
 	void Process (boolean bPlugAndPlayUpdated);
 
 private:
+	CConfig *m_pConfig;
+
 	static void KeyStatusHandlerRaw (unsigned char ucModifiers, const unsigned char RawKeys[6]);
 
-	static u8 KeyCodeToNote (u8 ucKeyCode);
+	u8 KeyCodeToNote (u8 ucKeyCode);
 
-	static u8 KeyCodeToCC (u8 ucKeyCode);
+	u8 KeyCodeToCC (u8 ucKeyCode);
 
 	static boolean FindByte (const u8 *pBuffer, u8 ucByte, unsigned nLength);
 

--- a/src/pckeyboard.h
+++ b/src/pckeyboard.h
@@ -25,6 +25,7 @@
 #include <circle/usb/usbkeyboard.h>
 #include <circle/device.h>
 #include <circle/types.h>
+#include "usb_hid_keys.h"
 
 class CMiniDexed;
 
@@ -39,7 +40,9 @@ public:
 private:
 	static void KeyStatusHandlerRaw (unsigned char ucModifiers, const unsigned char RawKeys[6]);
 
-	static u8 GetKeyNumber (u8 ucKeyCode);
+	static u8 KeyCodeToNote (u8 ucKeyCode);
+
+	static u8 KeyCodeToCC (u8 ucKeyCode);
 
 	static boolean FindByte (const u8 *pBuffer, u8 ucByte, unsigned nLength);
 
@@ -49,6 +52,8 @@ private:
 	CUSBKeyboardDevice * volatile m_pKeyboard;
 
 	u8 m_LastKeys[6];
+
+	u8 octave = 2;
 
 	static CPCKeyboard *s_pThis;
 };

--- a/src/usb_hid_keys.h
+++ b/src/usb_hid_keys.h
@@ -1,0 +1,287 @@
+/**
+ * USB HID Keyboard scan codes as per USB spec 1.11
+ * plus some additional codes
+ * 
+ * Created by MightyPork, 2016
+ * Public domain
+ * 
+ * Adapted from:
+ * https://source.android.com/devices/input/keyboard-devices.html
+ */
+
+#ifndef USB_HID_KEYS
+#define USB_HID_KEYS
+
+/**
+ * Modifier masks - used for the first byte in the HID report.
+ * NOTE: The second byte in the report is reserved, 0x00
+ */
+#define KEY_MOD_LCTRL  0x01
+#define KEY_MOD_LSHIFT 0x02
+#define KEY_MOD_LALT   0x04
+#define KEY_MOD_LMETA  0x08
+#define KEY_MOD_RCTRL  0x10
+#define KEY_MOD_RSHIFT 0x20
+#define KEY_MOD_RALT   0x40
+#define KEY_MOD_RMETA  0x80
+
+/**
+ * Scan codes - last N slots in the HID report (usually 6).
+ * 0x00 if no key pressed.
+ * 
+ * If more than N keys are pressed, the HID reports 
+ * KEY_ERR_OVF in all slots to indicate this condition.
+ */
+
+#define KEY_NONE 0x00 // No key pressed
+#define KEY_ERR_OVF 0x01 //  Keyboard Error Roll Over - used for all slots if too many keys are pressed ("Phantom key")
+// 0x02 //  Keyboard POST Fail
+// 0x03 //  Keyboard Error Undefined
+#define KEY_A 0x04 // Keyboard a and A
+#define KEY_B 0x05 // Keyboard b and B
+#define KEY_C 0x06 // Keyboard c and C
+#define KEY_D 0x07 // Keyboard d and D
+#define KEY_E 0x08 // Keyboard e and E
+#define KEY_F 0x09 // Keyboard f and F
+#define KEY_G 0x0a // Keyboard g and G
+#define KEY_H 0x0b // Keyboard h and H
+#define KEY_I 0x0c // Keyboard i and I
+#define KEY_J 0x0d // Keyboard j and J
+#define KEY_K 0x0e // Keyboard k and K
+#define KEY_L 0x0f // Keyboard l and L
+#define KEY_M 0x10 // Keyboard m and M
+#define KEY_N 0x11 // Keyboard n and N
+#define KEY_O 0x12 // Keyboard o and O
+#define KEY_P 0x13 // Keyboard p and P
+#define KEY_Q 0x14 // Keyboard q and Q
+#define KEY_R 0x15 // Keyboard r and R
+#define KEY_S 0x16 // Keyboard s and S
+#define KEY_T 0x17 // Keyboard t and T
+#define KEY_U 0x18 // Keyboard u and U
+#define KEY_V 0x19 // Keyboard v and V
+#define KEY_W 0x1a // Keyboard w and W
+#define KEY_X 0x1b // Keyboard x and X
+#define KEY_Y 0x1c // Keyboard y and Y
+#define KEY_Z 0x1d // Keyboard z and Z
+
+#define KEY_1 0x1e // Keyboard 1 and !
+#define KEY_2 0x1f // Keyboard 2 and @
+#define KEY_3 0x20 // Keyboard 3 and #
+#define KEY_4 0x21 // Keyboard 4 and $
+#define KEY_5 0x22 // Keyboard 5 and %
+#define KEY_6 0x23 // Keyboard 6 and ^
+#define KEY_7 0x24 // Keyboard 7 and &
+#define KEY_8 0x25 // Keyboard 8 and *
+#define KEY_9 0x26 // Keyboard 9 and (
+#define KEY_0 0x27 // Keyboard 0 and )
+
+#define KEY_ENTER 0x28 // Keyboard Return (ENTER)
+#define KEY_ESC 0x29 // Keyboard ESCAPE
+#define KEY_BACKSPACE 0x2a // Keyboard DELETE (Backspace)
+#define KEY_TAB 0x2b // Keyboard Tab
+#define KEY_SPACE 0x2c // Keyboard Spacebar
+#define KEY_MINUS 0x2d // Keyboard - and _
+#define KEY_EQUAL 0x2e // Keyboard = and +
+#define KEY_LEFTBRACE 0x2f // Keyboard [ and {
+#define KEY_RIGHTBRACE 0x30 // Keyboard ] and }
+#define KEY_BACKSLASH 0x31 // Keyboard \ and |
+#define KEY_HASHTILDE 0x32 // Keyboard Non-US # and ~
+#define KEY_SEMICOLON 0x33 // Keyboard ; and :
+#define KEY_APOSTROPHE 0x34 // Keyboard ' and "
+#define KEY_GRAVE 0x35 // Keyboard ` and ~
+#define KEY_COMMA 0x36 // Keyboard , and <
+#define KEY_DOT 0x37 // Keyboard . and >
+#define KEY_SLASH 0x38 // Keyboard / and ?
+#define KEY_CAPSLOCK 0x39 // Keyboard Caps Lock
+
+#define KEY_F1 0x3a // Keyboard F1
+#define KEY_F2 0x3b // Keyboard F2
+#define KEY_F3 0x3c // Keyboard F3
+#define KEY_F4 0x3d // Keyboard F4
+#define KEY_F5 0x3e // Keyboard F5
+#define KEY_F6 0x3f // Keyboard F6
+#define KEY_F7 0x40 // Keyboard F7
+#define KEY_F8 0x41 // Keyboard F8
+#define KEY_F9 0x42 // Keyboard F9
+#define KEY_F10 0x43 // Keyboard F10
+#define KEY_F11 0x44 // Keyboard F11
+#define KEY_F12 0x45 // Keyboard F12
+
+#define KEY_SYSRQ 0x46 // Keyboard Print Screen
+#define KEY_SCROLLLOCK 0x47 // Keyboard Scroll Lock
+#define KEY_PAUSE 0x48 // Keyboard Pause
+#define KEY_INSERT 0x49 // Keyboard Insert
+#define KEY_HOME 0x4a // Keyboard Home
+#define KEY_PAGEUP 0x4b // Keyboard Page Up
+#define KEY_DELETE 0x4c // Keyboard Delete Forward
+#define KEY_END 0x4d // Keyboard End
+#define KEY_PAGEDOWN 0x4e // Keyboard Page Down
+#define KEY_RIGHT 0x4f // Keyboard Right Arrow
+#define KEY_LEFT 0x50 // Keyboard Left Arrow
+#define KEY_DOWN 0x51 // Keyboard Down Arrow
+#define KEY_UP 0x52 // Keyboard Up Arrow
+
+#define KEY_NUMLOCK 0x53 // Keyboard Num Lock and Clear
+#define KEY_KPSLASH 0x54 // Keypad /
+#define KEY_KPASTERISK 0x55 // Keypad *
+#define KEY_KPMINUS 0x56 // Keypad -
+#define KEY_KPPLUS 0x57 // Keypad +
+#define KEY_KPENTER 0x58 // Keypad ENTER
+#define KEY_KP1 0x59 // Keypad 1 and End
+#define KEY_KP2 0x5a // Keypad 2 and Down Arrow
+#define KEY_KP3 0x5b // Keypad 3 and PageDn
+#define KEY_KP4 0x5c // Keypad 4 and Left Arrow
+#define KEY_KP5 0x5d // Keypad 5
+#define KEY_KP6 0x5e // Keypad 6 and Right Arrow
+#define KEY_KP7 0x5f // Keypad 7 and Home
+#define KEY_KP8 0x60 // Keypad 8 and Up Arrow
+#define KEY_KP9 0x61 // Keypad 9 and Page Up
+#define KEY_KP0 0x62 // Keypad 0 and Insert
+#define KEY_KPDOT 0x63 // Keypad . and Delete
+
+#define KEY_102ND 0x64 // Keyboard Non-US \ and |
+#define KEY_COMPOSE 0x65 // Keyboard Application
+#define KEY_POWER 0x66 // Keyboard Power
+#define KEY_KPEQUAL 0x67 // Keypad =
+
+#define KEY_F13 0x68 // Keyboard F13
+#define KEY_F14 0x69 // Keyboard F14
+#define KEY_F15 0x6a // Keyboard F15
+#define KEY_F16 0x6b // Keyboard F16
+#define KEY_F17 0x6c // Keyboard F17
+#define KEY_F18 0x6d // Keyboard F18
+#define KEY_F19 0x6e // Keyboard F19
+#define KEY_F20 0x6f // Keyboard F20
+#define KEY_F21 0x70 // Keyboard F21
+#define KEY_F22 0x71 // Keyboard F22
+#define KEY_F23 0x72 // Keyboard F23
+#define KEY_F24 0x73 // Keyboard F24
+
+#define KEY_OPEN 0x74 // Keyboard Execute
+#define KEY_HELP 0x75 // Keyboard Help
+#define KEY_PROPS 0x76 // Keyboard Menu
+#define KEY_FRONT 0x77 // Keyboard Select
+#define KEY_STOP 0x78 // Keyboard Stop
+#define KEY_AGAIN 0x79 // Keyboard Again
+#define KEY_UNDO 0x7a // Keyboard Undo
+#define KEY_CUT 0x7b // Keyboard Cut
+#define KEY_COPY 0x7c // Keyboard Copy
+#define KEY_PASTE 0x7d // Keyboard Paste
+#define KEY_FIND 0x7e // Keyboard Find
+#define KEY_MUTE 0x7f // Keyboard Mute
+#define KEY_VOLUMEUP 0x80 // Keyboard Volume Up
+#define KEY_VOLUMEDOWN 0x81 // Keyboard Volume Down
+// 0x82  Keyboard Locking Caps Lock
+// 0x83  Keyboard Locking Num Lock
+// 0x84  Keyboard Locking Scroll Lock
+#define KEY_KPCOMMA 0x85 // Keypad Comma
+// 0x86  Keypad Equal Sign
+#define KEY_RO 0x87 // Keyboard International1
+#define KEY_KATAKANAHIRAGANA 0x88 // Keyboard International2
+#define KEY_YEN 0x89 // Keyboard International3
+#define KEY_HENKAN 0x8a // Keyboard International4
+#define KEY_MUHENKAN 0x8b // Keyboard International5
+#define KEY_KPJPCOMMA 0x8c // Keyboard International6
+// 0x8d  Keyboard International7
+// 0x8e  Keyboard International8
+// 0x8f  Keyboard International9
+#define KEY_HANGEUL 0x90 // Keyboard LANG1
+#define KEY_HANJA 0x91 // Keyboard LANG2
+#define KEY_KATAKANA 0x92 // Keyboard LANG3
+#define KEY_HIRAGANA 0x93 // Keyboard LANG4
+#define KEY_ZENKAKUHANKAKU 0x94 // Keyboard LANG5
+// 0x95  Keyboard LANG6
+// 0x96  Keyboard LANG7
+// 0x97  Keyboard LANG8
+// 0x98  Keyboard LANG9
+// 0x99  Keyboard Alternate Erase
+// 0x9a  Keyboard SysReq/Attention
+// 0x9b  Keyboard Cancel
+// 0x9c  Keyboard Clear
+// 0x9d  Keyboard Prior
+// 0x9e  Keyboard Return
+// 0x9f  Keyboard Separator
+// 0xa0  Keyboard Out
+// 0xa1  Keyboard Oper
+// 0xa2  Keyboard Clear/Again
+// 0xa3  Keyboard CrSel/Props
+// 0xa4  Keyboard ExSel
+
+// 0xb0  Keypad 00
+// 0xb1  Keypad 000
+// 0xb2  Thousands Separator
+// 0xb3  Decimal Separator
+// 0xb4  Currency Unit
+// 0xb5  Currency Sub-unit
+#define KEY_KPLEFTPAREN 0xb6 // Keypad (
+#define KEY_KPRIGHTPAREN 0xb7 // Keypad )
+// 0xb8  Keypad {
+// 0xb9  Keypad }
+// 0xba  Keypad Tab
+// 0xbb  Keypad Backspace
+// 0xbc  Keypad A
+// 0xbd  Keypad B
+// 0xbe  Keypad C
+// 0xbf  Keypad D
+// 0xc0  Keypad E
+// 0xc1  Keypad F
+// 0xc2  Keypad XOR
+// 0xc3  Keypad ^
+// 0xc4  Keypad %
+// 0xc5  Keypad <
+// 0xc6  Keypad >
+// 0xc7  Keypad &
+// 0xc8  Keypad &&
+// 0xc9  Keypad |
+// 0xca  Keypad ||
+// 0xcb  Keypad :
+// 0xcc  Keypad #
+// 0xcd  Keypad Space
+// 0xce  Keypad @
+// 0xcf  Keypad !
+// 0xd0  Keypad Memory Store
+// 0xd1  Keypad Memory Recall
+// 0xd2  Keypad Memory Clear
+// 0xd3  Keypad Memory Add
+// 0xd4  Keypad Memory Subtract
+// 0xd5  Keypad Memory Multiply
+// 0xd6  Keypad Memory Divide
+// 0xd7  Keypad +/-
+// 0xd8  Keypad Clear
+// 0xd9  Keypad Clear Entry
+// 0xda  Keypad Binary
+// 0xdb  Keypad Octal
+// 0xdc  Keypad Decimal
+// 0xdd  Keypad Hexadecimal
+
+#define KEY_LEFTCTRL 0xe0 // Keyboard Left Control
+#define KEY_LEFTSHIFT 0xe1 // Keyboard Left Shift
+#define KEY_LEFTALT 0xe2 // Keyboard Left Alt
+#define KEY_LEFTMETA 0xe3 // Keyboard Left GUI
+#define KEY_RIGHTCTRL 0xe4 // Keyboard Right Control
+#define KEY_RIGHTSHIFT 0xe5 // Keyboard Right Shift
+#define KEY_RIGHTALT 0xe6 // Keyboard Right Alt
+#define KEY_RIGHTMETA 0xe7 // Keyboard Right GUI
+
+#define KEY_MEDIA_PLAYPAUSE 0xe8
+#define KEY_MEDIA_STOPCD 0xe9
+#define KEY_MEDIA_PREVIOUSSONG 0xea
+#define KEY_MEDIA_NEXTSONG 0xeb
+#define KEY_MEDIA_EJECTCD 0xec
+#define KEY_MEDIA_VOLUMEUP 0xed
+#define KEY_MEDIA_VOLUMEDOWN 0xee
+#define KEY_MEDIA_MUTE 0xef
+#define KEY_MEDIA_WWW 0xf0
+#define KEY_MEDIA_BACK 0xf1
+#define KEY_MEDIA_FORWARD 0xf2
+#define KEY_MEDIA_STOP 0xf3
+#define KEY_MEDIA_FIND 0xf4
+#define KEY_MEDIA_SCROLLUP 0xf5
+#define KEY_MEDIA_SCROLLDOWN 0xf6
+#define KEY_MEDIA_EDIT 0xf7
+#define KEY_MEDIA_SLEEP 0xf8
+#define KEY_MEDIA_COFFEE 0xf9
+#define KEY_MEDIA_REFRESH 0xfa
+#define KEY_MEDIA_CALC 0xfb
+
+#endif // USB_HID_KEYS


### PR DESCRIPTION
I'm building a new MiniDexed into an existing case that has a matrix scanned set of buttons.
With this change, I can use a small microcontroller to handle the tedium of scanning a matrix keyboard and just send PC keyboard button presses to the Pi.

I'm using the default CC from minidexed.ini :
Cursor keys send CC 46,47,48,49
Home sends CC 50
F1..F6 send CC 51..56

While I was in there I also:
- Added more note keys
- change octave with page up/down
- dont hold keys while changing octave! => stuck notes :)
- ESC sends 128 note off messages
- LCTRL+LALT+DEL to reboot
- cleanup usb key code to midi note lookup.

## Summary by Sourcery

Map additional PC keyboard keys to MIDI notes and control changes to support MiniDexed UI navigation and extended keyboard control.

New Features:
- Add mappings from cursor, Home, and F1–F6 keys to MIDI CC messages for on-device UI navigation.
- Extend the PC keyboard-to-note layout with more keys and introduce octave shifting via Page Up/Page Down.
- Add ESC handling to send an all-notes-off panic and Ctrl+Alt+Del handling to reboot the system.

Enhancements:
- Refactor keycode-to-note logic into explicit USB HID keycode mappings and separate helpers for note and CC translation.
- Introduce a shared USB HID keycode definition header for clearer and more maintainable key mappings.