### PR TITLE
Ethernet enabled breaks gpio button short/long/double click logic

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -135,10 +135,10 @@ bool CKernel::Initialize (void)
 	}
 	m_Config.SetUSBGadgetMode(bUSBGadgetMode);
 
-    if (!m_pUSB->Initialize ())
-    {
+	if (!m_pUSB->Initialize ())
+	{
 		return FALSE;
-    }
+	}
 	
 	m_pDexed = new CMiniDexed (&m_Config, &mInterrupt, &m_GPIOManager, &m_I2CMaster, m_pSPIMaster,
 				   &mFileSystem);

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -2271,10 +2271,8 @@ void CMiniDexed::UpdateNetwork()
 	}
 
 	bool bNetIsRunning = m_pNet->IsRunning();
-	if (m_pNetDevice->GetType() == NetDeviceTypeEthernet)
-		bNetIsRunning &= m_pNetDevice->IsLinkUp();
 
-	else if (m_pNetDevice->GetType() == NetDeviceTypeWLAN)
+	if (m_pNetDevice->GetType() == NetDeviceTypeWLAN)
 		bNetIsRunning &= (m_WPASupplicant && m_WPASupplicant->IsConnected());
 	
 	if (!m_bNetworkInit && bNetIsRunning)

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -66,6 +66,7 @@ CMiniDexed::CMiniDexed (CConfig *pConfig, CInterruptSystem *pInterrupt,
 	m_WPASupplicant(nullptr),
 	m_bNetworkReady(false),
 	m_bNetworkInit(false),
+	m_lastNetworkUpdate(0),
 	m_UDPMIDI(nullptr),
 	m_pmDNSPublisher (nullptr),
 	m_bSavePerformance (false),
@@ -395,7 +396,6 @@ void CMiniDexed::Process (bool bPlugAndPlayUpdated)
 		m_pMIDIKeyboard[i]->Process (bPlugAndPlayUpdated);
 		pScheduler->Yield();
 	}
-
 	m_PCKeyboard.Process (bPlugAndPlayUpdated);
 
 	if (m_bUseSerial)
@@ -461,9 +461,16 @@ void CMiniDexed::Process (bool bPlugAndPlayUpdated)
 		m_GetChunkTimer.Dump ();
 		pScheduler->Yield();
 	}
+#define NETWORK_UPDATE_NUM_TICKS 1000000
 	if (m_pNet) {
-		UpdateNetwork();
+		unsigned currentTick = CTimer::GetClockTicks();
+		if (currentTick - m_lastNetworkUpdate > NETWORK_UPDATE_NUM_TICKS)
+		{
+			m_lastNetworkUpdate = currentTick;
+			UpdateNetwork();
+		}
 	}
+
 	// Allow other tasks to run
 	pScheduler->Yield();
 }
@@ -2266,6 +2273,7 @@ void CMiniDexed::UpdateNetwork()
 	bool bNetIsRunning = m_pNet->IsRunning();
 	if (m_pNetDevice->GetType() == NetDeviceTypeEthernet)
 		bNetIsRunning &= m_pNetDevice->IsLinkUp();
+
 	else if (m_pNetDevice->GetType() == NetDeviceTypeWLAN)
 		bNetIsRunning &= (m_WPASupplicant && m_WPASupplicant->IsConnected());
 	

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -347,6 +347,7 @@ private:
 	CWPASupplicant* m_WPASupplicant; // Changed to pointer
 	bool m_bNetworkReady;
 	bool m_bNetworkInit;
+	unsigned m_lastNetworkUpdate;
 	CUDPMIDIDevice* m_UDPMIDI; // Changed to pointer
 	CFTPDaemon* m_pFTPDaemon;
 	CmDNSPublisher *m_pmDNSPublisher;

--- a/src/uibuttons.cpp
+++ b/src/uibuttons.cpp
@@ -472,6 +472,10 @@ void CUIButtons::Update (void)
 	}
 
 	m_interval = (currentTick - m_lastTick)/BUTTONS_UPDATE_NUM_TICKS;
+	if (m_interval == 0) {
+		m_interval = 1;
+	}
+
 	m_lastTick = currentTick;
 
 	for (unsigned i=0; i<MAX_BUTTONS; i++) {

--- a/src/uibuttons.cpp
+++ b/src/uibuttons.cpp
@@ -107,7 +107,7 @@ unsigned CUIButton::getPinNumber(void)
 	return m_pinNumber;
 }
 	
-CUIButton::BtnTrigger CUIButton::ReadTrigger (void)
+CUIButton::BtnTrigger CUIButton::ReadTrigger (unsigned interval)
 {
 	unsigned value;
 	if (isMidiPin(m_pinNumber))
@@ -130,15 +130,15 @@ CUIButton::BtnTrigger CUIButton::ReadTrigger (void)
 	}
 
 	if (m_timer < m_longPressTimeout) {
-		m_timer++;
+		m_timer+=interval;
 
-		if (m_timer == m_doubleClickTimeout && m_lastValue == 1 && m_numClicks == 1) {
+		if (m_timer >= m_doubleClickTimeout && m_lastValue == 1 && m_numClicks == 1) {
 			// The user has clicked and released the button once within the
 			// timeout - this must be a single click
 			reset();
 			return BtnTriggerClick;
 		}
-		if (m_timer == m_longPressTimeout) {
+		if (m_timer >= m_longPressTimeout) {
 			if (m_lastValue == 0 && m_numClicks == 1) {
 				// Single long press
 				reset();
@@ -219,8 +219,8 @@ void CUIButton::Write (unsigned nValue) {
 	}
 }
 
-CUIButton::BtnEvent CUIButton::Read (void) {
-	BtnTrigger trigger = ReadTrigger();
+CUIButton::BtnEvent CUIButton::Read (unsigned interval) {
+	BtnTrigger trigger = ReadTrigger(interval);
 
 	if (trigger == BtnTriggerClick) {
 		return m_clickEvent;
@@ -471,10 +471,11 @@ void CUIButtons::Update (void)
 		return;
 	}
 
+	m_interval = (currentTick - m_lastTick)/BUTTONS_UPDATE_NUM_TICKS;
 	m_lastTick = currentTick;
 
 	for (unsigned i=0; i<MAX_BUTTONS; i++) {
-		CUIButton::BtnEvent event = m_buttons[i].Read();
+		CUIButton::BtnEvent event = m_buttons[i].Read(m_interval);
 		if (event != CUIButton::BtnEventNone) {
 //			LOGDBG("Event: %u", event);
 			(*m_eventHandler) (event, m_eventParam);

--- a/src/uibuttons.h
+++ b/src/uibuttons.h
@@ -73,8 +73,8 @@ public:
 
 	unsigned getPinNumber(void);
 	
-	BtnTrigger ReadTrigger (void);
-	BtnEvent Read (void);
+	BtnTrigger ReadTrigger (unsigned interval);
+	BtnEvent Read (unsigned interval);
 	void Write (unsigned nValue); // MIDI buttons only!
 
 	static BtnTrigger triggerTypeFromString(const char* triggerString);
@@ -182,6 +182,7 @@ private:
 	void *m_eventParam;
 
 	unsigned m_lastTick;
+	unsigned m_interval;
 
 	void bindButton(unsigned pinNumber, CUIButton::BtnTrigger trigger, CUIButton::BtnEvent event);
 };


### PR DESCRIPTION
Fixes #1012 

Partially tested with my build on Pi2, Pi3 (and Pi1 with network enabled).

Will do more testing with generated build.

## Summary by Sourcery

Throttle network updates and make button handling time-based on actual elapsed ticks to fix input timing issues when Ethernet is enabled.

Bug Fixes:
- Fix GPIO button click, double-click, and long-press detection by basing timing on elapsed ticks instead of fixed update steps and handling threshold crossings robustly.
- Prevent Ethernet-enabled network processing from starving other logic by rate-limiting network updates.

Enhancements:
- Simplify network running-state detection by only applying WLAN-specific connectivity checks.
- Minor formatting cleanup in kernel initialization code.