### PR TITLE
Suppress serial error -1 on startup.

### DIFF
--- a/src/net/mdnspublisher.cpp
+++ b/src/net/mdnspublisher.cpp
@@ -84,7 +84,7 @@ boolean CmDNSPublisher::PublishService (const char *pServiceName, const char *pS
 		m_ServiceList.InsertAfter (nullptr, pService);
 	}
 	m_Mutex.Release ();
-	LOGDBG ("Publish service %s", (const char *) pService->ServiceName);
+	LOGDBG ("Publish service %s %s:%d", pServiceType, (const char *) pService->ServiceName, usServicePort);
 	m_Event.Set ();		// Trigger resent for everything
 	return TRUE;
 }

--- a/src/serialmididevice.cpp
+++ b/src/serialmididevice.cpp
@@ -58,6 +58,10 @@ boolean CSerialMIDIDevice::Initialize (void)
 	// Ensure CR->CRLF translation is disabled for MIDI links
 	ser_options &= ~(SERIAL_OPTION_ONLCR);
 	m_Serial.SetOptions(ser_options);
+	// initial dummy read to suppress SERIAL_ERROR_BREAK
+	CTimer::Get()->MsDelay(5);	// short delay for hardware to awaken
+	char dummy;
+	m_Serial.Read (&dummy, 1);
 	return res;
 }
 
@@ -71,7 +75,7 @@ void CSerialMIDIDevice::Process (void)
 	if (nResult <= 0)
 	{
 		if(nResult!=0)
-			LOGERR("Serial.Read() error: %d\n",nResult);
+			LOGERR("Serial.Read() error: %d",nResult);
 		return;
 	}
 


### PR DESCRIPTION
This is caused by the serial hardware detecting a break condition on startup.
In serial init just perform a single dummy read after a 5mS delay

Also provide more detail in mDNS publish log message